### PR TITLE
add markup quotes to the tmtheme file

### DIFF
--- a/MarkdownEditor.tmTheme
+++ b/MarkdownEditor.tmTheme
@@ -571,7 +571,7 @@
             <key>name</key>
             <string>Markdown: Punctuation</string>
             <key>scope</key>
-            <string>punctuation.definition.metadata.markdown,punctuation.definition.string.begin.markdown, punctuation.definition.string.end.markdown, punctuation.definition.constant.markdown, punctuation.separator.key-value.markdown, punctuation.definition.constant.begin.markdown, punctuation.definition.constant.end.markdown,punctuation.definition.bold.markdown, punctuation.definition.italic.markdown, punctuation.definition.heading.markdown</string>
+            <string>punctuation.definition.metadata.markdown,punctuation.definition.string.begin.markdown, punctuation.definition.string.end.markdown, punctuation.definition.constant.markdown, punctuation.separator.key-value.markdown, punctuation.definition.constant.begin.markdown, punctuation.definition.constant.end.markdown,punctuation.definition.bold.markdown, punctuation.definition.italic.markdown, punctuation.definition.heading.markdown, punctuation.definition.blockquote.markdown</string>
             <key>settings</key>
             <dict>
                 <key>foreground</key>
@@ -593,6 +593,21 @@
                 <string>#EEEEEE00</string>
             </dict>
         </dict>
+        <dict>
+            <key>name</key>
+            <string>Markdown: Quote</string>
+            <key>scope</key>
+            <string>markup.quote.markdown</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#666666</string>
+                <key>background</key>
+                <string>#EEEEEE00</string>
+                <key>fontStyle</key>
+                <string>italic</string>
+            </dict>
+        </dict> 
         <dict>
             <key>name</key>
             <string>Markup: Error</string>


### PR DESCRIPTION
two additions to the tmtheme file for theming markup blockquotes:
- `>` formated as punctuation
- blockquote text formated in italic

Intendation would be nice too but I don't know how to do that...
