### PR TITLE
decide_title.py : do not change name if name is already set

### DIFF
--- a/decide_title.py
+++ b/decide_title.py
@@ -24,5 +24,5 @@ class DecideTitle(sublime_plugin.EventListener):
                 break
 
             title = title.strip()
-            if view.file_name() is None and len(title) > 0:
+            if view.file_name() is None and view.name() is None and len(title) > 0:
                 view.set_name(title[:55])


### PR DESCRIPTION
If the buffer already has a name set by other plugin, we don't have to decide tile again.