### PR TITLE
V2.2.0

### DIFF
--- a/distraction_free_mode.py
+++ b/distraction_free_mode.py
@@ -7,7 +7,10 @@
 
 import sublime
 import sublime_plugin
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 def on_distraction_free():

--- a/footnotes.py
+++ b/footnotes.py
@@ -1,7 +1,10 @@
 import sublime
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 DEFINITION_KEY = 'MarkdownEditing-footnote-definitions'
 REFERENCE_KEY = 'MarkdownEditing-footnote-references'

--- a/indent_list_item.py
+++ b/indent_list_item.py
@@ -13,13 +13,13 @@ class IndentListItemCommand(MDETextCommand):
             line = self.view.line(region)
             line_content = self.view.substr(line)
 
-            bullet_pattern = "([*+\\-])"
+            bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
+            bullet_pattern = '([' + ''.join(re.escape(i) for i in bullets) + '])'
 
             new_line = line_content
 
             # Transform the bullet to the next/previous bullet type
             if self.view.settings().get("mde.list_indent_auto_switch_bullet", True):
-                bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
 
                 for key, bullet in enumerate(bullets):
                     if bullet in new_line:

--- a/indent_list_item.py
+++ b/indent_list_item.py
@@ -1,6 +1,9 @@
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class IndentListItemCommand(MDETextCommand):

--- a/indent_list_multiitem.py
+++ b/indent_list_multiitem.py
@@ -1,6 +1,9 @@
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class IndentListMultiitemCommand(MDETextCommand):

--- a/indent_list_multiitem.py
+++ b/indent_list_multiitem.py
@@ -27,14 +27,13 @@ class IndentListMultiitemCommand(MDETextCommand):
                     tab_str = "\t"
 
                 if re.match("^\\s*(>\\s*)?[*+\\-]\\s+(.*)$", line_content):
-                    bullet_pattern = "([*+\\-])"
+                    bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
+                    bullet_pattern = '([' + ''.join(re.escape(i) for i in bullets) + '])'
                     bullet_pattern_a = "^\\s*(?:>\\s*)?("
                     bullet_pattern_b = ")\\s+"
                     new_line = line_content
                     # Transform the bullet to the next/previous bullet type
                     if self.view.settings().get("mde.list_indent_auto_switch_bullet", True):
-                        bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
-
                         for key, bullet in enumerate(bullets):
                             re_bullet = re.escape(bullet)
                             search_pattern = bullet_pattern_a + \

--- a/lint.py
+++ b/lint.py
@@ -1,7 +1,10 @@
 import sublime
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class mddef(object):

--- a/messages/2.2.0.md
+++ b/messages/2.2.0.md
@@ -6,6 +6,7 @@ feedback you can use [GitHub issues][issues].
 ## Bug Fixes
 
 * Fixed an ImportError on some ST2 builds, breaking many MarkdownEditing commands
+* Added usage of bullet chars defined by list_indent_bullets in all non-lint handling
 
 ## New Features
 

--- a/messages/2.2.0.md
+++ b/messages/2.2.0.md
@@ -5,6 +5,8 @@ feedback you can use [GitHub issues][issues].
 
 ## Bug Fixes
 
+* Fixed an ImportError on some ST2 builds, breaking many MarkdownEditing commands
+
 ## New Features
 
 ## Changes

--- a/numbered_list.py
+++ b/numbered_list.py
@@ -1,6 +1,9 @@
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class NumberListCommand(MDETextCommand):

--- a/quote_indenting.py
+++ b/quote_indenting.py
@@ -1,7 +1,10 @@
 import re
 import sublime
 import sublime_plugin
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class IndentQuote(MDETextCommand):

--- a/references.py
+++ b/references.py
@@ -1,7 +1,10 @@
 import sublime
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 refname_scope_name = "constant.other.reference.link.markdown"
 definition_scope_name = "meta.link.reference.def.markdown"

--- a/switch_list_bullet_type.py
+++ b/switch_list_bullet_type.py
@@ -10,6 +10,7 @@ class SwitchListBulletTypeCommand(MDETextCommand):
 
     def run(self, edit):
         todo = []
+        unordered_bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
         for region in self.view.sel():
             lines = self.view.line(region)
             lines = self.view.split_by_newlines(lines)
@@ -27,11 +28,12 @@ class SwitchListBulletTypeCommand(MDETextCommand):
                     # Insert the new item
                     todo.append([line, new_line])
                 else:
-                    m = re.match(r"^(\s*(?:>\s*)?)[0-9]+\.(\s+.*)$", line_content)
+                    m = re.match(r"^(\s*(?:>\s*)?)[" +
+                                 ''.join(re.escape(i) for i in unordered_bullets) +
+                                 r"](\s+.*)$", line_content)
                     if m:
-                        marker = self.view.settings().get('mde.list_indent_bullets', ["*"])
                         # Transform the bullet to unnumbered bullet type
-                        new_line = m.group(1) + marker[0] + m.group(2)
+                        new_line = m.group(1) + unordered_bullets[0] + m.group(2)
 
                         # Insert the new item
                         todo.append([line, new_line])

--- a/switch_list_bullet_type.py
+++ b/switch_list_bullet_type.py
@@ -1,6 +1,9 @@
 import sublime_plugin
 import re
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 
 class SwitchListBulletTypeCommand(MDETextCommand):

--- a/underlined_headers.py
+++ b/underlined_headers.py
@@ -20,7 +20,10 @@ import sublime
 import sublime_plugin
 import re
 import itertools
-from MarkdownEditing.mdeutils import *
+try:
+    from MarkdownEditing.mdeutils import *
+except ImportError:
+    from mdeutils import *
 
 SETEXT_DASHES_RE = re.compile( r'''
     (?: =+ | -+ ) # A run of ---- or ==== underline characters.


### PR DESCRIPTION
#388 is fixed by 5b8c4fc, it's an incredibly straightforward change:

> Import mdeutils fall back if MarkdownEditing.mdeutils fails (ST2)
> In ST2 imports were failing for me causing none of the commands to be found, can see this in the console whenever the plugin is loaded. I'm unsure if newer ST2 builds and/or ST3 injects the plugin directory into PYTHONPATH, but it doesn't appear to on ST2 in Windows by default, at least on earlier builds. This has a fallback to the import to attempt to load from local import of mdeutils if the import of MarkdownEditing.mdeutils fails on the first attempt.

#393 is fixed by b546e13, it's slightly more complicated but the commit message explains it well enough I believe:

>Unordered bullets should respect list_indent_bullets vs hardcoded list
> Primarily for regular expressions, use the values in list_indent_bullets rather than hardcoded *+- currently in any regex strings to match bullet characters.
> Not including lint handling, since linting is intended to compare vs markdown standards, in contrast to things like tab indentation and ordered vs unordered list type switching.