### PR TITLE
Command to convert SETEXT headers to ATX

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,6 +4,10 @@
         "command": "fix_all_underlined_headers"
     },
     {
+        "caption": "MarkdownEditing: Convert Underlined Headers to ATX",
+        "command": "convert_to_atx"
+    },
+    {
         "caption": "MarkdownEditing: Add Missing Link Labels",
         "command": "gather_missing_link_markers"
     },

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Strikethrough is supported:
 
 Adjusts every setext-style header to add or remove `=` or `-` characters as needed to match the lengths of their header text.
 
+### Convert Underlined Headers to ATX
+
+Converts every setext-style header into an ATX style header. If something is selected only the headers in the selections will be converted, otherwise the conversion will be applied to the whole view.
+
 ### Add Missing Link Labels
 
 Scans document for referenced link usages (`[some link][some_ref]` and `[some link][]`) and checks if they are all defined. If there are undefined link references, command will automatically create their definition snippet at the bottom of the file.

--- a/messages/2.0.7.md
+++ b/messages/2.0.7.md
@@ -4,4 +4,8 @@ Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of fee
 
 * Fenced code blocks now supports Lisp. Fixes #156
 
+## New Features
+
+* Added command to convert underlined (SETEXT) headers to hashed (ATX) headers
+
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues


### PR DESCRIPTION
Add the command `convert_to_atx` to convert all (selected) SETEXT headers like these

```
Title
=====

Subtitle
----------
```

to ATX style headers

```
# Title

## Subtitle
```

Revised as suggested in #161
