### PR TITLE
Changed goto_reference default binding.

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -226,7 +226,7 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
-    { "keys": ["ctrl+shift+l"], "command": "goto_reference", "context":
+    { "keys": ["ctrl+alt+g"], "command": "goto_reference", "context":
         [
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]


### PR DESCRIPTION
The keyboard shortcut for goto_reference is used for creating multiple cursors from selected lines in the default keymap. Changed to ctrl+alt+g which has no default binding. This may need to be modified in the default keymap for OS X as well.
