### PR TITLE
Add YAML metadata highlighting

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -28,6 +28,44 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>comment</key>
+			<string>
+				Pandoc and blogging programs based on Markdown
+				allow a YAML header with metadata.
+				It is buggy if using `...` delimiter
+				and  last item is an unquoted block
+			</string>
+			<key>begin</key>
+			<string>^---$\n</string>
+			<key>end</key>
+			<string>^(---|\.\.\.)$\n</string>
+			<key>name</key>
+			<string>meta.metadata.markdown</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>meta.separator.metadata.markdown</string>
+				</dict>
+			</dict>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>meta.separator.metadata.markdown</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.yaml</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>(?x)^
 				(?=	[ ]{,3}&gt;


### PR DESCRIPTION
Many tools, such as Pandoc, Jackyl, Hakyll and others, support a metadata block written in YAML.

This PR adds support for highlighting of the metadata block by including the YAML language defs in `---` fenced blocks.

It is not super robust when using `...` as an end delimiter due to the YAML definitions and could conflict with other extensions so please test and confirm this is desirable.

Another option would be including this in a draft language definition for Pandoc's markdown variant.
