### PR TITLE
add partial xonsh support in fenced code blocks

### DIFF
--- a/messages/3.0.3.md
+++ b/messages/3.0.3.md
@@ -8,6 +8,7 @@ feedback you can use [GitHub issues][issues].
 ## New Features
 
 * Support fish fenced code (if supported syntax is installed)
+* Partially support xonsh fenced code (use Python syntax due to a lack of xonsh syntax support in ST)
 
 ## Changes
 

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -1241,6 +1241,7 @@ contexts:
     - include: fenced-stata
     - include: fenced-swift
     - include: fenced-toml
+    - include: fenced-xonsh
 
   fenced-clojure:
     - match: |-
@@ -2282,6 +2283,23 @@ contexts:
       escape: '{{code_fence_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.toml.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-xonsh:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:xonsh|xsh))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.xonsh.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.python
+      embed_scope: markup.raw.code-fence.xonsh.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.xonsh.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
 
   code-span:


### PR DESCRIPTION
This is using Python syntax since xonsh is a Python-based shell, so this should work in a lot of cases
However, whenever the real xonsh syntax is added to ST, the scope should be updated from `source.python` to `source.xonsh` (or to whatever that syntax will be using)