### PR TITLE
Overriding font choice for Windows users

### DIFF
--- a/Markdown (Windows).sublime-settings
+++ b/Markdown (Windows).sublime-settings
@@ -1,0 +1,10 @@
+{
+	"extensions":
+	[
+		"md",
+		"mdown",
+		"mmd",
+		"txt"
+	],
+	"font_face": "Consolas",
+}


### PR DESCRIPTION
The Consolas font is the best monospaced font on Windows, and Menlo
isn't available at all. This sets the font correctly for Windows users.
