### PR TITLE
Dropped requirement of having package_control installed

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -121,21 +121,23 @@ function fibo(n) {
 
 
 def plugin_loaded():
-    from package_control import events
+    if "package_control" in sys.modules:
+        from package_control import events
 
-    if events.install(package_name):
-        # Native package causes some conflicts.
-        disable_native_markdown_package()
-        # Prmopts to select a color theme
-        choose_color_theme()
+        if events.install(package_name):
+            # Native package causes some conflicts.
+            disable_native_markdown_package()
+            # Prmopts to select a color theme
+            choose_color_theme()
 
 
 def plugin_unloaded():
-    from package_control import events
+    if "package_control" in sys.modules:
+        from package_control import events
 
-    if events.remove(package_name):
-        # Native package causes some conflicts.
-        enable_native_markdown_package()
+        if events.remove(package_name):
+            # Native package causes some conflicts.
+            enable_native_markdown_package()
 
 # Compat with ST2
 if sys.version_info < (3,):


### PR DESCRIPTION
The conditional code isn't strictly needed, it is even shown in your docs how to disable it manually in settings (for those who don't want package_control)