### PR TITLE
Update Markdown (Windows).sublime-settings

### DIFF
--- a/Markdown (Windows).sublime-settings
+++ b/Markdown (Windows).sublime-settings
@@ -6,5 +6,5 @@
 		"mmd",
 		"txt"
 	],
-	"font_face": "Consolas",
+	"font_face": "Consolas"
 }


### PR DESCRIPTION
in windows, after installing the extension i got the following error:
_"Error trying to parse settings: Trailing comma before closing bracket in ...\Sublime Text 2\Packages\MarkdownEditing\Markdown (Windows).sublime-settings:10:1"_

Removing the trailing comma resolves this problem
