### PR TITLE
Don't add hash marks when they already exist at the end of the heading line

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -222,6 +222,7 @@
         [
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^#+\\s+[^#]", "match_all": true },
+            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "#+$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true }
         ]
     },


### PR DESCRIPTION
I often use this workflow to mark up a heading starting with a plain line:

```
Heading
```

I select the line and press the Opt-3 to convert it to a heading:

```
# Heading #
```

I then arrow to the end of the line and press return to move to the next line. Currently the keymapping causes this to happen:

```
# Heading # #
```

This update to the keymapping checks to see if the last characters on the line are hash marks - if so the assumption is that the heading has already been marked up appropriately, and no extra hash marks will be added.

Apologies for being from the UK and saying "hash marks" instead of "pound signs"
