### PR TITLE
Allow quotes in lists

### DIFF
--- a/Markdown.sublime-syntax
+++ b/Markdown.sublime-syntax
@@ -209,10 +209,12 @@ contexts:
             - include: block_quote
         - match: |-
             (?x)\G
-            (?= [#]{1,6}\s*+
+            (?= ([ ]{4}|\t)
+            | [#]{1,6}\s*+
             | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             )
           push:
+            - include: block_raw
             - include: heading
             - include: separator
             - match: ^

--- a/Markdown.sublime-syntax
+++ b/Markdown.sublime-syntax
@@ -194,13 +194,14 @@ contexts:
             (?= \s*$
             | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             | [ ]{,3}([*+-])(?=\s)
-            | [ ]{0,3}([0-9]+\.)(?=\s)
+            | [ ]{,3}([0-9]+\.)(?=\s)
             | [ ]{,3}>
             )
           pop: true
         - match: |-
             (?x)\G
-            (?= [ ]{,3}>
+            [ ]*
+            (?= >
             )
           push:
             - match: ^
@@ -208,12 +209,10 @@ contexts:
             - include: block_quote
         - match: |-
             (?x)\G
-            (?= ([ ]{4}|\t)
-            | [#]{1,6}\s*+
+            (?= [#]{1,6}\s*+
             | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
             )
           push:
-            - include: block_raw
             - include: heading
             - include: separator
             - match: ^

--- a/Markdown.sublime-syntax
+++ b/Markdown.sublime-syntax
@@ -75,6 +75,7 @@ contexts:
             1: punctuation.definition.list_item.markdown
           pop: true
         - include: fenced-code-blocks
+        - include: block_quote
         - include: list-paragraph
     - match: '^[ ]{0,3}([0-9]+\.)(?=\s)'
       captures:
@@ -86,6 +87,7 @@ contexts:
             1: punctuation.definition.list_item.markdown
           pop: true
         - include: fenced-code-blocks
+        - include: block_quote
         - include: list-paragraph
     - include: fenced-code-blocks
     - match: '<!---'
@@ -180,7 +182,8 @@ contexts:
     - match: '\G[ ]{,3}(>)[ ]?'
       comment: |
         We terminate the block quote when seeing an empty line, a
-                        separator or a line with leading > characters. The latter is
+                        separator, a numbered or un-numbered list-item
+                        or a line with leading > characters. The latter is
                         to “reset” the quote level for quoted lines.
       captures:
         1: punctuation.definition.blockquote.markdown
@@ -190,6 +193,8 @@ contexts:
             (?x)^
             (?= \s*$
             | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+            | [ ]{,3}([*+-])(?=\s)
+            | [ ]{0,3}([0-9]+\.)(?=\s)
             | [ ]{,3}>
             )
           pop: true
@@ -909,6 +914,7 @@ contexts:
             1: punctuation.definition.list_item.markdown
         - include: scope:text.html.basic
         - include: fenced-code-blocks
+        - include: block_quote
   raw:
     - include: latex-display
     - match: '(`+)((?:[^`]|(?!(?<!`)\1(?!`))`)*+)(\1)'


### PR DESCRIPTION
Enables having quotes in both numbered and un-numbered lists.

How the scopes are assigned currently:
<img width="500" alt="screen shot 2018-03-09 at 14 08 08" src="https://user-images.githubusercontent.com/8899240/37207019-b935f4ac-23a3-11e8-9f77-0ee870c39fd3.png">

How the scopes are assigned after:
<img width="500" alt="screen shot 2018-03-09 at 14 09 00" src="https://user-images.githubusercontent.com/8899240/37207030-beba4798-23a3-11e8-8f3e-d8fab490b5de.png">

I though about removing `block_raw` from inside quotes, but ended up keeping them. To my understanding, raw blocks require a blank line before, which the rule doesn't capture. Instead, I changed how new leading `>` are captured to allow for deeper lists with quotes.

<img width="500" alt="screen shot 2018-03-09 at 15 01 04" src="https://user-images.githubusercontent.com/8899240/37209396-d37ec9c4-23ad-11e8-8a80-ce1d98aef9e1.png">

