### PR TITLE
Parse tut fences as scala

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -1873,7 +1873,7 @@
 		<key>fenced-scala</key>
 		<dict>
 		    <key>begin</key>
-		    <string>^(\s*[`~]{3,})\s*(scala)\s*$</string>
+		    <string>^(\s*[`~]{3,})\s*(scala|tut)\s*(:\S*)?$</string>
 		    <key>end</key>
 		    <string>^(\1)\n</string>
 		    <key>name</key>


### PR DESCRIPTION
[Tut](https://github.com/tpolecat/tut) is a scala sbt plugin which enables one to write scala code within markdown which is compiled and interpreted. Generated markdown documents contain both the source code and the output of that code as it would be in a REPL environment.

Because tut is widely-used in writing scala documentation in markdown, this pull request adds "tut" as an alias for scala syntax highlighting.

Tut blocks can optionally be suffixed with `:suffix`, to generate docs in different ways, so the regex also matches on that optional colon.

Example:

~~~
```tut
val x = "Hello"
println(x)
```
~~~

Compiles to:
~~~
```scala
scala> val x = "Hello"
res0: String = "Hello"

scala> println(x)
"Hello"
```
~~~


