### PR TITLE
3.0.2

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1168,13 +1168,13 @@
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_make_page_reference", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link.wiki | markup.underline.link)", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link | markup.underline.link)", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.make_page_reference", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1168,13 +1168,13 @@
 	},
 	{ "keys": ["super+shift+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},
 	{ "keys": ["super+shift+d"], "command": "mde_make_page_reference", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link.wiki | markup.underline.link)", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link | markup.underline.link)", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.make_page_reference", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1168,13 +1168,13 @@
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_make_page_reference", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link.wiki | markup.underline.link)", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link | markup.underline.link)", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.make_page_reference", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -188,7 +188,7 @@
 		"command": "mde_unfold_all_sections"
 	},
 	{
-		"caption": "MarkdownEditing: Auto Fold Link URLs",
+		"caption": "MarkdownEditing: Toggle Automatic Link URL Folding",
 		"command": "mde_fold_links"
 	},
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -159,6 +159,26 @@ Folding is bound to following keys by default:
 | <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold/Unfold current section.
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold all sections under headings of a certain level.
 
+## Automatic Link Url Folding
+
+MarkdownEditing folds image/link/reference urls automatically if the caret is not within the url brackets, in order to improve a document's readability.
+
+This feature can be temporarily enabled or disabled for the active view via Command Palette
+
+*   **MarkdownEditing: Toggle Automatic Link URL Folding**
+
+To globally disable it, add the following setting to _Perferences.sublime-settings_
+
+```jsonc
+    "mde.auto_fold_link.enabled": false,
+```
+
+The folding selector can be tweaked in order to add or remove certain kinds of urls from being automatically folded.
+
+```jsonc
+    "mde.auto_fold_link.selector": "( meta.image | meta.link ) & ( markup.underline | constant.other) - meta.link.reference.footnote - meta.link.reference.def - meta.link.inet",
+```
+
 ## Navigation
 
 MarkdownEditing provides various ways to navigate between sections.

--- a/messages.json
+++ b/messages.json
@@ -27,5 +27,6 @@
 	"2.2.4": "messages/2.2.4.md",
 	"2.2.10": "messages/2.2.10.md",
 	"3.0.0": "messages/3.0.0.md",
-	"3.0.1": "messages/3.0.1.md"
+	"3.0.1": "messages/3.0.1.md",
+	"3.0.1": "messages/3.0.2.md"
 }

--- a/messages/3.0.2.md
+++ b/messages/3.0.2.md
@@ -1,0 +1,14 @@
+# MarkdownEditing 3.0.2 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* Add missing Automatic Link Folding usage description
+* Improve bootstrapper (fixes #623)
+* Correct heading style detection (fixes #625)
+* Correct wiki link selectors (fixes #626)
+* Strip image/ref urls from indexed symbols
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/plugins/headings/style.py
+++ b/plugins/headings/style.py
@@ -76,19 +76,16 @@ class MdeMatchHeadingHashesDetector(MdeViewEventListener):
             view.settings().set("mde.auto_match_heading_hashes", False)
             return
 
-        num_leading = 0
-        num_trailing = 0
-
-        for h1, h2 in zip(
-            view.find_by_selector("markup.heading")[:10],
-            view.find_by_selector("markup.heading - punctuation.definition.heading")[:10],
-        ):
-            num_leading += 1
-            if h1.end() > h2.end():
-                num_trailing += 1
-
+        num_leading = len(
+            view.find_by_selector("markup.heading punctuation.definition.heading.begin")
+        )
         if num_leading:
+            num_trailing = len(
+                view.find_by_selector("markup.heading punctuation.definition.heading.end")
+            )
             view.settings().set("mde.match_heading_hashes", num_trailing / num_leading > 0.5)
+        else:
+            view.settings().erase("mde.match_heading_hashes")
 
         if view.settings().get("mde.auto_match_heading_hashes", False):
             view.run_command("mde_match_heading_hashes")

--- a/plugins/wiki_page.py
+++ b/plugins/wiki_page.py
@@ -28,7 +28,7 @@ class MdeMakePageReferenceCommand(MdeTextCommand):
     def is_visible(self):
         """Return True if  is on a wiki page reference."""
         for sel in self.view.sel():
-            if not self.view.match_selector(sel.end(), "meta.link.wiki.markdown"):
+            if self.view.match_selector(sel.begin(), "meta.link.reference.wiki"):
                 return False
         return True
 
@@ -66,9 +66,9 @@ class MdeOpenPageCommand(MdeTextCommand):
     def is_visible(self):
         """Return True if caret is on a wiki page reference."""
         for sel in self.view.sel():
-            if not self.view.match_selector(sel.end(), "meta.link.wiki.markdown"):
-                return False
-        return True
+            if self.view.match_selector(sel.begin(), "meta.link.reference.wiki"):
+                return True
+        return False
 
     def run(self, edit):
         wiki_page = WikiPage(self.view)

--- a/syntaxes/Symbol List - Heading.tmPreferences
+++ b/syntaxes/Symbol List - Heading.tmPreferences
@@ -8,7 +8,7 @@
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
-		<string>
+		<string><![CDATA[
 			s/\!?\[([^]]+)\]\([^)]*\)/$1/g; 	# strip image or link urls
 			s/\[([^]]+)\]\[[^]]*\]/$1/g; 		# strip reference urls
 			s/\[\^[^]]+\]//g; 					# strip footnotes
@@ -20,14 +20,17 @@
 			s/^#{3}/    /g;						# indent atx heading
 			s/^#{2}/  /g;						# indent atx heading
 			s/^#{1}//g;							# indent atx heading
-		</string>
+		]]></string>
 		<key>showInIndexedSymbolList</key>
 		<integer>1</integer>
 		<key>symbolIndexTransformation</key>
-		<string>
+		<string><![CDATA[
+			s/\!?\[([^]]+)\]\([^)]*\)/$1/g; 	# strip image or link urls
+			s/\[([^]]+)\]\[[^]]*\]/$1/g; 		# strip reference urls
+			s/\[\^[^]]+\]//g; 					# strip footnotes
 			s/^\s*//g;							# strip leading whitespace
 			s/\s*#+\s*\z//g;					# strip trailing hashes
-		</string>
+		]]></string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
# MarkdownEditing 3.0.2 Changelog

## Bug Fixes

* Add missing Automatic Link Folding usage description
* Improve bootstrapper (fixes #623)
* Correct heading style detection (fixes #625)
* Correct wiki link selectors (fixes #626)
* Strip image/ref urls from indexed symbols