### PR TITLE
Fix invalid first_line_match in MultiMarkdown.tmLanguage

### DIFF
--- a/MultiMarkdown.tmLanguage
+++ b/MultiMarkdown.tmLanguage
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>firstLineMatch</key>
-	<string>^Format:\s*(?i:complete)\s*$</string>
+	<string>(?i)^format:\s*complete\s*$</string>
 	<key>foldingStartMarker</key>
 	<string>(?x)
 		(&lt;(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\b.*?&gt;


### PR DESCRIPTION
This change has been merged by official ST: https://github.com/sublimehq/Packages/pull/657

--

Other reference(s):

- https://github.com/jfcherng/Sublime-AutoSetSyntax/issues/6