### PR TITLE
List indentation improvements

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -61,7 +61,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -77,7 +76,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -344,6 +344,24 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol} /}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+])\\s+)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol}/}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+]))$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s+\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     // Extend lists with GFM tasks
     { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*([*\\-+])(\\s+)\\[[ x]\\](\\s+)).*/\n$2$3[ ]$4/}"}, "context":
         [

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -60,7 +60,7 @@
     { "keys": ["tab"], "command": "indent_list_item", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -84,7 +84,7 @@
     { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -65,6 +65,15 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent_list_item", "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     { "keys": ["tab"], "command": "indent_list_multiitem", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
@@ -76,6 +85,15 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -61,7 +61,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -77,7 +76,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -344,6 +344,24 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol} /}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+])\\s+)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol}/}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+]))$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s+\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     // Extend lists with GFM tasks
     { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*([*\\-+])(\\s+)\\[[ x]\\](\\s+)).*/\n$2$3[ ]$4/}"}, "context":
         [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -60,7 +60,7 @@
     { "keys": ["tab"], "command": "indent_list_item", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -84,7 +84,7 @@
     { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -65,6 +65,15 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent_list_item", "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     { "keys": ["tab"], "command": "indent_list_multiitem", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
@@ -76,6 +85,15 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -61,7 +61,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -77,7 +76,6 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
-            { "key": "following_text", "operator": "regex_contains", "operand": "^$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -344,6 +344,24 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol} /}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+])\\s+)$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*(?<symbol>[*\\-+])(?<space>\\s)?).*/\n$+{symbol}/}"}, "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^(\\s*([*\\-+]))$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s+\\S.*$", "match_all": true },
+            { "key": "auto_complete_visible", "operator": "equal", "operand": false },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     // Extend lists with GFM tasks
     { "keys": ["enter"], "command": "insert_snippet", "args": {"contents": "${TM_CURRENT_LINE/^(\\s*([*\\-+])(\\s+)\\[[ x]\\](\\s+)).*/\n$2$3[ ]$4/}"}, "context":
         [

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -60,7 +60,7 @@
     { "keys": ["tab"], "command": "indent_list_item", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
@@ -84,7 +84,7 @@
     { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s*$", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -65,6 +65,15 @@
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]
     },
+    { "keys": ["tab"], "command": "indent_list_item", "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
     { "keys": ["tab"], "command": "indent_list_multiitem", "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
@@ -76,6 +85,15 @@
         [
             { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+$", "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+            { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
+        ]
+    },
+    { "keys": ["shift+tab"], "command": "indent_list_item", "args": {"reverse": true}, "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+            { "key": "preceding_text", "operator": "regex_contains", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_contains", "operand": "^\\s*(>\\s*)?[*+\\-]\\s+", "match_all": true },
             { "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
             { "key": "selector", "operator": "not_equal", "operand": "markup.raw", "match_all": true }
         ]


### PR DESCRIPTION
Current behavior allows for indenting list items using the `tab` key (`shift+tab` for dedent), but only if the cursor is after the list item symbol, and if there is a space between the symbol and the cursor.

These changes allow the following to trigger the `indent_list_item` function:

```
*<space><cursor><text>

*<cursor><space><text>

<cursor><space>*<space>

<cursor>*<space>
```