### PR TITLE
Strip headers from Markdown links of []()

### DIFF
--- a/Symbol List - Heading.tmPreferences
+++ b/Symbol List - Heading.tmPreferences
@@ -12,6 +12,7 @@
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string>
+			s/\[([^]]+)\]\([^)]+\)/$1/g;
 			s/\s*#+\s*$//g;
 			s/^\s*#(#*)\s*/$1/g;
 			s/^#{5}/                                   /g;


### PR DESCRIPTION
This edit allows to strip Markdown headers from link urls (applies to _Goto to symbol_ menu and to _Outline plugin_ display)