### PR TITLE
Fix automatch * when closing bold

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -5,7 +5,7 @@
          { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
          { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
          { "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\)|]|\\}|$)", "match_all": true },
-         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "['a-zA-Z0-9_]$", "match_all": true },
+         { "key": "preceding_text", "operator": "not_regex_contains", "operand": "['a-zA-Z0-9_*]$", "match_all": true },
          { "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
          { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
          { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }


### PR DESCRIPTION
Suppose you want to write a bold word.
You type in `**Word|` (here `|` is the cursor) and you now want to close the `**`.
You press `*` and you have `**Word*|` but then when you press `*` again, it gets automatched resulting in `**Word**|*`. You then have to advance the cursor and delete the extra `*`.
Obviously you could also select `Word` and press `*` twice but the other workflow should also be supported.

This PR fixes the problem by disabling automatch of `*` when the preceding text is a letter or `*`.
