### PR TITLE
Add ability to wrap/unwrap inline code

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -211,6 +211,30 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
+    // code on Super + Alt + ´
+    { "keys": ["super+alt+´"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Code.sublime-macro"}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
+    { "keys": ["super+alt+´"], "command": "insert_snippet", "args": {"contents": "`$1`"}, "context":
+     [
+         { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+         { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+         { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|$)", "match_all": true },
+         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "['a-zA-Z0-9_]$", "match_all": true },
+         { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
+         { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+     ]
+    },
+    { "keys": ["super+alt+´"], "command": "insert_snippet", "args": {"contents": "`${SELECTION/(^`*|`*$)//g}`"}, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
 
     // Unbold on Super + Alt + B if already bold
     { "keys": ["super+alt+b"], "command": "insert_snippet", "args": {"contents": "${SELECTION/(^[\\*_]{2}|[\\*_]{2}$)//g}"}, "context":
@@ -220,13 +244,13 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
-    { "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize.sublime-macro"}, "context":
+    { "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold.markdown", "match_all": true }
         ]
     },
-    { "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize.sublime-macro"}, "context":
+    { "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\b__+\\S+__+$", "match_all": true },
@@ -242,13 +266,35 @@
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
         ]
     },
-    { "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize.sublime-macro"}, "context":
+    { "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic.markdown", "match_all": true }
         ]
     },
-    { "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize.sublime-macro"}, "context":
+    { "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "\\b_(?!_)\\S+_$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
+
+    // Uncode on Super + Alt + ´ if already code
+    { "keys": ["super+alt+´"], "command": "insert_snippet", "args": {"contents": "${SELECTION/(^`|`$)//g}"}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "text", "operator": "regex_match", "operand": "^`.*`$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+        ]
+    },
+    { "keys": ["super+alt+´"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.raw.inline", "match_all": true }
+        ]
+    },
+    { "keys": ["super+alt+´"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro"}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "\\b_(?!_)\\S+_$", "match_all": true },

--- a/macros/Transform Word - Code.sublime-macro
+++ b/macros/Transform Word - Code.sublime-macro
@@ -1,0 +1,4 @@
+[
+    {"command": "custom_find_under_expand"},
+    {"command": "insert_snippet", "args": {"contents": "`${SELECTION/(^`*|`*$)//g}`"}}
+]

--- a/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro
+++ b/macros/Transform Word - Unbold Unitalicize Uncode.sublime-macro
@@ -1,0 +1,4 @@
+[
+    {"command": "custom_find_under_expand"},
+    {"command": "insert_snippet", "args": {"contents": "${SELECTION/(^[*_`]*|[*_`]*$)//g}"}}
+]

--- a/macros/Transform Word - Unbold Unitalicize.sublime-macro
+++ b/macros/Transform Word - Unbold Unitalicize.sublime-macro
@@ -1,4 +1,0 @@
-[
-    {"command": "custom_find_under_expand"},
-    {"command": "insert_snippet", "args": {"contents": "${SELECTION/(^[*_]*|[*_]*$)//g}"}}
-]

--- a/messages/2.0.7.md
+++ b/messages/2.0.7.md
@@ -3,5 +3,6 @@
 Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of feedback you can use [GitHub issues][issues].
 
 * Fenced code blocks now supports Lisp. Fixes #156
+* Like with bold and italic you can now wrap (and unwrap) text in backticks (`) for inline code. Default shortcut on OS X is <kbd>⌘</kbd><kbd>⌥</kbd><kbd>´</kbd>.
 
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues


### PR DESCRIPTION
Basically the same functionality like (un)wrapping text with **bold** and *italic* markers, just for `inline code`.

It's working for basic usage, but a few things to consider:
- I'm not sure if the shortcut (<kbd>⌘</kbd><kbd>⌥</kbd><kbd>´</kbd>) translates well to other keyboard layouts than the german one. Actually I'm pretty sure it doesn't. But I have no way to test it.
- For the same reason I didn't add any default shortcuts for windows and linux.

For the sake of semantics I renamed

_Transform Word - Unbold Unitalicize.sublime-macro_

to

_Transform Word - Unbold Unitalicize <strong>Uncode</strong>.sublime-macro_

What do you say?
