### PR TITLE
Handle defaults better for mde.keep_centered setting

### DIFF
--- a/distraction_free_mode.py
+++ b/distraction_free_mode.py
@@ -21,11 +21,10 @@ class KeepCurrentLineCentered(sublime_plugin.EventListener):
             return False
 
         if on_distraction_free():
-            if view.settings().get("mde.distraction_free_mode").get("mde.keep_centered") is False:
+            if not view.settings().get('mde.distraction_free_mode', {}) \
+                                  .get('mde.keep_centered', True):
                 return False
-
-        else:
-            if view.settings().get("mde.keep_centered") is False:
-                return False
+        elif not view.settings().get('mde.keep_centered', False):
+            return False
 
         view.show_at_center(view.sel()[0].begin())

--- a/messages.json
+++ b/messages.json
@@ -11,5 +11,6 @@
     "2.0.8": "messages/2.0.8.md",
     "2.0.9": "messages/2.0.9.md",
     "2.1.0": "messages/2.1.0.md",
-    "2.1.1": "messages/2.1.1.md"
+    "2.1.1": "messages/2.1.1.md",
+    "2.1.2": "messages/2.1.2.md"
 }

--- a/messages/2.1.2.md
+++ b/messages/2.1.2.md
@@ -1,0 +1,13 @@
+# MarkdownEditing {version} Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* Fixed keep centered feature unintentionally switching on.
+
+## New Features
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues


### PR DESCRIPTION
Now defaults will always be `False` in normal mode and `True` in distraction free one, not depending on used syntax. 

Default settings in syntax files is only useful now as reference, so you may want to cut that down.