### PR TITLE
Indent list items with Tab key

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -51,6 +51,14 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent", "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(\\*|-) $", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
     { "keys": ["_"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
      [
          { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },

--- a/messages/2.0.4.md
+++ b/messages/2.0.4.md
@@ -1,0 +1,9 @@
+# MarkdownEditing 2.0.4 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of feedback you can use [GitHub issues][issues].
+
+## New Features
+
+* Pressing <kbd>Tab</kbd> on a blank list item (starting with `*` or `-` and a trailing space) indents it.
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues


### PR DESCRIPTION
I was wondering why I can't press <kbd>Tab</kbd> to indent list items, so I added it.  
It will work on both list styles (`*` and `-`).
