### PR TITLE
Fixes an issue with numbered lists.

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -9,5 +9,6 @@
     "2.0.6": "messages/2.0.6.md",
     "2.0.7": "messages/2.0.7.md",
     "2.0.8": "messages/2.0.8.md",
-    "2.0.9": "messages/2.0.9.md"
+    "2.0.9": "messages/2.0.9.md",
+    "2.0.10": "messages/2.0.10.md"
 }

--- a/messages/2.0.10.md
+++ b/messages/2.0.10.md
@@ -1,0 +1,9 @@
+# MarkdownEditing 2.0.10 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* Fixes an issue where non-collapsed selections in numbered lists would not get deleted upon pressing `Enter`.
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/numbered_list.py
+++ b/numbered_list.py
@@ -9,9 +9,11 @@ class NumberListCommand(sublime_plugin.TextCommand):
 		num = re.search('\d', text).start()
 		dot = text.find(".")
 		if num == 0:
-			view.insert(edit, sel.end(), "\n%d. " % (int(text[:dot]) + 1,))
+			view.erase(edit, sel)
+			view.insert(edit, sel.begin(), "\n%d. " % (int(text[:dot]) + 1,))
 		else:
-			view.insert(edit, sel.end(), "\n%s%d. " % (text[:num], int(text[num:dot]) + 1))
+			view.erase(edit, sel)
+			view.insert(edit, sel.begin(), "\n%s%d. " % (text[:num], int(text[num:dot]) + 1))
 
 	def is_enabled(self):
 		return bool(self.view.score_selector(self.view.sel()[0].a, "text.html.markdown"))


### PR DESCRIPTION
When the selection spanned one or more characters (the selection was not collapsed) in a numbered list, pressing 'enter' did not cause the selection to be deleted. This fixes that issue.

For example (`|` denotes the selection):

```
1. This is a |list |item.
```

Previously, pressing `Enter` caused this to happen:

```
1. This is a |list |
2. item
```

Whereas the correct behaviour, which this commit implements, would be:

```
1. This is a
2. |item
```
