### PR TITLE
Fix inline image syntax

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -634,7 +634,7 @@
 					<key>name</key>
 					<string>string.other.link.description.markdown</string>
 				</dict>
-				<key>3</key>
+				<key>4</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.string.end.markdown</string>


### PR DESCRIPTION
The `Markdown.tmLanguage` file supplied with ST2 displays an inline image with the last letter of the caption highlighted where it should highlight the closing square brace. See image below:

![Screenshot of Sublime Text 2](https://f.cloud.github.com/assets/729402/323832/ecaa3c66-9ace-11e2-8e20-d15aedc2a582.png)

This pull request uses the correct captured section of the regex, fixing the highlighting. See image below:

![Screenshot of Sublime Text 2](https://f.cloud.github.com/assets/729402/323834/0780d4be-9acf-11e2-8f71-1f42b59ef487.png)
