### PR TITLE
Add snippets for markdown code block

### DIFF
--- a/snippets/Markdown_codeblock_(mdc).sublime-snippet
+++ b/snippets/Markdown_codeblock_(mdc).sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[```${1:language}
+${2:code}
+```]]></content>
+  <tabTrigger>mdc</tabTrigger>
+  <scope>text.html.markdown.multimarkdown, text.html.markdown</scope>
+  <description>Markdown Codeblock</description>
+</snippet>


### PR DESCRIPTION
I think this is easier for author to type instead of the six ` characters.