### PR TITLE
Space2tabs tmPreference fix

### DIFF
--- a/Symbol List - Heading.tmPreferences
+++ b/Symbol List - Heading.tmPreferences
@@ -14,12 +14,12 @@
 		<string>
 			s/\s*#+\s*$//g;
 			s/^\s*#(#*)\s*/$1/g;
-			s/^#{5}/                                   /g;
-			s/^#{4}/                            /g;
-			s/^#{3}/                     /g;
-			s/^#{2}/              /g;
-			s/^#{1}/       /g;
-			s/^(-+)\s*$/       $1/
+			s/^#{5}/					/g;
+			s/^#{4}/				/g;
+			s/^#{3}/			/g;
+			s/^#{2}/		/g;
+			s/^#{1}/	/g;
+			s/^(-+)\s*$/	$1/
 		</string>
 		<key>showInIndexedSymbolList</key>
 		<integer>1</integer>


### PR DESCRIPTION
SublimeText Outline plugin has an option of tab size, which should affect identation of lower levels of headings in outine view. But since MarkdownEditing plugin uses spaces in .tmPreferences, tab size in Outline plugin does not work. This commit fixes it.