### PR TITLE
Solves issue inserting footnotes above 10

### DIFF
--- a/footnotes.py
+++ b/footnotes.py
@@ -87,7 +87,7 @@ class GatherMissingFootnotesCommand(sublime_plugin.TextCommand):
             self.view.insert(edit, self.view.size(), "\n")
             for note in missingnotes:
                 self.view.insert(edit, self.view.size(), '\n [^%s]: ' % note)
-            self.view.end_edit(edit)
+        self.view.end_edit(edit)
 
     def is_enabled(self):
         return self.view.sel()
@@ -201,9 +201,6 @@ class SortFootnotesCommand(sublime_plugin.TextCommand):
         [self.view.erase(edit, reg) for reg in erase]
         self.view.end_edit(edit)
 
-        import pprint
-        pprint.pprint(notes)
-        pprint.pprint(keys)
         edit = self.view.begin_edit()
         for key in keys:
             self.view.insert(edit, self.view.size(), '\n\n ' + notes[key])


### PR DESCRIPTION
When 9+ footnotes are present, `⌘⇧6` would insert footnote marker `[^10]`, even if `[^10]` was already present. This was caused by get_last_footnote_marker using string sorting rather than numerical sorting.

This pull request resolves this issue, removes superfluous logging from GatherMissingFootnotesCommand, and resolves an edge case where GatherMissingFootnotesCommand would fail to call view.end_edit().
