### PR TITLE
List "md" file type first in grammar

### DIFF
--- a/Markdown.tmLanguage
+++ b/Markdown.tmLanguage
@@ -4,10 +4,10 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
+		<string>md</string>
 		<string>mdown</string>
 		<string>markdown</string>
 		<string>markdn</string>
-		<string>md</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(?x)


### PR DESCRIPTION
The first extension is used by Sublime as the default extension when saving a new file or doing a "Save As".