### PR TITLE
Remove font-size from MultiMarkdown settings

### DIFF
--- a/MultiMarkdown.sublime-settings
+++ b/MultiMarkdown.sublime-settings
@@ -8,7 +8,6 @@
 	],
 	"trim_trailing_white_space_on_save": false,
 	"font_face": "Menlo",
-	"font_size": 15,
 	"font_options": [ "subpixel_antialias", "no_round", "directwrite"],
 	"color_scheme": "Packages/MarkdownEditing/MarkdownEditor.tmTheme",
 	// "color_scheme": "Packages/MarkdownEditing/MarkdownEditor-Focus.tmTheme",


### PR DESCRIPTION
Removed the default font-size from the MultiMarkdown.sublime-settings file.
