### PR TITLE
Remove spell check package settings for Markdown syntax

### DIFF
--- a/Markdown.sublime-settings
+++ b/Markdown.sublime-settings
@@ -21,7 +21,5 @@
 	"caret_style": "wide",
 	"highlight_line": true,
 	// add trailing #'s to headlines
-	"match_header_hashes": false,
-	"spell_check": true,
-	"dictionary": "Packages/Language - English/en_US.dic"
+	"match_header_hashes": false
 }


### PR DESCRIPTION
Spell-check should be a Sublime setting. Hardcoding spell-checking settings into the package for a specific file format makes Sublime ignore the global settings. It is probable that the user will be confused why the application is ignoring the settings the UI is reporting as being used (Menu View > Spell Check / Dictionary).
