### PR TITLE
Add support for ```objc code fence

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -1828,7 +1828,7 @@
 		<key>fenced-obj-c</key>
 		<dict>
 		    <key>begin</key>
-		    <string>^(\s*[`~]{3,})\s*(objective-c)\s*$</string>
+		    <string>^(\s*[`~]{3,})\s*(obj(ective-)?c)\s*$</string>
 		    <key>end</key>
 		    <string>^(\1)\n</string>
 		    <key>name</key>


### PR DESCRIPTION
When marking a code block as Objective-C the short notation `objc` is often used.
This patch makes the plugin understand both

    ```objective-c

and

    ```objc