### PR TITLE
Added a settings menu for MarkdownEditing

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,51 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Markdown Editing",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/MarkdownEditing/README.md"},
+                                "caption": "README"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/MarkdownEditing/Markdown.sublime-settings"},
+                                "caption": "Markdown Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/Markdown.sublime-settings"},
+                                "caption": "Markdown Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/MarkdownEditing/MultiMarkdown.sublime-settings"},
+                                "caption": "MultiMarkdown Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/MultiMarkdown.sublime-settings"},
+                                "caption": "MultiMarkdown Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
When I was first trying to re-configure the default settings I had to go hunting for the defaults in the MarkdownEditing folder. This commit adds a new menu under _Preferences -> Packages -> Markdown Editing_.

The menu will open the Markdown and MultiMarkdown default settings from the MarkdownEditing package, and also the user files. This duplicates the action of _Preferences -> Settings - More -> Syntax Specific - User_ but I felt it wasn't the end of the world to duplicate it here.

Also - added the ability to view the README for the package.
