### PR TITLE
Commands to insert and refer to reference links

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -183,6 +183,21 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    { "keys": ["super+ctrl+r"], "command": "insert_named_reference", "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
+    { "keys": ["super+ctrl+shift+r"], "command": "insert_numbered_reference", "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
+    { "keys": ["super+ctrl+alt+l"], "command": "list_markdown_references", "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
     { "keys": ["#"], "command": "insert_snippet", "args": {"contents": "#${0: ${SELECTION/(^ | $)//g} }#"}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },

--- a/insert_named_reference.py
+++ b/insert_named_reference.py
@@ -1,0 +1,77 @@
+# -*- coding: UTF-8 -*-
+
+import sublime
+import sublime_plugin
+import re
+
+
+# Inspired by http://www.leancrew.com/all-this/2012/08/markdown-reference-links-in-bbedit/
+# Appends a new reference link to end of document, using a user-input name and URL.
+# Then inserts a reference to the link at the current selection(s).
+
+class InsertNamedReferenceCommand(sublime_plugin.TextCommand):
+
+    def description(self):
+        return 'Insert Numbered Reference Link'
+
+    def run(self, edit):
+
+        # If the clipboard contains an URL, use it as the default value in the input panel
+        # Otherwise, leave it empty
+        re_match_urls = re.compile(r"""((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.‌​][a-z]{2,4}/)(?:[^\s()<>]+|(([^\s()<>]+|(([^\s()<>]+)))*))+(?:(([^\s()<>]+|(‌​([^\s()<>]+)))*)|[^\s`!()[]{};:'".,<>?«»“”‘’]))""", re.DOTALL)
+        m = re_match_urls.search(sublime.get_clipboard())
+        s = m.group() if m else ''
+
+        self.view.window().show_input_panel(
+            'URL to link to:',
+            s,
+            self.receive_link,
+            None, None)
+
+    def receive_link(self, linkurl):
+        self.view.window().show_input_panel(
+            'Name for reference:',
+            '',
+            lambda newref: self.insert_link(linkurl, newref),
+            None, None)
+
+    def insert_link(self, linkurl, newref):
+        view = self.view
+        edit = view.begin_edit()
+
+        try:
+            # Detect if file ends with \n
+            if view.substr(view.size() - 1) == '\n':
+                nl = ''
+            else:
+                nl = '\n'
+
+            # Append the new reference link to the end of the file
+            view.insert(edit, view.size(), '{0}[{1}]: {2}\n'.format(nl, newref, linkurl))
+
+            # Now, add a reference to that link at the current cursor or around the current selection(s)
+            sels = view.sel()
+            caret = []
+
+            for sel in sels:
+                text = view.substr(sel)
+                # If something is selected...
+                if len(text) > 0:
+                    # ... turn the selected text into the link text
+                    view.replace(edit, sel, "[{0}][{1}]".format(text, newref))
+                else:
+                    # Add the link, with empty link text, and the caret positioned
+                    # ready to type the link text
+                    view.replace(edit, sel, "[][{0}]".format(newref))
+                    caret += [sublime.Region(sel.begin() + 1, sel.begin() + 1)]
+
+            if len(caret) > 0:
+                sels.clear()
+                for c in caret:
+                    sels.add(c)
+
+        finally:
+            view.end_edit(edit)
+
+    def is_enabled(self):
+        return self.view.sel()

--- a/insert_numbered_reference.py
+++ b/insert_numbered_reference.py
@@ -1,0 +1,77 @@
+# -*- coding: UTF-8 -*-
+
+import sublime
+import sublime_plugin
+import re
+
+
+# Inspired by http://www.leancrew.com/all-this/2012/08/markdown-reference-links-in-bbedit/
+# Appends a new reference link to end of document, using an autoincrementing number as the reference title.
+# Then inserts a reference to the link at the current selection(s).
+
+class InsertNumberedReferenceCommand(sublime_plugin.TextCommand):
+
+    def description(self):
+        return 'Insert Numbered Reference Link'
+
+    def run(self, edit):
+
+        # If the clipboard contains an URL, use it as the default value in the input panel
+        # Otherwise, leave it empty
+        re_match_urls = re.compile(r"""((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.‌​][a-z]{2,4}/)(?:[^\s()<>]+|(([^\s()<>]+|(([^\s()<>]+)))*))+(?:(([^\s()<>]+|(‌​([^\s()<>]+)))*)|[^\s`!()[]{};:'".,<>?«»“”‘’]))""", re.DOTALL)
+        m = re_match_urls.search(sublime.get_clipboard())
+        s = m.group() if m else ''
+
+        self.view.window().show_input_panel(
+            'URL to link to:',
+            s,
+            self.insert_link,
+            None, None)
+
+    def insert_link(self, linkurl):
+        view = self.view
+        edit = view.begin_edit()
+
+        try:
+            # Find the next reference number
+            reflinks = view.find_all(r'(?<=^\[)(\d+)(?=\]: )')
+            if len(reflinks) == 0:
+                newref = 1
+            else:
+                newref = max(int(view.substr(reg)) for reg in reflinks) + 1
+
+            # Detect if file ends with \n
+            if view.substr(view.size() - 1) == '\n':
+                nl = ''
+            else:
+                nl = '\n'
+
+            # Append the new reference link to the end of the file
+            view.insert(edit, view.size(), '{0}[{1}]: {2}\n'.format(nl, newref, linkurl))
+
+            # Now, add a reference to that link at the current cursor or around the current selection(s)
+            sels = view.sel()
+            caret = []
+
+            for sel in sels:
+                text = view.substr(sel)
+                # If something is selected...
+                if len(text) > 0:
+                    # ... turn the selected text into the link text
+                    view.replace(edit, sel, "[{0}][{1}]".format(text, newref))
+                else:
+                    # Add the link, with empty link text, and the caret positioned
+                    # ready to type the link text
+                    view.replace(edit, sel, "[][{0}]".format(newref))
+                    caret += [sublime.Region(sel.begin() + 1, sel.begin() + 1)]
+
+            if len(caret) > 0:
+                sels.clear()
+                for c in caret:
+                    sels.add(c)
+
+        finally:
+            view.end_edit(edit)
+
+    def is_enabled(self):
+        return self.view.sel()

--- a/list_markdown_references.py
+++ b/list_markdown_references.py
@@ -1,0 +1,47 @@
+import sublime, sublime_plugin
+import re
+
+
+# Based on http://www.macdrifter.com/2012/08/making-a-sublime-text-plugin-markdown-reference-viewer.html
+# and http://www.leancrew.com/all-this/2012/08/more-markdown-reference-links-in-bbedit/
+# Displays a list of reference links in the document, and
+# inserts a reference to the chosen item at the current selection.
+
+class ListMarkdownReferencesCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.markers = []
+        self.view.find_all(r'^(\[[^^\]]+\]):[ \t]+(.+)$', 0, '$1: $2', self.markers)
+        self.view.window().show_quick_panel(self.markers, self.insert_link, sublime.MONOSPACE_FONT)
+
+    def insert_link(self, choice):
+        if choice == -1:
+            return
+        edit = self.view.begin_edit()
+
+        try:
+            # Extract the reference name that was selected
+            ref = re.match(r'^\[([^^\]]+)\]', self.markers[choice]).group(1)
+
+            # Now, add a reference to that link at the current cursor or around the current selection(s)
+            sels = self.view.sel()
+            caret = []
+
+            for sel in sels:
+                text = self.view.substr(sel)
+                # If something is selected...
+                if len(text) > 0:
+                    # ... turn the selected text into the link text
+                    self.view.replace(edit, sel, "[{0}][{1}]".format(text, ref))
+                else:
+                    # Add the link, with empty link text, and the caret positioned
+                    # ready to type the link text
+                    self.view.replace(edit, sel, "[][{0}]".format(ref))
+                    caret += [sublime.Region(sel.begin() + 1, sel.begin() + 1)]
+
+            if len(caret) > 0:
+                sels.clear()
+                for c in caret:
+                    sels.add(c)
+
+        finally:
+            self.view.end_edit(edit)


### PR DESCRIPTION
Add a variety of commands for inserting and referring to reference
links. Inspired by and largely based on recent blog posts at leancrew.com and
macdrifter.com
