### PR TITLE
Tune `lineHighlight` on MarkdownEditor Theme.

### DIFF
--- a/MarkdownEditor.tmTheme
+++ b/MarkdownEditor.tmTheme
@@ -18,7 +18,7 @@
                 <key>invisibles</key>
                 <string>#E0E0E0</string>
                 <key>lineHighlight</key>
-                <string>#e6e6e6</string>
+                <string>#B6B6B6</string>
                 <key>selection</key>
                 <string>#C2E8FF</string>
                 <key>selectionBorder</key>


### PR DESCRIPTION
Current color of `lineHighlight` in `MarkdownEditor.tmTheme`
is lighter than background color.
This makes current line highlight invisible
even a user enabled `highlight_line` in setting.

This commit uses a darker color.

Rebase from master to v2.1.7 and close #345.

---
 MarkdownEditor.tmTheme | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)