### PR TITLE
Indent list items with Tab key

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -51,6 +51,14 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent", "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(\\*|-) $", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
     { "keys": ["_"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
      [
          { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -51,6 +51,14 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent", "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(\\*|-) $", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
     { "keys": ["_"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
      [
          { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -51,6 +51,14 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent", "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "(\\*|-) $", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
     { "keys": ["_"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
      [
          { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },

--- a/messages/2.0.4.md
+++ b/messages/2.0.4.md
@@ -13,6 +13,7 @@ Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of fee
 * Caret is now taller similar to iA Writer. Works in only Sublime Text Build 3057 and above.
 * MultiMarkdown now imports GitHub flavored markdown instead of standard markdown.
     _Description_: MultiMarkdown syntax file doesn't redefine things, instead imports standard markdown syntax file. With this version, it imports GFM syntax file instead of the standard one. GFM has had many bug fixes and improvements over the standard md syntax file. So hopefully, MultiMarkdown users will benefit from this improvements, too.
+* Pressing <kbd>Tab</kbd> on a blank list item (starting with `*` or `-` and a trailing space) indents it.
 
 ## Changes
 


### PR DESCRIPTION
I was wondering why I can't press <kbd>Tab</kbd> to indent list items, so I added it.
It will work on both list styles (`*` and `-`).
