### PR TITLE
Require HTML block closing tags be at the beginning of their line

### DIFF
--- a/Markdown (Standard).tmLanguage
+++ b/Markdown (Standard).tmLanguage
@@ -122,7 +122,7 @@
 				Markdown formatting is disabled inside block-level tags.
 			</string>
 			<key>end</key>
-			<string>(?&lt;=&lt;/\1&gt;$\n)</string>
+			<string>(?&lt;=^&lt;/\1&gt;$\n)</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -136,7 +136,7 @@
 				Markdown formatting is disabled inside block-level tags.
 			</string>
 			<key>end</key>
-			<string>(?&lt;=&lt;/\1&gt;$\n)</string>
+			<string>(?&lt;=^&lt;/\1&gt;$\n)</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
See discussion in #316.