### PR TITLE
Add install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,20 @@ There's a long way to go and I have a lot of Python to learn.
 
 ### Installation
 
+#### Sublime Package Control
+
+The preferred method of installation is via [Sublime Package Control](http://wbond.net/sublime_packages/package_control).
+
+1. [Install Sublime Package Control](http://wbond.net/sublime_packages/package_control/installation)
+2. From inside Sublime Text 2, open Package Control's Command Pallet: CTRL+SHIFT+P (Windows, Linux) or CMD+SHIFT+P on Mac.
+3. Type `install package` and hit Return. A list of available packages will be displayed.
+4. Type `MarkdownEditing` and hit Return. The package will be downloaded to the appropriate directory.
+5. Restart Sublime Text 2 to complete installation. Open a Markdown file and this custom theme. The features listed above should now be available.
+
+#### Manual Installation
+
 1. Download or clone this repository to a directory `MarkdownEditing` in the Sublime Text 2 Packages directory for your platform:
     * Mac: `git clone https://github.com/ttscoff/MarkdownEditing.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/MarkdownEditing`
     * Windows: `git clone https://github.com/ttscoff/MarkdownEditing.git %APPDATA%\Sublime/ Text/ 2/\MarkdownEditing`
     * Linux: `git clone https://github.com/ttscoff/MarkdownEditing.git ~/.Sublime\ Text\ 2/Packages/MarkdownEditing`
-2. Restart Sublime Text 2 to be sure the new package is available.
-3. Open a Markdown file and this custom theme. The features listed above should now be available.
+2. Restart Sublime Text 2 to complete installation. Open a Markdown file and this custom theme. The features listed above should now be available.


### PR DESCRIPTION
I hadn't ever installed a Sublime Text 2 package before, so I had no clue how to install this package. While it's relatively easy, I think it helps having this kind of info available in the package README. You do make it available on your website, so I've taken most of that text and included it.

I'm not 100% sure on the `Packages` directory path, so that may need cleanup if not correct. It is at least correct for the default Mac location, as I tested it on my local install.
