### PR TITLE
Assign a scope to item bullets inside lists

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -1322,6 +1322,12 @@
 							<string>#inline</string>
 						</dict>
 						<dict>
+							<key>match</key>
+							<string>\G\s*(?:[*\-+]|[0-9]+\.)\s+</string>
+							<key>name</key>
+							<string>punctuation.definition.list_item</string>
+						</dict>
+						<dict>
 							<key>include</key>
 							<string>text.html.basic</string>
 						</dict>


### PR DESCRIPTION
Currently the list bullets/numbers in a list are not assigned a scope apart from the first one.
This patch assigns the scope `punctuation.definition.list_item` to all of them.
