### PR TITLE
"Fix Underlined Markdown Headers" update for ST 3

### DIFF
--- a/underlined_headers.py
+++ b/underlined_headers.py
@@ -94,7 +94,7 @@ class FixAllUnderlinedHeadersCommand(sublime_plugin.TextCommand):
 		prev_lines, lines = itertools.tee(lines)
 		next(prev_lines)
 
-		for text_line, dashes_line in itertools.izip(prev_lines, lines):
+		for text_line, dashes_line in zip(prev_lines, lines):
 			dashes_text = self.view.substr(dashes_line)
 			m = SETEXT_DASHES_RE.match(dashes_text)
 			if m:


### PR DESCRIPTION
Command failed in Sublime Text 3. Was using `itertools.izip` from
Python 2, which was removed in Python 3. Updated to just use `zip`
built-in.
