### PR TITLE
Fix the 'keymap_disable...' field names

### DIFF
--- a/Markdown (Standard).sublime-settings
+++ b/Markdown (Standard).sublime-settings
@@ -96,29 +96,29 @@
 	// Super key references to a key next to left Alt key. It usually has a Windows logo or "win" or "Command" on it.
 	// Jump between link/image/footnote reference and definition
 	// Default keys: (OSX)super+ctrl+shift+l	(Linux/Win)ctrl+alt+g
-	"mde.keymap_disable_reference_jump": false,
+	"mde.keymap_disable.reference_jump": false,
 	// Add a new link
 	// Default keys: (OSX)super+alt+r	(Linux/Win)ctrl+super+r
-	"mde.keymap_disable_reference_new_reference": false,
+	"mde.keymap_disable.reference_new_reference": false,
 	// Add a new inline link
 	// Default keys: (OSX)super+alt+v	(Linux/Win)ctrl+super+v
-	"mde.keymap_disable_reference_new_inline_link": false,
+	"mde.keymap_disable.reference_new_inline_link": false,
 	// Add a new inline image
 	// Default keys: (OSX/Linux/Win)super+shift+k
-	"mde.keymap_disable_reference_new_inline_image": false,
+	"mde.keymap_disable.reference_new_inline_image": false,
 	// Add a new footnote
 	// Default keys: (OSX/Linux/Win)alt+shift+6
-	"mde.keymap_disable_reference_new_footnote": false,
+	"mde.keymap_disable.reference_new_footnote": false,
 	// Fold current section
 	// Default keys: (OSX/Linux/Win)shift+tab
-	"mde.keymap_disable_fold_section": false,
+	"mde.keymap_disable.fold_section": false,
 	// Open a panel showing all functions related to folding
 	// Default keys: (OSX/Linux/Win)ctrl+shift+tab
-	"mde.keymap_disable_show_fold_all_sections": false,
+	"mde.keymap_disable.show_fold_all_sections": false,
 	// Jump to the next heading (any level/same or higher level)
 	// Default keys: (OSX)super+ctrl/shift+pagedown	(Linux/Win)ctrl+shift(+alt)+pagedown
-	"mde.keymap_disable_goto_next_heading": false,
+	"mde.keymap_disable.goto_next_heading": false,
 	// Jump to the previous heading (any level/same or higher level)
 	// Default keys: (OSX)super+ctrl/shift+pageup	(Linux/Win)ctrl+shift(+alt)+pageup
-	"mde.keymap_disable_goto_previous_heading": false
+	"mde.keymap_disable.goto_previous_heading": false
 }

--- a/MultiMarkdown.sublime-settings
+++ b/MultiMarkdown.sublime-settings
@@ -101,29 +101,29 @@
 	// Super key references to a key next to left Alt key. It usually has a Windows logo or "win" or "Command" on it.
 	// Jump between link/image/footnote reference and definition
 	// Default keys: (OSX)super+ctrl+shift+l	(Linux/Win)ctrl+alt+g
-	"mde.keymap_disable_reference_jump": false,
+	"mde.keymap_disable.reference_jump": false,
 	// Add a new link
 	// Default keys: (OSX)super+alt+r	(Linux/Win)ctrl+super+r
-	"mde.keymap_disable_reference_new_reference": false,
+	"mde.keymap_disable.reference_new_reference": false,
 	// Add a new inline link
 	// Default keys: (OSX)super+alt+v	(Linux/Win)ctrl+super+v
-	"mde.keymap_disable_reference_new_inline_link": false,
+	"mde.keymap_disable.reference_new_inline_link": false,
 	// Add a new inline image
 	// Default keys: (OSX/Linux/Win)super+shift+k
-	"mde.keymap_disable_reference_new_inline_image": false,
+	"mde.keymap_disable.reference_new_inline_image": false,
 	// Add a new footnote
 	// Default keys: (OSX/Linux/Win)alt+shift+6
-	"mde.keymap_disable_reference_new_footnote": false,
+	"mde.keymap_disable.reference_new_footnote": false,
 	// Fold current section
 	// Default keys: (OSX/Linux/Win)shift+tab
-	"mde.keymap_disable_fold_section": false,
+	"mde.keymap_disable.fold_section": false,
 	// Open a panel showing all functions related to folding
 	// Default keys: (OSX/Linux/Win)ctrl+shift+tab
-	"mde.keymap_disable_show_fold_all_sections": false,
+	"mde.keymap_disable.show_fold_all_sections": false,
 	// Jump to the next heading (any level/same or higher level)
 	// Default keys: (OSX)super+ctrl/shift+pagedown	(Linux/Win)ctrl+shift(+alt)+pagedown
-	"mde.keymap_disable_goto_next_heading": false,
+	"mde.keymap_disable.goto_next_heading": false,
 	// Jump to the previous heading (any level/same or higher level)
 	// Default keys: (OSX)super+ctrl/shift+pageup	(Linux/Win)ctrl+shift(+alt)+pageup
-	"mde.keymap_disable_goto_previous_heading": false
+	"mde.keymap_disable.goto_previous_heading": false
 }


### PR DESCRIPTION
Fix the 'keymap_disable...' field names, so that they match the names from the keymap files. (Creating User settings based on these names was, obviously, not working.)