### PR TITLE
Fix padded header expanding selection issue

### DIFF
--- a/Padded Headline.sublime-macro
+++ b/Padded Headline.sublime-macro
@@ -1,4 +1,5 @@
 [
     {"command": "expand_selection", "args": {"to": "line"}},
-    {"command": "insert_snippet","args":{"contents": "${0:${SELECTION/(^#+ | #+$)//gm}}"}}
+    {"command": "insert_snippet","args":{"contents": "${0:${SELECTION/(^#+ | #+$)//gm}}"}},
+    {"command": "move", "args": {"by": "characters", "forward": false, "extend": true}}
 ]


### PR DESCRIPTION
When the #s reset from six to none, the selection unexpectedly expands
to contain the trailing newline.

I don't know why Sublime is doing that. This stops it. (Strictly
speaking: this undoes the expansion.)
