### PR TITLE
3.0.3 (ST4107+)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -349,84 +349,100 @@
 	// Headings
 	//
 
-	{ "keys": ["ctrl+alt+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+."], "command": "mde_change_headings_level", "args": {"by": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+,"], "command": "mde_change_headings_level", "args": {"by": -1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	// If nothing is selected, pressing hash in front of heading label increases level by one
@@ -1168,7 +1184,7 @@
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.description.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -184,7 +184,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "**$0**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -194,7 +194,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "__$0__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -205,7 +205,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -213,7 +213,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -221,7 +221,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -229,7 +229,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -238,7 +238,7 @@
 	// Transform selection to bold
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "**${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -247,7 +247,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "__${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -257,7 +257,12 @@
 	// Unbold bold text
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - markup.italic - punctuation", "match_all": true }
+		]
+	},
+	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Bold Italics.sublime-macro"}, "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -268,7 +273,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "*$0*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -278,7 +283,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -289,7 +294,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -297,7 +302,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -305,7 +310,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -313,7 +318,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -322,7 +327,7 @@
 	// Transform selection to italics
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "*${SELECTION/(^[\\*_]*|[\\*_]*$)//g}*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -332,7 +337,7 @@
 	// Remove italics style from text
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "_${SELECTION/(^[\\*_]*|[\\*_]*$)//g}_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -341,7 +346,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unitalicize.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -662,21 +667,10 @@
 	//
 
 	// Create new GFM Task
-	{ "keys": ["alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ] $0"}, "context":
+	{ "keys": ["alt+t"], "command": "mde_insert_task_list_item", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": false },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }
-		]
-	},
-	{ "keys": ["alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ]\t$0"}, "context":
-		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -349,84 +349,100 @@
 	// Headings
 	//
 
-	{ "keys": ["super+ctrl+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["super+ctrl+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+."], "command": "mde_change_headings_level", "args": {"by": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+,"], "command": "mde_change_headings_level", "args": {"by": -1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	// If nothing is selected, pressing hash in front of heading label increases level by one
@@ -1168,7 +1184,7 @@
 	},
 	{ "keys": ["super+shift+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.description.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -184,7 +184,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["super+alt+b"], "command": "insert_snippet", "args": {"contents": "**$0**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -194,7 +194,7 @@
 	},
 	{ "keys": ["super+alt+b"], "command": "insert_snippet", "args": {"contents": "__$0__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -205,7 +205,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -213,7 +213,7 @@
 	},
 	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -221,7 +221,7 @@
 	},
 	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -229,7 +229,7 @@
 	},
 	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -238,7 +238,7 @@
 	// Transform selection to bold
 	{ "keys": ["super+alt+b"], "command": "insert_snippet", "args": {"contents": "**${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -247,7 +247,7 @@
 	},
 	{ "keys": ["super+alt+b"], "command": "insert_snippet", "args": {"contents": "__${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -257,7 +257,12 @@
 	// Unbold bold text
 	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - markup.italic - punctuation", "match_all": true }
+		]
+	},
+	{ "keys": ["super+alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Bold Italics.sublime-macro"}, "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -268,7 +273,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["super+alt+i"], "command": "insert_snippet", "args": {"contents": "*$0*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -278,7 +283,7 @@
 	},
 	{ "keys": ["super+alt+i"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -289,7 +294,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -297,7 +302,7 @@
 	},
 	{ "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -305,7 +310,7 @@
 	},
 	{ "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -313,7 +318,7 @@
 	},
 	{ "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -322,7 +327,7 @@
 	// Transform selection to italics
 	{ "keys": ["super+alt+i"], "command": "insert_snippet", "args": {"contents": "*${SELECTION/(^[\\*_]*|[\\*_]*$)//g}*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -332,7 +337,7 @@
 	// Remove italics style from text
 	{ "keys": ["super+alt+i"], "command": "insert_snippet", "args": {"contents": "_${SELECTION/(^[\\*_]*|[\\*_]*$)//g}_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -341,7 +346,7 @@
 	},
 	{ "keys": ["super+alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unitalicize.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -662,21 +667,10 @@
 	//
 
 	// Create new GFM Task
-	{ "keys": ["super+alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ] $0"}, "context":
+	{ "keys": ["super+alt+t"], "command": "mde_insert_task_list_item", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": false },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }
-		]
-	},
-	{ "keys": ["super+alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ]\t$0"}, "context":
-		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -349,84 +349,100 @@
 	// Headings
 	//
 
-	{ "keys": ["ctrl+alt+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+keypad0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
+	{ "keys": ["alt+k", "alt+0"], "command": "mde_change_headings_level", "args": {"to": 0}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+keypad1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
+	{ "keys": ["alt+k", "alt+1"], "command": "mde_change_headings_level", "args": {"to": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+keypad2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
+	{ "keys": ["alt+k", "alt+2"], "command": "mde_change_headings_level", "args": {"to": 2}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+keypad3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
+	{ "keys": ["alt+k", "alt+3"], "command": "mde_change_headings_level", "args": {"to": 3}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+keypad4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
+	{ "keys": ["alt+k", "alt+4"], "command": "mde_change_headings_level", "args": {"to": 4}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+keypad5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
+	{ "keys": ["alt+k", "alt+5"], "command": "mde_change_headings_level", "args": {"to": 5}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+keypad6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
-	{ "keys": ["ctrl+alt+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
+	{ "keys": ["alt+k", "alt+6"], "command": "mde_change_headings_level", "args": {"to": 6}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+."], "command": "mde_change_headings_level", "args": {"by": 1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+alt+,"], "command": "mde_change_headings_level", "args": {"by": -1}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true },
+			{ "key": "mde.keymap_disable.set_heading_level", "operand": false }
 		]
 	},
 	// If nothing is selected, pressing hash in front of heading label increases level by one
@@ -1168,7 +1184,7 @@
 	},
 	{ "keys": ["ctrl+alt+d"], "command": "mde_open_page", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.description.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -184,7 +184,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "**$0**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -194,7 +194,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "__$0__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -205,7 +205,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -213,7 +213,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -221,7 +221,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -229,7 +229,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Bold (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -238,7 +238,7 @@
 	// Transform selection to bold
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "**${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}**"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -247,7 +247,7 @@
 	},
 	{ "keys": ["alt+b"], "command": "insert_snippet", "args": {"contents": "__${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}__"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.bold", "match_all": true },
 			{ "key": "setting.mde.bold_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|__$", "match_all": true },
@@ -257,7 +257,12 @@
 	// Unbold bold text
 	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold - markup.italic - punctuation", "match_all": true }
+		]
+	},
+	{ "keys": ["alt+b"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unbold Bold Italics.sublime-macro"}, "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.bold markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -268,7 +273,7 @@
 	// auto-pair if not within a word
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "*$0*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -278,7 +283,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "_$0_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "eol_selector", "operator": "not_equal", "operand": "string.quoted.single", "match_all": true },
@@ -289,7 +294,7 @@
 	// Transform a word to bold if caret is at the beginning, in the middle of or at the end of a word
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -297,7 +302,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Asterisk).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -305,7 +310,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_contains", "operand": "\\w$", "match_all": true }
@@ -313,7 +318,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Italic (Underscore).sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "following_text", "operator": "regex_contains", "operand": "^\\w", "match_all": true }
@@ -322,7 +327,7 @@
 	// Transform selection to italics
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "*${SELECTION/(^[\\*_]*|[\\*_]*$)//g}*"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -332,7 +337,7 @@
 	// Remove italics style from text
 	{ "keys": ["alt+i"], "command": "insert_snippet", "args": {"contents": "_${SELECTION/(^[\\*_]*|[\\*_]*$)//g}_"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic - markup.bold_italic", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - markup.italic", "match_all": true },
 			{ "key": "setting.mde.italic_marker_asterisk", "operator": "equal", "operand": false },
 			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\*$|_$", "match_all": true },
@@ -341,7 +346,7 @@
 	},
 	{ "keys": ["alt+i"], "command": "run_macro_file", "args": {"file": "Packages/MarkdownEditing/macros/Transform Word - Unitalicize.sublime-macro"}, "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation, text.html.markdown markup.bold_italic - punctuation", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown markup.italic - punctuation", "match_all": true }
 		]
 	},
 
@@ -662,21 +667,10 @@
 	//
 
 	// Create new GFM Task
-	{ "keys": ["alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ] $0"}, "context":
+	{ "keys": ["alt+t"], "command": "mde_insert_task_list_item", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": false },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
-			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
-			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }
-		]
-	},
-	{ "keys": ["alt+t"], "command": "insert_snippet", "args": {"contents": "* [ ]\t$0"}, "context":
-		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.kbd - meta.table", "match_all": true },
-			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
-			{ "key": "setting.mde.list_align_text", "operator": "equal", "operand": true },
 			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "preceding_text", "operator": "regex_match", "operand": "^[\\s>]*$", "match_all": true },
 			{ "key": "following_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true }

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -125,6 +125,10 @@
 
 	// You can opt out some keybinds by setting the corresponding value from 'false' to 'true' (without single-quotes).
 	// Super key references to a key next to left Alt key. It usually has a Windows logo or "win" or "Command" on it.
+
+	// Set Heading Level
+	// Default keys: (OSX/Linux/Win): alt+k, alt+0..9
+	"mde.keymap_disable.set_heading_level": false,
 	// Jump between link/image/footnote reference and definition
 	// Default keys: (OSX)super+ctrl+shift+l    (Linux/Win)ctrl+alt+g
 	"mde.keymap_disable.reference_jump": false,

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -109,7 +109,7 @@
 	"mde.auto_fold_link.enabled": true,
 	// MarkdownEditing (Folding):
 	// Selector for urls to automatically fold
-	"mde.auto_fold_link.selector": "( meta.image | meta.link ) & ( markup.underline | constant.other) - meta.link.reference.footnote - meta.link.reference.def - meta.link.inet",
+	"mde.auto_fold_link.selector": "( meta.image.inline.metadata.markdown | meta.image.reference.metadata.markdown | meta.link.inline.metadata.markdown | meta.link.reference.metadata.markdown ) - punctuation.definition.metadata",
 
 	// MarkdownEditing (Wiki):
 	// wiki file extensions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,10 +107,12 @@ or use one of the following bindings:
 
 | Linux/Windows | MacOS | Description
 |---------------|-------|-------------
-| <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>0</kbd> | <kbd>⌘</kbd> + <kbd>^</kbd> + <kbd>0</kbd> | convert headings into normal text
-| <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>1..6</kbd> | <kbd>⌘</kbd> + <kbd>^</kbd> + <kbd>1..6</kbd> | set headings level to 1..6
+| <kbd>alt</kbd> + <kbd>k</kbd>, <kbd>alt</kbd> + <kbd>0</kbd> | <kbd>^</kbd> + <kbd>k</kbd>, <kbd>^</kbd> + <kbd>0</kbd> | convert headings into normal text
+| <kbd>alt</kbd> + <kbd>k</kbd>, <kbd>alt</kbd> + <kbd>1..6</kbd> | <kbd>^</kbd> + <kbd>k</kbd>, <kbd>^</kbd> + <kbd>1..6</kbd> | set headings level to 1..6
 | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>,</kbd> | <kbd>⌘</kbd> + <kbd>^</kbd> + <kbd>,</kbd> | reduce headings level by one
 | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>.</kbd> | <kbd>⌘</kbd> + <kbd>^</kbd> + <kbd>.</kbd> | increase headings level by one
+
+Key bindings can be disabled via `"mde.keymap_disable.set_heading_level": true`.
 
 Adding or removing `#` at the beginning of lines also modifies heading levels implicitly while maintaining open or closed heading styles.
 

--- a/macros/Transform Word - Bold (Asterisk).sublime-macro
+++ b/macros/Transform Word - Bold (Asterisk).sublime-macro
@@ -1,5 +1,4 @@
 [
 	{"command": "expand_selection", "args": {"to": "word"}},
-	{"command": "insert_snippet", "args": {"contents": "**${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}**"}},
-	{"command": "move", "args": {"by": "words", "forward": false}}
+	{"command": "insert_snippet", "args": {"contents": "**${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}**"}}
 ]

--- a/macros/Transform Word - Bold (Underscore).sublime-macro
+++ b/macros/Transform Word - Bold (Underscore).sublime-macro
@@ -1,5 +1,4 @@
 [
 	{"command": "expand_selection", "args": {"to": "word"}},
-	{"command": "insert_snippet", "args": {"contents": "__${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}__"}},
-	{"command": "move", "args": {"by": "words", "forward": false}}
+	{"command": "insert_snippet", "args": {"contents": "__${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}__"}}
 ]

--- a/macros/Transform Word - Italic (Asterisk).sublime-macro
+++ b/macros/Transform Word - Italic (Asterisk).sublime-macro
@@ -1,5 +1,4 @@
 [
 	{"command": "expand_selection", "args": {"to": "word"}},
-	{"command": "insert_snippet", "args": {"contents": "*${SELECTION/^(\\*{2}|_{2})?([*_])(.+)([*_])(\\*{2}|_{2})?$/$1$3$1/g}*"}},
-	{"command": "move", "args": {"by": "words", "forward": false}}
+	{"command": "insert_snippet", "args": {"contents": "*${SELECTION/^(\\*{2}|_{2})?([*_])(.+)([*_])(\\*{2}|_{2})?$/$1$3$1/g}*"}}
 ]

--- a/macros/Transform Word - Italic (Underscore).sublime-macro
+++ b/macros/Transform Word - Italic (Underscore).sublime-macro
@@ -1,5 +1,4 @@
 [
 	{"command": "expand_selection", "args": {"to": "word"}},
-	{"command": "insert_snippet", "args": {"contents": "_${SELECTION/^(\\*{2}|_{2})?([*_])(.+)([*_])(\\*{2}|_{2})?$/$1$3$1/g}_"}},
-	{"command": "move", "args": {"by": "words", "forward": false}}
+	{"command": "insert_snippet", "args": {"contents": "_${SELECTION/^(\\*{2}|_{2})?([*_])(.+)([*_])(\\*{2}|_{2})?$/$1$3$1/g}_"}}
 ]

--- a/macros/Transform Word - Unbold Bold Italics.sublime-macro
+++ b/macros/Transform Word - Unbold Bold Italics.sublime-macro
@@ -1,4 +1,5 @@
 [
 	{"command": "expand_selection", "args": {"to": "scope"}},
+	{"command": "expand_selection", "args": {"to": "scope"}},
 	{"command": "insert_snippet", "args": {"contents": "${SELECTION/^\\*\\*|^__|\\*\\*$|__$//g}"}}
 ]

--- a/macros/Transform Word - Unitalicize.sublime-macro
+++ b/macros/Transform Word - Unitalicize.sublime-macro
@@ -1,5 +1,4 @@
 [
 	{"command": "expand_selection", "args": {"to": "scope"}},
-	{"command": "insert_snippet", "args": {"contents": "${SELECTION/^(?:(\\*{2}|_{2})?([*_])|([*_])(\\*{2}|_{2})?)(\\S(?:.*\\S))(?:(\\2)(\\1)|(\\4)?(\\3))$/$1$4$5$7$8/g}"}},
-	{"command": "move", "args": {"by": "words", "forward": false}}
+	{"command": "insert_snippet", "args": {"contents": "${SELECTION/^(?:(\\*{2}|_{2})?([*_])|([*_])(\\*{2}|_{2})?)(\\S(?:.*\\S))(?:(\\2)(\\1)|(\\4)?(\\3))$/$1$4$5$7$8/g}"}}
 ]

--- a/messages/3.0.3.md
+++ b/messages/3.0.3.md
@@ -17,9 +17,11 @@ feedback you can use [GitHub issues][issues].
 * Remove obsolete keymap selectors (required due to recent syntax changes)
 * Add a macro to unbold bold italc text (required due to recent syntax changes)
 * Only strip whitespace separated trailing hashes of headings from symbol lists
+* Scope inet/email autolinks according to CommonMark 0.30.0
 
 ## New Features
 
+* Scope path separators and escapes in urls
 * Support fish fenced code (if supported syntax is installed)
 * Partially support xonsh fenced code (use Python syntax due to a lack of xonsh syntax support in ST)
 

--- a/messages/3.0.3.md
+++ b/messages/3.0.3.md
@@ -10,7 +10,7 @@ feedback you can use [GitHub issues][issues].
 * Restore Goto Link Reference/Definition functionality (fixes #632)
 * Refactor image/link/reference syntax definitions (fixes #633)
 * Don't hide inline code-span punctuation im Mariana/Monokai (fixes #633)
-* Resolve key binding conflicts (#634)
+* Resolve key binding conflicts (fixes #634)
 * Don't move caret to beginning of word after changing formatting (fixes #636)
 * Adding task via `alt+t` respects `mde.list_indent_bullets` setting (fixes #636)
 * Bootstrapper reassigns Markdown syntaxes from any location

--- a/messages/3.0.3.md
+++ b/messages/3.0.3.md
@@ -1,0 +1,28 @@
+# MarkdownEditing 3.0.3 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* Tweak auto link folding selector (fixes #624)
+* Use correct selector for open page key binding (fixes #629)
+* Restore Goto Link Reference/Definition functionality (fixes #632)
+* Refactor image/link/reference syntax definitions (fixes #633)
+* Don't hide inline code-span punctuation im Mariana/Monokai (fixes #633)
+* Resolve key binding conflicts (#634)
+* Don't move caret to beginning of word after changing formatting (fixes #636)
+* Adding task via `alt+t` respects `mde.list_indent_bullets` setting (fixes #636)
+* Bootstrapper reassigns Markdown syntaxes from any location
+* Remove obsolete keymap selectors (required due to recent syntax changes)
+* Add a macro to unbold bold italc text (required due to recent syntax changes)
+* Only strip whitespace separated trailing hashes of headings from symbol lists
+
+## New Features
+
+* Support fish fenced code (if supported syntax is installed)
+* Partially support xonsh fenced code (use Python syntax due to a lack of xonsh syntax support in ST)
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.0.3.md
+++ b/messages/3.0.3.md
@@ -10,10 +10,12 @@ feedback you can use [GitHub issues][issues].
 * Restore Goto Link Reference/Definition functionality (fixes #632)
 * Refactor image/link/reference syntax definitions (fixes #633)
 * Don't hide inline code-span punctuation im Mariana/Monokai (fixes #633)
-* Resolve key binding conflicts (fixes #634)
+* Resolve `AltGr` key binding conflicts (fixes #634)
 * Don't move caret to beginning of word after changing formatting (fixes #636)
 * Adding task via `alt+t` respects `mde.list_indent_bullets` setting (fixes #636)
 * Bootstrapper reassigns Markdown syntaxes from any location
+* Bootstrapper removes invalid syntax specific color scheme settings
+* Color Scheme Selector correctly detects 'auto' color scheme
 * Remove obsolete keymap selectors (required due to recent syntax changes)
 * Add a macro to unbold bold italc text (required due to recent syntax changes)
 * Only strip whitespace separated trailing hashes of headings from symbol lists

--- a/plugin.py
+++ b/plugin.py
@@ -63,6 +63,7 @@ else:
         MdeUnindentListItemCommand,
         MdeNumberListCommand,
         MdeSwitchListBulletTypeCommand,
+        MdeInsertTaskListItemCommand,
         MdeToggleTaskListItemCommand,
         MdeJoinLines,
     )

--- a/plugins/bootstrap.py
+++ b/plugins/bootstrap.py
@@ -4,7 +4,7 @@ import sys
 
 import sublime
 
-from .color_schemes import clear_color_schemes, select_color_scheme
+from .color_schemes import clear_color_schemes, clear_invalid_color_schemes, select_color_scheme
 
 BOOTSTRAP_VERSION = "3.0.3"
 
@@ -25,14 +25,6 @@ def save_ingored_packages(ignored_packages):
 def disable_native_markdown_package():
     ignored_packages = get_ingored_packages()
     if "Markdown" not in ignored_packages:
-        reassign_syntax(
-            "Markdown.sublime-syntax",
-            "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax",
-        )
-        reassign_syntax(
-            "MultiMarkdown.sublime-syntax",
-            "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax",
-        )
         ignored_packages.append("Markdown")
         save_ingored_packages(ignored_packages)
 
@@ -64,6 +56,35 @@ def reassign_syntax(current_syntax, new_syntax):
                 view.assign_syntax(new_syntax)
 
 
+def bootstrap_syntax_assignments():
+    """
+    Reassign syntax to all open Markdown, MultiMarkdown or Plain Text files.
+
+    Repair syntax assignments of open views after install or upgrade, in case
+    old ones no longer exist.
+    """
+    markdown = "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax"
+    multimarkdown = "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
+
+    for window in sublime.windows():
+        for view in window.views():
+            syntax = view.settings().get("syntax")
+            if syntax:
+                syntax = os.path.basename(syntax)
+                if syntax in ("Markdown.tmLanguage", "Markdown.sublime-syntax"):
+                    view.assign_syntax(markdown)
+                    continue
+                if syntax in ("MultiMarkdown.tmLanguage", "MultiMarkdown.sublime-syntax"):
+                    view.assign_syntax(multimarkdown)
+                    continue
+
+            file_name = view.file_name()
+            if file_name:
+                _, ext = os.path.splitext(file_name)
+                if ext in (".md", ".mdown", ".markdown"):
+                    view.assign_syntax(markdown)
+
+
 def on_after_install():
     cache_path = os.path.join(sublime.cache_path(), "MarkdownEditing")
     bootstrapped = os.path.join(cache_path, "bootstrapped")
@@ -79,19 +100,16 @@ def on_after_install():
     shutil.rmtree(cache_path, ignore_errors=True)
     os.makedirs(cache_path, exist_ok=True)
 
-    # remove wrong bootstrapped cookie file created by 3.0.1
-    try:
-        os.remove(os.path.join(sublime.packages_path(), "User", "MarkdownEditing.sublime-syntax"))
-    except FileNotFoundError:
-        pass
+    def async_worker():
+        bootstrap_syntax_assignments()
+        disable_native_markdown_package()
+        clear_invalid_color_schemes()
+        # Update bootstrap cookie.
+        open(bootstrapped, "w").write(BOOTSTRAP_VERSION)
 
-    # Native package causes some conflicts.
-    disable_native_markdown_package()
-    # Prompts to select a color scheme.
-    sublime.set_timeout_async(select_color_scheme, 500)
+        select_color_scheme()
 
-    # Update bootstrap cookie.
-    open(bootstrapped, "w").write(BOOTSTRAP_VERSION)
+    sublime.set_timeout_async(async_worker, 200)
 
 
 def on_before_uninstall():

--- a/plugins/bootstrap.py
+++ b/plugins/bootstrap.py
@@ -6,7 +6,7 @@ import sublime
 
 from .color_schemes import clear_color_schemes, select_color_scheme
 
-BOOTSTRAP_VERSION = "3.0.2"
+BOOTSTRAP_VERSION = "3.0.3"
 
 package_name = "MarkdownEditing"
 
@@ -26,11 +26,11 @@ def disable_native_markdown_package():
     ignored_packages = get_ingored_packages()
     if "Markdown" not in ignored_packages:
         reassign_syntax(
-            "Packages/Markdown/Markdown.sublime-syntax",
+            "Markdown.sublime-syntax",
             "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax",
         )
         reassign_syntax(
-            "Packages/Markdown/MultiMarkdown.sublime-syntax",
+            "MultiMarkdown.sublime-syntax",
             "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax",
         )
         ignored_packages.append("Markdown")
@@ -45,11 +45,11 @@ def enable_native_markdown_package():
 
         def reassign():
             reassign_syntax(
-                "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax",
+                "Markdown.sublime-syntax",
                 "Packages/Markdown/Markdown.sublime-syntax",
             )
             reassign_syntax(
-                "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax",
+                "MultiMarkdown.sublime-syntax",
                 "Packages/Markdown/MultiMarkdown.sublime-syntax",
             )
 
@@ -60,7 +60,7 @@ def reassign_syntax(current_syntax, new_syntax):
     for window in sublime.windows():
         for view in window.views():
             syntax = view.settings().get("syntax")
-            if syntax and syntax == current_syntax:
+            if syntax and syntax.endswith(current_syntax) and syntax != new_syntax:
                 view.assign_syntax(new_syntax)
 
 

--- a/plugins/color_schemes.py
+++ b/plugins/color_schemes.py
@@ -42,8 +42,11 @@ def select_color_scheme(view=None):
     schemes_display = []
     selected_index = 0
     for i, s in enumerate(schemes):
-        m = re.search(r"[^/]+(?=\.(sublime-color-scheme|tmTheme)$)", s)
-        theme_display = m.group(0)
+        if s == "auto":
+            theme_display = "Auto"
+        else:
+            m = re.search(r"[^/]+(?=\.(sublime-color-scheme|tmTheme)$)", s)
+            theme_display = m.group(0)
         if s == global_scheme:
             theme_display += " (Global)"
             if not md_scheme:
@@ -95,3 +98,21 @@ def clear_color_scheme(filename):
     settings = sublime.load_settings(filename)
     settings.erase("color_scheme")
     sublime.save_settings(filename)
+
+
+def clear_invalid_color_schemes():
+    clear_invalid_color_scheme("Markdown.sublime-settings")
+    clear_invalid_color_scheme("Markdown GFM.sublime-settings")
+    clear_invalid_color_scheme("MultiMarkdown.sublime-settings")
+
+
+def clear_invalid_color_scheme(filename):
+    settings = sublime.load_settings(filename)
+    color_scheme = settings.get("color_scheme")
+    if not color_scheme:
+        return
+    try:
+        sublime.load_resource(color_scheme)
+    except FileNotFoundError:
+        settings.erase("color_scheme")
+        sublime.save_settings(filename)

--- a/plugins/lists.py
+++ b/plugins/lists.py
@@ -175,6 +175,27 @@ class MdeNumberListCommand(MdeTextCommand):
             view.insert(edit, sel.begin(), to_insert)
 
 
+class MdeInsertTaskListItemCommand(MdeTextCommand):
+    """
+    The `mde_insert_task_list_item` command inserts a new GFM task.
+
+    It respects the primary bullet set via `"mde.list_indent_bullets"` setting.
+    """
+
+    def run(self, edit):
+        align_text = self.view.settings().get("mde.list_align_text", True)
+        bullets = self.view.settings().get("mde.list_indent_bullets", ["*", "-", "+"])
+
+        to_insert = "{} [ ]".format(bullets[0])
+        if align_text:
+            to_insert += "\t"
+        else:
+            to_insert += " "
+
+        for sel in self.view.sel():
+            self.view.insert(edit, sel.begin(), to_insert)
+
+
 class MdeToggleTaskListItemCommand(MdeTextCommand):
     """
     The `mde_toggle_task_list_item` command toggles the check mark of task list items.

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -22,15 +22,15 @@ import operator
 from .view import MdeTextCommand
 from .view import MdeViewEventListener
 
-refname_scope_name = "constant.other.reference.link.markdown"
+refname_scope_name = "entity.name.reference.link.markdown"
 definition_scope_name = "meta.link.reference.def.markdown"
 footnote_scope_name = "meta.link.reference.footnote.markdown"
 marker_scope_name = "meta.link.reference.markdown"
 marker_literal_scope_name = "meta.link.reference.literal.markdown"
 marker_image_scope_name = "meta.image.reference.markdown"
 ref_link_scope_name = "markup.underline.link.markdown"
-marker_begin_scope_name = "punctuation.definition.string.begin.markdown"
-marker_text_end_scope_name = "punctuation.definition.string.end.markdown"
+marker_begin_scope_name = "punctuation.definition.link.begin.markdown"
+marker_text_end_scope_name = "punctuation.definition.link.end.markdown"
 marker_text_scope_name = "string.other.link.title.markdown"
 refname_start_scope_name = "punctuation.definition.constant.begin.markdown"
 marker_end_scope_name = "punctuation.definition.constant.end.markdown"

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -24,16 +24,16 @@ from .view import MdeViewEventListener
 
 refname_scope_name = "entity.name.reference.link.markdown"
 definition_scope_name = "meta.link.reference.def.markdown"
-footnote_scope_name = "meta.link.reference.footnote.markdown"
-marker_scope_name = "meta.link.reference.markdown"
-marker_literal_scope_name = "meta.link.reference.literal.markdown"
-marker_image_scope_name = "meta.image.reference.markdown"
+footnote_scope_name = "meta.link.reference.footnote.markdown-extra"
+marker_scope_name = "meta.link.reference.description.markdown"
+marker_literal_scope_name = "meta.link.reference.literal.description.markdown"
+marker_image_scope_name = "meta.image.reference.description.markdown"
 ref_link_scope_name = "markup.underline.link.markdown"
 marker_begin_scope_name = "punctuation.definition.link.begin.markdown"
 marker_text_end_scope_name = "punctuation.definition.link.end.markdown"
 marker_text_scope_name = "string.other.link.title.markdown"
-refname_start_scope_name = "punctuation.definition.constant.begin.markdown"
-marker_end_scope_name = "punctuation.definition.constant.end.markdown"
+refname_start_scope_name = "punctuation.definition.metadata.begin.markdown"
+marker_end_scope_name = "punctuation.definition.metadata.end.markdown"
 
 
 def hasScope(scope_name, to_find):

--- a/plugins/wiki_page.py
+++ b/plugins/wiki_page.py
@@ -236,8 +236,9 @@ class WikiPage:
         link_text = PAGE_REF_FORMAT % page_name
 
         try:
-            if link_text in open(filename).read():
-                return True
+            return bool(link_text in open(filename).read())
+        except UnicodeDecodeError:
+            return bool(link_text in open(filename, encoding="utf-8").read())
         except OSError:
             pass
 

--- a/schemes/Mariana.sublime-color-scheme
+++ b/schemes/Mariana.sublime-color-scheme
@@ -94,12 +94,6 @@
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Inline Code Block Punctuation",
-			"scope": "text.html.markdown markup.raw.inline punctuation.definition.raw",
-			"foreground": "var(raw_bg)",
-			"background": "var(raw_bg)"
-		},
-		{
 			"name": "Raw Code Block",
 			"scope": "text.html.markdown markup.raw, text.html.markdown meta.code-fence",
 			"foreground": "var(raw_fg)",

--- a/schemes/Monokai.sublime-color-scheme
+++ b/schemes/Monokai.sublime-color-scheme
@@ -94,12 +94,6 @@
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Inline Code Block Punctuation",
-			"scope": "text.html.markdown markup.raw.inline punctuation.definition.raw",
-			"foreground": "var(raw_bg)",
-			"background": "var(raw_bg)"
-		},
-		{
 			"name": "Raw Code Block",
 			"scope": "text.html.markdown markup.raw, text.html.markdown meta.code-fence",
 			"foreground": "var(raw_fg)",

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -740,31 +740,22 @@ contexts:
     - include: inline-bold-italic
 
   image-inline:
-    - match: |-
-        (?x:
-            (\!\[)                             # Images start with ![
-            (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-                  \]                           # Closing square bracket
-                  [ ]?                         # Space not allowed, but we check for it anyway to mark it as invalid
-                  \(                           # Open paren
-            )
-         )
-      captures:
-        1: meta.image.inline.markdown punctuation.definition.image.begin.markdown
+    - match: \!\[(?={{balance_square_brackets}}?\]\()
+      scope: meta.image.inline.markdown punctuation.definition.image.begin.markdown
       push: [image-inline-attr, image-inline-after-text, image-link-text]
 
   image-link-text:
-    - meta_content_scope: meta.image.inline.description.markdown
+    - meta_content_scope:
+        meta.image.inline.description.markdown
+        string.other.link.title.markdown
     - include: link-text
     - match: \]
       scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
       pop: true
 
   image-inline-after-text:
-    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.metadata.begin.markdown
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
       set:
         - meta_scope: meta.image.inline.markdown
         - match: \)
@@ -791,54 +782,43 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+    - include: immediately-pop
 
   image-inline-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.image.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
 
   image-ref:
-    - match: |-
-        (?x:
-          (\!\[)                             # Images start with ![
-          (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-                \]                           # Closing square bracket
-                [ ]?                         # Space
-                \[                           # [
-                [^\]]+                       # anything other than ]
-                \]                           # ]
-          )
-        )
-      captures:
-        1: meta.image.reference.markdown punctuation.definition.image.begin.markdown
+    - match: \!\[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+      scope: meta.image.reference.markdown punctuation.definition.image.begin.markdown
       push: [image-ref-attr, image-ref-after-text, image-ref-text]
 
   image-ref-text:
-    - meta_content_scope: meta.image.reference.description.markdown
+    - meta_content_scope:
+        meta.image.reference.description.markdown
+        string.other.link.title.markdown
     - include: link-text
     - match: \]
       scope: meta.image.reference.markdown punctuation.definition.image.end.markdown
       pop: true
 
   image-ref-after-text:
-    - match: '[ ]?(\[)([^\]]+)(\])'
+    - match: (\[)([^\]]+)(\])
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
       scope: meta.image.reference.markdown
       pop: true
+    - include: immediately-pop
 
   image-ref-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.image.reference.markdown
         - include: tag-attributes
@@ -977,24 +957,13 @@ contexts:
           scope: markup.underline.link.markdown-gfm
 
   link-inline:
-    - match: |-
-        (?x:
-            (\[)
-            (?=
-                {{balance_square_brackets}}?
-                \]
-                [ ]?\(
-            )
-        )
-      captures:
-        1: meta.link.inline.markdown punctuation.definition.link.begin.markdown
+    - match: \[(?={{balance_square_brackets}}?\]\()
+      scope: meta.link.inline.markdown punctuation.definition.link.begin.markdown
       push: [link-inline-attr, link-inline-after-text, link-inline-link-text]
 
   link-inline-after-text:
-    - match: '([ ]*)(\()' # spaces not allowed before the open paren, but we check for it anyway to mark it as invalid
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.metadata.begin.markdown
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
       set:
         - meta_scope: meta.link.inline.markdown
         - match: \)
@@ -1020,124 +989,93 @@ contexts:
               scope: invalid.illegal.unexpected-whitespace.markdown
             - match: (?=\s*(?!\)))
               push: link-title
+    - include: immediately-pop
 
   link-inline-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.inline.markdown
         - include: tag-attributes
     - include: immediately-pop
 
   link-inline-link-text:
-    - meta_content_scope: meta.link.inline.description.markdown
+    - meta_content_scope:
+        meta.link.inline.description.markdown
+        string.other.link.title.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
       pop: true
 
   link-ref:
-    - match: |-
-        (?x:
-          (\[)
-          (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-                \]                           # Closing square bracket
-                [ ]?                         # Space
-                \[                           # [
-                [^\]]+                       # anything other than ]
-                \]                           # ]
-          )
-        )
-      captures:
-        1: meta.link.reference.markdown punctuation.definition.link.begin.markdown
+    - match: \[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+      scope: meta.link.reference.markdown punctuation.definition.link.begin.markdown
       push: [link-ref-attr, link-ref-after-text, link-ref-link-text]
-    - match: |-
-        (?x:
-          (\[)(?!\^)
-          (?=   {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-                \]
-          )
-        )
-      captures:
-        1: meta.link.reference.markdown punctuation.definition.link.begin.markdown
+    - match: \[(?=(?!\^){{balance_square_brackets}}?\])
+      scope: meta.link.reference.markdown punctuation.definition.link.begin.markdown
       push: link-ref-link-text
 
   link-ref-link-text:
-    - meta_content_scope: meta.link.reference.description.markdown
+    - meta_content_scope:
+        meta.link.reference.description.markdown
+        string.other.link.title.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.markdown punctuation.definition.link.end.markdown
       pop: true
 
   link-ref-after-text:
-    - match: '[ ]?(\[)([^\]]+)(\])'
+    - match: (\[)([^\]]+)(\])
+      scope: meta.link.reference.markdown
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: constant.other.reference.link.markdown
         3: punctuation.definition.constant.end.markdown
-      scope: meta.link.reference.markdown
       pop: true
+    - include: immediately-pop
 
   link-ref-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.reference.markdown
         - include: tag-attributes
     - include: immediately-pop
 
   link-ref-literal:
-    - match: |-
-        (?x:
-          (\[)
-          (?=
-              {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-              \]                           # Closing square bracket
-              [ ]?                         # Space
-              \[                           # [
-              \]                           # ]
-          )
-        )
-      captures:
-        1: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
+    - match: \[(?={{balance_square_brackets}}?\]\[\])
+      scope: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
       push: [link-ref-literal-attr, link-ref-literal-after-text, link-ref-literal-link-text]
 
   link-ref-literal-link-text:
-    - meta_content_scope: meta.link.reference.literal.description.markdown
+    - meta_content_scope:
+        meta.link.reference.literal.description.markdown
+        string.other.link.title.markdown
     - include: link-text-allow-image
     - match: \]
       scope: meta.link.reference.literal.markdown punctuation.definition.link.end.markdown
       pop: true
 
   link-ref-literal-after-text:
-    - match: '[ ]?(\[)(\])'
+    - match: (\[)(\])
       scope: meta.link.reference.literal.markdown
       captures:
         1: punctuation.definition.constant.begin.markdown
         2: punctuation.definition.constant.end.markdown
       pop: true
+    - include: immediately-pop
 
   link-ref-literal-attr:
-    - match: '([ ]*)(\{)(?=[^}]*\})'
-      captures:
-        1: invalid.illegal.whitespace.markdown
-        2: punctuation.definition.attributes.begin.markdown
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
       set:
         - meta_scope: meta.link.reference.literal.markdown
         - include: tag-attributes
     - include: immediately-pop
 
   link-ref-footnote:
-    - match: |-
-        (?x:
-          (\[\^)
-          ([^]]+)
-          (\])
-        )
+    - match: (\[\^)([^]]+)(\])
       captures:
         0: meta.link.reference.footnote.markdown-extra
         1: punctuation.definition.link.begin.markdown
@@ -1145,20 +1083,14 @@ contexts:
         3: punctuation.definition.link.end.markdown
 
   link-ref-wiki:
-    - match: |-
-        (?x:
-          (\[\[)
-          (?=
-              {{balance_square_brackets}}? # balanced square brackets, backticks, taking into account escapes etc.
-              \]\]                         # Closing square bracket
-          )
-        )
-      captures:
-        1: meta.link.reference.wiki.markdown punctuation.definition.link.begin.markdown
+    - match: \[\[(?={{balance_square_brackets}}?\]\])
+      scope: meta.link.reference.wiki.markdown punctuation.definition.link.begin.markdown
       push: link-ref-wiki-link-text
 
   link-ref-wiki-link-text:
-    - meta_content_scope: meta.link.reference.wiki.description.markdown
+    - meta_content_scope:
+        meta.link.reference.wiki.description.markdown
+        string.other.link.title.markdown
     - include: link-text-allow-image
     - match: \]\]
       scope: meta.link.reference.wiki.markdown punctuation.definition.link.end.markdown

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -327,6 +327,7 @@ contexts:
   setext-heading1:
     # https://spec.commonmark.org/0.30/#setext-headings
     - meta_scope: markup.heading.1.markdown
+    - meta_content_scope: entity.name.section.markdown
     - match: ^[ ]{,3}(=+)[ \t]*$(\n?)
       captures:
         1: punctuation.definition.heading.setext.markdown
@@ -337,6 +338,7 @@ contexts:
   setext-heading2:
     # https://spec.commonmark.org/0.30/#setext-headings
     - meta_scope: markup.heading.2.markdown
+    - meta_content_scope: entity.name.section.markdown
     - match: ^[ ]{,3}(-+)[ \t]*$(\n?)
       captures:
         1: punctuation.definition.heading.setext.markdown

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -138,6 +138,11 @@ variables:
         )
         \s*$          # any amount of whitespace until EOL
       )
+
+    # https://spec.commonmark.org/0.30/#email-autolink
+    email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
+    email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
+
     html_tag_open_commonmark: |-
       (?xi:
         <
@@ -750,8 +755,8 @@ contexts:
     - include: code-span
     - include: image-inline
     - include: link-inline
-    - include: autolink-inet
     - include: autolink-email
+    - include: autolink-inet
     - include: image-ref
     - include: link-ref-wiki
     - include: link-ref-footnote
@@ -836,42 +841,6 @@ contexts:
       scope: meta.hard-line-break.markdown
       captures:
         1: constant.character.escape.markdown
-
-  autolink-email:
-    - match: '(<)((?:mailto:)?[-+.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+)(>)'
-      scope: meta.link.email.lt-gt.markdown
-      captures:
-        1: punctuation.definition.link.begin.markdown
-        2: markup.underline.link.markdown
-        4: punctuation.definition.link.end.markdown
-    - match: '[\w.+-]+@[\w-]+(\.((?![._-][\W])[\w_-])+)+(?![_-])'
-      scope: markup.underline.link.markdown
-
-  autolink-inet:
-    - match: (<)((?:https?|ftp)://.*?)(>)
-      scope: meta.link.inet.markdown
-      captures:
-        1: punctuation.definition.link.begin.markdown
-        2: markup.underline.link.markdown
-        3: punctuation.definition.link.end.markdown
-    - match: (((https|http|ftp)://)|www\.)[\w-]+(\.[\w-]+)+
-      scope: markup.underline.link.markdown-gfm
-      push: # After a valid domain, zero or more non-space non-< characters may follow
-        - match: (?=[?!.,:*_~]*(?:[\s<]|$)) # Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be considered part of the autolink, though they may be included in the interior of the link
-          pop: true
-        - match: (?={{html_entity}}[?!.,:*_~]*[\s<]) # If an autolink ends in a semicolon (;), we check to see if it appears to resemble an entity reference; if the preceding text is & followed by one or more alphanumeric characters. If so, it is excluded from the autolink
-          pop: true
-        - match: \( # When an autolink ends in ), we scan the entire autolink for the total number of parentheses. If there is a greater number of closing parentheses than opening ones, we don’t consider the last character part of the autolink, in order to facilitate including an autolink inside a parenthesis
-          push:
-            - meta_scope: markup.underline.link.markdown-gfm
-            - match: (?=[?!.,:*_~]*[\s<])
-              pop: true
-            - match: \)
-              pop: true
-        - match: (?=\)[?!.,:*_~]*[\s<])
-          pop: true
-        - match: '[^?!.,:*_~\s<&()]+|\S'
-          scope: markup.underline.link.markdown-gfm
 
   reference-link-definition:
     - match: |-
@@ -2488,13 +2457,29 @@ contexts:
     - include: link-url-common
 
   link-url-common:
+    - include: link-url-path-separators
+    - include: link-url-scheme-separators
+    - include: link-url-escapes
+    - include: paragraph-end
+
+  link-url-escapes:
     - match: (%)\h{2}
       scope: constant.character.escape.url.markdown
       captures:
         1: punctuation.definition.escape.markdown
-    - match: '[/&?#]|://'
+
+  link-url-path-separators:
+    - match: '[/&?#]'
       scope: punctuation.separator.path.markdown
-    - include: paragraph-end
+
+  link-url-scheme-separators:
+    - match: ':/{,2}'
+      scope: punctuation.separator.path.markdown
+
+  link-url-scheme-separator:
+    - match: ':/{,2}'
+      scope: punctuation.separator.path.markdown
+      pop: true
 
 ###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################
 
@@ -2550,6 +2535,91 @@ contexts:
         - match: '["''`<]'
           scope: invalid.illegal.attribute-value.markdown
     - include: else-pop
+
+###[ AUTOLINKS ]##############################################################
+
+  autolink-email:
+    # CommonMark
+    # https://spec.commonmark.org/0.30/#email-autolink
+    - match: |-
+        (?x)
+        (<)
+        (
+          (?:mailto(:))?
+          {{email_user_commonmark}}
+          (@)
+          {{email_domain_commonmark}}(?:\.{{email_domain_commonmark}})*
+        )
+        (>)
+      captures:
+        0: meta.link.email.markdown
+        1: punctuation.definition.link.begin.markdown
+        2: markup.underline.link.markdown
+        3: punctuation.separator.path.markdown
+        4: punctuation.separator.path.markdown
+        5: punctuation.definition.link.end.markdown
+    # Github Flavoured Markdown
+    - match: '[\w.+-]+(@)[\w-]+(?:\.(?:(?![._-][\W])[\w_-])+)+(?![_-])'
+      captures:
+        0: meta.link.email.markdown markup.underline.link.markdown
+        1: punctuation.separator.path.markdown
+
+  autolink-inet:
+    # CommonMark
+    # https://spec.commonmark.org/0.30/#autolinks
+    - match: <(?=[[:alpha:]][[:alnum:].+-]+:)
+      scope: punctuation.definition.link.begin.markdown
+      push:
+        - autolink-inet-angled-content
+        - link-url-scheme-separator
+    # Github Flavoured Markdown
+    # After a valid domain, zero or more non-space non-< characters may follow
+    - match: (?:(?:https|http|ftp)(://)|www\.)[\w-]+
+      captures:
+        1: punctuation.separator.path.markdown
+      push: autolink-inet-unquoted-content
+
+  autolink-inet-angled-content:
+    - meta_scope: meta.link.inet.markdown
+    - meta_content_scope: markup.underline.link.markdown
+    - match: \>
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    # Spaces are not allowed in autolinks
+    - match: (?=\s)
+      pop: true
+    - include: autolink-inet-common
+
+  autolink-inet-unquoted-content:
+    - meta_scope: meta.link.inet.markdown markup.underline.link.markdown-gfm
+    # Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be
+    # considered part of the autolink, though they may be included in the interior
+    # of the link
+    - match: (?=[?!.,:*_~]*[\s<])
+      pop: true
+    # If an autolink ends in a semicolon (;), we check to see if it appears to
+    # resemble an entity reference; if the preceding text is & followed by one
+    # or more alphanumeric characters. If so, it is excluded from the autolink
+    - match: (?={{html_entity}})
+      pop: true
+    # When an autolink ends in ), we scan the entire autolink for the total number
+    # of parentheses. If there is a greater number of closing parentheses than
+    # opening ones, we don’t consider the last character part of the autolink,
+    # in order to facilitate including an autolink inside a parenthesis
+    - match: (?=\)[?!.,:*_~]*[\s<])
+      pop: true
+    - match: \(
+      push: autolink-inet-group
+    - include: autolink-inet-common
+
+  autolink-inet-group:
+    - match: \)
+      pop: true
+    - include: autolink-inet-unquoted-content
+
+  autolink-inet-common:
+    - include: link-url-path-separators
+    - include: link-url-escapes
 
 ###[ TABLE ]##################################################################
 

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -741,91 +741,6 @@ contexts:
       pop: true
     - include: inline-bold-italic
 
-  image-inline:
-    - match: \!\[(?={{balance_square_brackets}}?\]\()
-      scope: meta.image.inline.markdown punctuation.definition.image.begin.markdown
-      push: [image-inline-attr, image-inline-after-text, image-link-text]
-
-  image-link-text:
-    - meta_content_scope:
-        meta.image.inline.description.markdown
-        string.other.link.title.markdown
-    - include: link-text
-    - match: \]
-      scope: meta.image.inline.markdown punctuation.definition.image.end.markdown
-      pop: true
-
-  image-inline-after-text:
-    - match: \(
-      scope: punctuation.definition.metadata.begin.markdown
-      set:
-        - meta_scope: meta.image.inline.markdown
-        - match: \)
-          scope: punctuation.definition.metadata.end.markdown
-          pop: true
-        - match: <(?=[^>)]*>)
-          scope: punctuation.definition.link.begin.markdown
-          push:
-            - meta_content_scope: markup.underline.link.image.markdown
-            - match: \>
-              scope: punctuation.definition.link.end.markdown
-              set: link-title
-            - match: \s+
-              scope: invalid.illegal.unexpected-whitespace.markdown
-        - match: (?=\S)
-          set:
-            - meta_scope: meta.image.inline.markdown
-            - match: '[^\s)]+'
-              scope: markup.underline.link.image.markdown
-            - match: \)
-              scope: punctuation.definition.metadata.end.markdown
-              pop: true
-            - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
-              scope: invalid.illegal.unexpected-whitespace.markdown
-            - match: (?=\s*(?!\)))
-              push: link-title
-    - include: immediately-pop
-
-  image-inline-attr:
-    - match: \{(?=[^}]*\})
-      scope: punctuation.definition.attributes.begin.markdown
-      set:
-        - meta_scope: meta.image.inline.markdown
-        - include: tag-attributes
-    - include: immediately-pop
-
-  image-ref:
-    - match: \!\[(?={{balance_square_brackets}}?\]\[[^\]]+\])
-      scope: meta.image.reference.markdown punctuation.definition.image.begin.markdown
-      push: [image-ref-attr, image-ref-after-text, image-ref-text]
-
-  image-ref-text:
-    - meta_content_scope:
-        meta.image.reference.description.markdown
-        string.other.link.title.markdown
-    - include: link-text
-    - match: \]
-      scope: meta.image.reference.markdown punctuation.definition.image.end.markdown
-      pop: true
-
-  image-ref-after-text:
-    - match: (\[)([^\]]+)(\])
-      captures:
-        1: punctuation.definition.constant.begin.markdown
-        2: constant.other.reference.link.markdown
-        3: punctuation.definition.constant.end.markdown
-      scope: meta.image.reference.markdown
-      pop: true
-    - include: immediately-pop
-
-  image-ref-attr:
-    - match: \{(?=[^}]*\})
-      scope: punctuation.definition.attributes.begin.markdown
-      set:
-        - meta_scope: meta.image.reference.markdown
-        - include: tag-attributes
-    - include: immediately-pop
-
   inline:
     - include: escape
     - include: ampersand
@@ -958,146 +873,6 @@ contexts:
         - match: '[^?!.,:*_~\s<&()]+|\S'
           scope: markup.underline.link.markdown-gfm
 
-  link-inline:
-    - match: \[(?={{balance_square_brackets}}?\]\()
-      scope: meta.link.inline.markdown punctuation.definition.link.begin.markdown
-      push: [link-inline-attr, link-inline-after-text, link-inline-link-text]
-
-  link-inline-after-text:
-    - match: \(
-      scope: punctuation.definition.metadata.begin.markdown
-      set:
-        - meta_scope: meta.link.inline.markdown
-        - match: \)
-          scope: punctuation.definition.metadata.end.markdown
-          pop: true
-        - match: <(?=[^>)]*>)
-          scope: punctuation.definition.link.begin.markdown
-          push:
-            - match: \>
-              scope: punctuation.definition.link.end.markdown
-              set: link-title
-            - match: \s+
-              scope: invalid.illegal.unexpected-whitespace.markdown
-        - match: (?=\S)
-          set:
-            - meta_scope: meta.link.inline.markdown
-            - match: '[^\s)]+'
-              scope: markup.underline.link.markdown
-            - match: \)
-              scope: punctuation.definition.metadata.end.markdown
-              pop: true
-            - match: (?!\n)\s+(?!\s*(?:[)('"]|$))
-              scope: invalid.illegal.unexpected-whitespace.markdown
-            - match: (?=\s*(?!\)))
-              push: link-title
-    - include: immediately-pop
-
-  link-inline-attr:
-    - match: \{(?=[^}]*\})
-      scope: punctuation.definition.attributes.begin.markdown
-      set:
-        - meta_scope: meta.link.inline.markdown
-        - include: tag-attributes
-    - include: immediately-pop
-
-  link-inline-link-text:
-    - meta_content_scope:
-        meta.link.inline.description.markdown
-        string.other.link.title.markdown
-    - include: link-text-allow-image
-    - match: \]
-      scope: meta.link.inline.markdown punctuation.definition.link.end.markdown
-      pop: true
-
-  link-ref:
-    - match: \[(?={{balance_square_brackets}}?\]\[[^\]]+\])
-      scope: meta.link.reference.markdown punctuation.definition.link.begin.markdown
-      push: [link-ref-attr, link-ref-after-text, link-ref-link-text]
-    - match: \[(?=(?!\^){{balance_square_brackets}}?\])
-      scope: meta.link.reference.markdown punctuation.definition.link.begin.markdown
-      push: link-ref-link-text
-
-  link-ref-link-text:
-    - meta_content_scope:
-        meta.link.reference.description.markdown
-        string.other.link.title.markdown
-    - include: link-text-allow-image
-    - match: \]
-      scope: meta.link.reference.markdown punctuation.definition.link.end.markdown
-      pop: true
-
-  link-ref-after-text:
-    - match: (\[)([^\]]+)(\])
-      scope: meta.link.reference.markdown
-      captures:
-        1: punctuation.definition.constant.begin.markdown
-        2: constant.other.reference.link.markdown
-        3: punctuation.definition.constant.end.markdown
-      pop: true
-    - include: immediately-pop
-
-  link-ref-attr:
-    - match: \{(?=[^}]*\})
-      scope: punctuation.definition.attributes.begin.markdown
-      set:
-        - meta_scope: meta.link.reference.markdown
-        - include: tag-attributes
-    - include: immediately-pop
-
-  link-ref-literal:
-    - match: \[(?={{balance_square_brackets}}?\]\[\])
-      scope: meta.link.reference.literal.markdown punctuation.definition.link.begin.markdown
-      push: [link-ref-literal-attr, link-ref-literal-after-text, link-ref-literal-link-text]
-
-  link-ref-literal-link-text:
-    - meta_content_scope:
-        meta.link.reference.literal.description.markdown
-        string.other.link.title.markdown
-    - include: link-text-allow-image
-    - match: \]
-      scope: meta.link.reference.literal.markdown punctuation.definition.link.end.markdown
-      pop: true
-
-  link-ref-literal-after-text:
-    - match: (\[)(\])
-      scope: meta.link.reference.literal.markdown
-      captures:
-        1: punctuation.definition.constant.begin.markdown
-        2: punctuation.definition.constant.end.markdown
-      pop: true
-    - include: immediately-pop
-
-  link-ref-literal-attr:
-    - match: \{(?=[^}]*\})
-      scope: punctuation.definition.attributes.begin.markdown
-      set:
-        - meta_scope: meta.link.reference.literal.markdown
-        - include: tag-attributes
-    - include: immediately-pop
-
-  link-ref-footnote:
-    - match: (\[\^)([^]]+)(\])
-      captures:
-        0: meta.link.reference.footnote.markdown-extra
-        1: punctuation.definition.link.begin.markdown
-        2: meta.link.reference.literal.footnote-id.markdown
-        3: punctuation.definition.link.end.markdown
-
-  link-ref-wiki:
-    - match: \[\[(?={{balance_square_brackets}}?\]\])
-      scope: meta.link.reference.wiki.markdown punctuation.definition.link.begin.markdown
-      push: link-ref-wiki-link-text
-
-  link-ref-wiki-link-text:
-    - meta_content_scope:
-        meta.link.reference.wiki.description.markdown
-        string.other.link.title.markdown
-    - include: link-text-allow-image
-    - match: \]\]
-      scope: meta.link.reference.wiki.markdown punctuation.definition.link.end.markdown
-      pop: true
-
   reference-link-definition:
     - match: |-
         (?x:
@@ -1119,6 +894,13 @@ contexts:
         7: punctuation.definition.link.end.markdown
         8: markup.underline.link.markdown
       push: [link-ref-def-expect-end, link-title]
+
+  link-ref-def-expect-end:
+    - meta_scope: meta.link.reference.def.markdown
+    - match: $
+      pop: true
+    - match: \s*\S+
+      scope: invalid.illegal.expected-eol.markdown
 
   list-paragraph:
     - match: '^(?=(?:[ ]{4}|\t){2,}(?![>+*\s-]))(?={{indented_code_block}})'
@@ -1241,6 +1023,7 @@ contexts:
     - include: fenced-docker
     - include: fenced-dosbatch
     - include: fenced-elixir
+    - include: fenced-fish
     - include: fenced-graphql
     - include: fenced-ini
     - include: fenced-jade
@@ -1257,6 +1040,7 @@ contexts:
     - include: fenced-stata
     - include: fenced-swift
     - include: fenced-toml
+    - include: fenced-xonsh
 
   fenced-clojure:
     - match: |-
@@ -2009,6 +1793,23 @@ contexts:
         0: meta.code-fence.definition.end.elixir.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
 
+  fenced-fish:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:fish))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.fish.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.shell.fish
+      embed_scope: markup.raw.code-fence.fish.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.fish.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+
   fenced-graphql:
     - match: |-
          (?x)
@@ -2283,6 +2084,23 @@ contexts:
         0: meta.code-fence.definition.end.toml.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
 
+  fenced-xonsh:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:xonsh|xsh))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.xonsh.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:source.python
+      embed_scope: markup.raw.code-fence.xonsh.markdown-gfm
+      escape: '{{code_fence_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.xonsh.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+
   code-span:
     - match: (`+)(?!`)
       scope: punctuation.definition.raw.begin.markdown
@@ -2365,6 +2183,229 @@ contexts:
         8: entity.name.tag.inline.any.html
         9: punctuation.definition.tag.end.html
 
+###[ INLINE IMAGES ]##########################################################
+
+  image-inline:
+    - match: \!\[(?={{balance_square_brackets}}?\]\()
+      scope: punctuation.definition.image.begin.markdown
+      push:
+        - image-inline-metadata
+        - image-inline-text
+
+  image-inline-text:
+    - meta_scope: meta.image.inline.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]
+      scope: punctuation.definition.image.end.markdown
+      pop: true
+    - include: link-text
+
+  image-inline-metadata:
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
+      set:
+        - image-inline-metadata-end
+        - link-title
+        - link-url
+    - include: immediately-pop
+
+  image-inline-metadata-end:
+    - meta_scope: meta.image.inline.metadata.markdown
+    - match: \)
+      scope: punctuation.definition.metadata.end.markdown
+      set: image-inline-attr
+    - include: else-pop
+
+  image-inline-attr:
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
+      set: image-inline-attr-body
+    - include: immediately-pop
+
+  image-inline-attr-body:
+    - meta_scope: meta.image.inline.attributes.markdown
+    - include: tag-attributes
+
+###[ IMAGE REFERENCES ]#######################################################
+
+  image-ref:
+    - match: \!\[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+      scope: punctuation.definition.image.begin.markdown
+      push:
+        - image-ref-attr
+        - image-ref-metadata
+        - image-ref-text
+
+  image-ref-text:
+    - meta_scope: meta.image.reference.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]
+      scope: punctuation.definition.image.end.markdown
+      pop: true
+    - include: link-text
+
+  image-ref-metadata:
+    - match: (\[)([^\]]+)(\])
+      scope: meta.image.reference.metadata.markdown
+      captures:
+        1: punctuation.definition.metadata.begin.markdown
+        2: constant.other.reference.link.markdown
+        3: punctuation.definition.metadata.end.markdown
+      pop: true
+    - include: immediately-pop
+
+  image-ref-attr:
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
+      set: image-ref-attr-body
+    - include: immediately-pop
+
+  image-ref-attr-body:
+    - meta_scope: meta.image.reference.markdown
+    - include: tag-attributes
+
+###[ INLINE LINKS ]###########################################################
+
+  link-inline:
+    - match: \[(?={{balance_square_brackets}}?\]\()
+      scope: punctuation.definition.link.begin.markdown
+      push:
+        - link-inline-metadata
+        - link-inline-text
+
+  link-inline-text:
+    - meta_scope: meta.link.inline.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    - include: link-text-allow-image
+
+  link-inline-metadata:
+    - match: \(
+      scope: punctuation.definition.metadata.begin.markdown
+      set:
+        - link-inline-metadata-end
+        - link-title
+        - link-url
+    - include: immediately-pop
+
+  link-inline-metadata-end:
+    - meta_scope: meta.link.inline.metadata.markdown
+    - match: \)
+      scope: punctuation.definition.metadata.end.markdown
+      set: link-inline-attr
+    - include: else-pop
+
+  link-inline-attr:
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-inline-attr-body
+    - include: immediately-pop
+
+  link-inline-attr-body:
+    - meta_scope: meta.link.inline.attributes.markdown
+    - include: tag-attributes
+
+###[ LINK REFERENCES ]########################################################
+
+  link-ref:
+    - match: \[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+      scope: punctuation.definition.link.begin.markdown
+      push:
+        - link-ref-attr
+        - link-ref-metadata
+        - link-ref-link-text
+    - match: \[(?=(?!\^){{balance_square_brackets}}?\])
+      scope: punctuation.definition.link.begin.markdown
+      push: link-ref-link-text
+
+  link-ref-link-text:
+    - meta_scope: meta.link.reference.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    - include: link-text-allow-image
+
+  link-ref-metadata:
+    - match: (\[)([^\]]+)(\])
+      scope: meta.link.reference.metadata.markdown
+      captures:
+        1: punctuation.definition.metadata.begin.markdown
+        2: constant.other.reference.link.markdown
+        3: punctuation.definition.metadata.end.markdown
+      pop: true
+    - include: immediately-pop
+
+  link-ref-attr:
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-ref-attr-body
+    - include: immediately-pop
+
+  link-ref-attr-body:
+    - meta_scope: meta.link.reference.attributes.markdown
+    - include: tag-attributes
+
+  link-ref-literal:
+    - match: \[(?={{balance_square_brackets}}?\]\[\])
+      scope: punctuation.definition.link.begin.markdown
+      push:
+        - link-ref-literal-attr
+        - link-ref-literal-metadata
+        - link-ref-literal-link-text
+
+  link-ref-literal-link-text:
+    - meta_scope: meta.link.reference.literal.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    - include: link-text-allow-image
+
+  link-ref-literal-metadata:
+    - match: (\[)(\])
+      scope: meta.link.reference.literal.metadata.markdown
+      captures:
+        1: punctuation.definition.metadata.begin.markdown
+        2: punctuation.definition.metadata.end.markdown
+      pop: true
+    - include: immediately-pop
+
+  link-ref-literal-attr:
+    - match: \{(?=[^}]*\})
+      scope: punctuation.definition.attributes.begin.markdown
+      set: link-ref-literal-attr-body
+    - include: immediately-pop
+
+  link-ref-literal-attr-body:
+    - meta_scope: meta.link.reference.literal.attributes.markdown
+    - include: tag-attributes
+
+  link-ref-footnote:
+    - match: (\[\^)([^]]+)(\])
+      captures:
+        0: meta.link.reference.footnote.markdown-extra
+        1: punctuation.definition.link.begin.markdown
+        2: meta.link.reference.literal.footnote-id.markdown
+        3: punctuation.definition.link.end.markdown
+
+  link-ref-wiki:
+    - match: \[\[(?={{balance_square_brackets}}?\]\])
+      scope: punctuation.definition.link.begin.markdown
+      push: link-ref-wiki-link-text
+
+  link-ref-wiki-link-text:
+    - meta_scope: meta.link.reference.wiki.description.markdown
+    - meta_content_scope: string.other.link.title.markdown
+    - match: \]\]
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    - include: link-text-allow-image
+
+###[ LINK/IMAGE PROTOTYPES ]##################################################
+
   link-text:
     - match: \b__?(?=[^]_]+\]) # eat underscores where there is no pair before the end of the square brackets - it's not a formatting mark
     - match: \b\*\*?(?=[^]*]+\]) # eat asterisks where there is no pair before the end of the square brackets - it's not a formatting mark
@@ -2390,42 +2431,70 @@ contexts:
   link-title:
     - match: \'
       scope: punctuation.definition.string.begin.markdown
-      set:
-        - meta_scope: string.other.link.description.title.markdown
-        - match: \'
-          scope: punctuation.definition.string.end.markdown
-          pop: true
-        - include: non-terminated-link-title
+      set: link-title-single-quoted-content
     - match: \"
       scope: punctuation.definition.string.begin.markdown
-      set:
-        - meta_scope: string.other.link.description.title.markdown
-        - match: \"
-          scope: punctuation.definition.string.end.markdown
-          pop: true
-        - include: non-terminated-link-title
+      set: link-title-double-quoted-content
     - match: \(
       scope: punctuation.definition.string.begin.markdown
-      set:
-        - meta_scope: string.other.link.description.title.markdown
-        - match: \)
-          scope: punctuation.definition.string.end.markdown
-          pop: true
-        - include: non-terminated-link-title
+      set: link-title-other-quoted-content
     - match: $|(?=\S)
       pop: true
 
-  non-terminated-link-title:
+  link-title-double-quoted-content:
+    - meta_scope: string.other.link.description.title.markdown
+    - match: \"
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+    - include: link-title-common
+
+  link-title-single-quoted-content:
+    - meta_scope: string.other.link.description.title.markdown
+    - match: \'
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+    - include: link-title-common
+
+  link-title-other-quoted-content:
+    - meta_scope: string.other.link.description.title.markdown
+    - match: \)
+      scope: punctuation.definition.string.end.markdown
+      pop: true
+    - include: link-title-common
+
+  link-title-common:
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.link-title.markdown
       pop: true
 
-  link-ref-def-expect-end:
-    - meta_scope: meta.link.reference.def.markdown
-    - match: $
+  link-url:
+    - match: <
+      scope: punctuation.definition.link.begin.markdown
+      set: link-url-angled
+    - match: (?=\S)
+      set: link-url-unquoted
+
+  link-url-angled:
+    - meta_content_scope: markup.underline.link.markdown
+    - match: \>
+      scope: punctuation.definition.link.end.markdown
       pop: true
-    - match: \s*\S+
-      scope: invalid.illegal.expected-eol.markdown
+    - include: link-url-common
+
+  link-url-unquoted:
+    - meta_scope: markup.underline.link.markdown
+    - match: (?=[ \t)])
+      pop: true
+    - include: link-url-common
+
+  link-url-common:
+    - match: (%)\h{2}
+      scope: constant.character.escape.url.markdown
+      captures:
+        1: punctuation.definition.escape.markdown
+    - match: '[/&?#]|://'
+      scope: punctuation.separator.path.markdown
+    - include: paragraph-end
 
 ###[ LINK/IMAGE/REFERENCE ATTRIBUTES ]########################################
 

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -191,6 +191,9 @@ variables:
     tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
     tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
 
+    footnote_name: (?:\^(?:\\\]|[^]])+)
+    reference_name: (?:(?:\\\]|[^]])+)
+
 contexts:
 
   main:
@@ -296,23 +299,7 @@ contexts:
     - match: '^[ ]{0,3}(?=(?:{{html_tag_open_commonmark}}|{{html_tag_close_commonmark}})\s*$|<{{html_tag_block_end_at_blank_line}})'
       comment: Markdown formatting is disabled inside block level tags and if a complete HTML tag is the only thing on the line.
       push: [disabled-markdown-pop-at-eol, disable-markdown-pop-at-blank-line]
-    - match: |-
-        (?x:
-            \s*                        # Leading whitespace
-            (\[)(\^[^]]*)(\])(:)       # Reference name
-            [ \t]*                     # Optional whitespace
-        )
-      captures:
-        1: punctuation.definition.constant.begin.markdown
-        2: entity.name.reference.link.markdown
-        3: punctuation.definition.constant.end.markdown
-        4: punctuation.separator.key-value.markdown
-      push:
-        - meta_scope: meta.link.reference.def.footnote.markdown-extra
-        - match: ^(?![ ]{4}|$)
-          pop: true
-        - include: inline-bold-italic
-    - include: reference-link-definition
+    - include: reference-definitions
     - include: latex-blocks
     - include: fenced-code-blocks
     - include: setext-heading-or-paragraph
@@ -842,35 +829,6 @@ contexts:
       captures:
         1: constant.character.escape.markdown
 
-  reference-link-definition:
-    - match: |-
-        (?x:
-            [ ]{0,3}                     # Leading whitespace
-            (\[)(|(?:\\\]|[^]])+)(\])(:) # Reference name
-            [ \t]*                       # Optional whitespace
-            (?:
-              (<)([^>]*)(>)              # The url
-            | (\S+)                      # The url
-            )
-        )
-      captures:
-        1: punctuation.definition.constant.begin.markdown
-        2: entity.name.reference.link.markdown
-        3: punctuation.definition.constant.end.markdown
-        4: punctuation.separator.key-value.markdown
-        5: punctuation.definition.link.begin.markdown
-        6: markup.underline.link.markdown
-        7: punctuation.definition.link.end.markdown
-        8: markup.underline.link.markdown
-      push: [link-ref-def-expect-end, link-title]
-
-  link-ref-def-expect-end:
-    - meta_scope: meta.link.reference.def.markdown
-    - match: $
-      pop: true
-    - match: \s*\S+
-      scope: invalid.illegal.expected-eol.markdown
-
   list-paragraph:
     - match: '^(?=(?:[ ]{4}|\t){2,}(?![>+*\s-]))(?={{indented_code_block}})'
       push:
@@ -885,7 +843,7 @@ contexts:
         - block-quote-content
     - include: latex-blocks
     - include: fenced-code-blocks
-    - include: reference-link-definition
+    - include: reference-definitions
     - match: \s+(?=\S)
       push:
         - match: ^\s*$
@@ -2152,6 +2110,73 @@ contexts:
         8: entity.name.tag.inline.any.html
         9: punctuation.definition.tag.end.html
 
+###[ LEAF BLOCKS: LINK REFERENCE DEFINITIONS ]################################
+
+  reference-definitions:
+    - include: footnote-definitions
+    - include: link-definitions
+
+  footnote-definitions:
+    # Mardown Extras Footnotes
+    - match: '[ ]{0,3}(\[)({{footnote_name}})(\])(:)'
+      captures:
+        1: punctuation.definition.reference.begin.markdown
+        2: entity.name.reference.link.markdown
+        3: punctuation.definition.reference.end.markdown
+        4: punctuation.separator.key-value.markdown
+      push: footnote-def-body
+
+  footnote-def-body:
+    - meta_scope: meta.link.reference.def.footnote.markdown-extra
+    - match: ^(?![ ]{4}|$)
+      pop: true
+    - include: inline-bold-italic
+
+  link-definitions:
+    # https://spec.commonmark.org/0.30/#link-reference-definition
+    - match: '[ ]{0,3}(\[)({{reference_name}})(\])(:)'
+      captures:
+        1: punctuation.definition.reference.begin.markdown
+        2: entity.name.reference.link.markdown
+        3: punctuation.definition.reference.end.markdown
+        4: punctuation.separator.key-value.markdown
+      push:
+        - link-def-end
+        - link-title
+        - link-def-url
+
+  link-def-end:
+    - meta_scope: meta.link.reference.def.markdown
+    - include: eol-pop
+    - match: \s*\S+
+      scope: invalid.illegal.expected-eol.markdown
+
+  link-def-url:
+    - match: <
+      scope: punctuation.definition.link.begin.markdown
+      set: link-def-url-angled
+    - match: (?=\S)
+      set: link-def-url-unquoted
+    - include: eol-pop
+
+  link-def-url-angled:
+    - meta_content_scope: markup.underline.link.markdown
+    - match: \>
+      scope: punctuation.definition.link.end.markdown
+      pop: true
+    - include: link-def-url-common
+
+  link-def-url-unquoted:
+    - meta_scope: markup.underline.link.markdown
+    - include: link-def-url-common
+
+  link-def-url-common:
+    # URLs are terminated by whitespace or newline in reference definitions
+    # Note: \s includes \n
+    - match: (?=\s)
+      pop: true
+    - include: link-url-common
+
 ###[ INLINE IMAGES ]##########################################################
 
   image-inline:
@@ -2198,7 +2223,7 @@ contexts:
 ###[ IMAGE REFERENCES ]#######################################################
 
   image-ref:
-    - match: \!\[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+    - match: \!\[(?={{balance_square_brackets}}?\]\[{{reference_name}}\])
       scope: punctuation.definition.image.begin.markdown
       push:
         - image-ref-attr
@@ -2214,7 +2239,7 @@ contexts:
     - include: link-text
 
   image-ref-metadata:
-    - match: (\[)([^\]]+)(\])
+    - match: (\[)({{reference_name}})(\])
       scope: meta.image.reference.metadata.markdown
       captures:
         1: punctuation.definition.metadata.begin.markdown
@@ -2279,7 +2304,7 @@ contexts:
 ###[ LINK REFERENCES ]########################################################
 
   link-ref:
-    - match: \[(?={{balance_square_brackets}}?\]\[[^\]]+\])
+    - match: \[(?={{balance_square_brackets}}?\]\[{{reference_name}}\])
       scope: punctuation.definition.link.begin.markdown
       push:
         - link-ref-attr
@@ -2298,7 +2323,7 @@ contexts:
     - include: link-text-allow-image
 
   link-ref-metadata:
-    - match: (\[)([^\]]+)(\])
+    - match: (\[)({{reference_name}})(\])
       scope: meta.link.reference.metadata.markdown
       captures:
         1: punctuation.definition.metadata.begin.markdown
@@ -2353,7 +2378,7 @@ contexts:
     - include: tag-attributes
 
   link-ref-footnote:
-    - match: (\[\^)([^]]+)(\])
+    - match: (\[)({{footnote_name}})(\])
       captures:
         0: meta.link.reference.footnote.markdown-extra
         1: punctuation.definition.link.begin.markdown
@@ -2592,32 +2617,30 @@ contexts:
 
   autolink-inet-unquoted-content:
     - meta_scope: meta.link.inet.markdown markup.underline.link.markdown-gfm
-    # Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not be
-    # considered part of the autolink, though they may be included in the interior
-    # of the link
-    - match: (?=[?!.,:*_~]*[\s<])
+    # 1. When an autolink ends in ), we scan the entire autolink for the total
+    #    number of parentheses. If there is a greater number of closing parentheses
+    #    than opening ones, we don’t consider the last character part of the
+    #    autolink, in order to facilitate including an autolink inside a parenthesis
+    # 2. If an autolink ends in a semicolon (;), we check to see if it appears to
+    #    resemble an entity reference; if the preceding text is & followed by one
+    #    or more alphanumeric characters. If so, it is excluded from the autolink
+    # 3. Trailing punctuation (specifically, ?, !, ., ,, :, *, _, and ~) will not
+    #    be considered part of the autolink, though they may be included in the
+    #    interior # of the link
+    - match: (?=(?:\)|(?:{{html_entity}})*)[?!.,:*_~]*[\s<])
       pop: true
-    # If an autolink ends in a semicolon (;), we check to see if it appears to
-    # resemble an entity reference; if the preceding text is & followed by one
-    # or more alphanumeric characters. If so, it is excluded from the autolink
-    - match: (?={{html_entity}})
-      pop: true
-    # When an autolink ends in ), we scan the entire autolink for the total number
-    # of parentheses. If there is a greater number of closing parentheses than
-    # opening ones, we don’t consider the last character part of the autolink,
-    # in order to facilitate including an autolink inside a parenthesis
-    - match: (?=\)[?!.,:*_~]*[\s<])
-      pop: true
-    - match: \(
-      push: autolink-inet-group
     - include: autolink-inet-common
 
   autolink-inet-group:
     - match: \)
       pop: true
-    - include: autolink-inet-unquoted-content
+    - match: (?=(?:{{html_entity}})*[?!.,:*_~]*[\s<])
+      pop: true
+    - include: autolink-inet-common
 
   autolink-inet-common:
+    - match: \(
+      push: autolink-inet-group
     - include: link-url-path-separators
     - include: link-url-escapes
 
@@ -2806,6 +2829,10 @@ contexts:
 
   else-pop:
     - match: (?=\S)
+      pop: true
+
+  eol-pop:
+    - match: $
       pop: true
 
   immediately-pop:

--- a/syntaxes/Symbol List - Heading.tmPreferences
+++ b/syntaxes/Symbol List - Heading.tmPreferences
@@ -13,7 +13,8 @@
 			s/\[([^]]+)\]\[[^]]*\]/$1/g; 		# strip reference urls
 			s/\[\^[^]]+\]//g; 					# strip footnotes
 			s/^\s*//g;							# strip leading whitespace
-			s/\s*#+\s*\z//g;					# strip trailing hashes
+			s/\s+#+\s*\z//g;					# strip trailing hashes
+			s/\s+/ /g;							# convert (multiple) whitespace to one space
 			s/^#{6}/          /g;				# indent atx heading 6
 			s/^#{5}/        /g;					# indent atx heading
 			s/^#{4}/      /g;					# indent atx heading
@@ -31,7 +32,8 @@
 			s/\[([^]]+)\]\[[^]]*\]/$1/g; 		# strip reference urls
 			s/\[\^[^]]+\]//g; 					# strip footnotes
 			s/^\s*//g;							# strip leading whitespace
-			s/\s*#+\s*\z//g;					# strip trailing hashes
+			s/\s+#+\s*\z//g;					# strip trailing hashes
+			s/\s+/ /g;							# convert (multiple) whitespace to one space
 			s/^(.+?)=+\s*$/# $1/g;				# convert SETEXT to ATX heading 1
 			s/^(.+?)-+\s*$/## $1/g;				# convert SETEXT to ATX heading 2
 		]]></string>

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -134,14 +134,14 @@ this must not be bold italic***
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - markup.italic
 
 SETEXT Heading Level 1
-| <- markup.heading.1.markdown
+| <- markup.heading.1.markdown entity.name.section.markdown
 =================
 | <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
 |^^^^^^^^^^^^^^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
 |                ^ markup.heading.1.markdown meta.whitespace.newline.markdown
 
 SETEXT Heading Level 2
-| <- markup.heading.2.markdown
+| <- markup.heading.2.markdown entity.name.section.markdown
 ------------------------------
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
@@ -160,8 +160,8 @@ underlined heading followed by another one that should be treated as a normal pa
 https://spec.commonmark.org/0.30/#example-80
 
 Foo *bar*
-| <- markup.heading.1.markdown
-|^^^^^^^^^ markup.heading.1.markdown
+| <- markup.heading.1.markdown entity.name.section.markdown
+|^^^^^^^^^ markup.heading.1.markdown entity.name.section.markdown
 |   ^^^^^ markup.italic.markdown
 =========
 | <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
@@ -169,8 +169,8 @@ Foo *bar*
 |        ^ markup.heading.1.markdown meta.whitespace.newline.markdown
 
 Foo *bar*
-| <- markup.heading.2.markdown
-|^^^^^^^^^ markup.heading.2.markdown
+| <- markup.heading.2.markdown entity.name.section.markdown
+|^^^^^^^^^ markup.heading.2.markdown entity.name.section.markdown
 |   ^^^^^ markup.italic.markdown
 ---------
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
@@ -178,8 +178,8 @@ Foo *bar*
 |        ^ markup.heading.2.markdown meta.whitespace.newline.markdown
 
 Foo *bar
-| <- markup.heading.1.markdown
-|^^^^^^^^^ markup.heading.1.markdown
+| <- markup.heading.1.markdown entity.name.section.markdown
+|^^^^^^^^^ markup.heading.1.markdown entity.name.section.markdown
 |   ^^^^^ markup.italic.markdown
 =========
 | <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown - markup.italic
@@ -187,8 +187,8 @@ Foo *bar
 |        ^ markup.heading.1.markdown meta.whitespace.newline.markdown - markup.italic
 
 Foo *bar
-| <- markup.heading.2.markdown
-|^^^^^^^^^ markup.heading.2.markdown
+| <- markup.heading.2.markdown entity.name.section.markdown
+|^^^^^^^^^ markup.heading.2.markdown entity.name.section.markdown
 |   ^^^^^ markup.italic.markdown
 ---------
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown - markup.italic
@@ -199,9 +199,9 @@ https://spec.commonmark.org/0.30/#example-81
 
 Foo *bar
 baz*
-| <- markup.heading.1.markdown markup.italic.markdown
-|^^^ markup.heading.1.markdown markup.italic.markdown
-|   ^ markup.heading.1.markdown - markup.italic
+| <- markup.heading.1.markdown entity.name.section.markdown markup.italic.markdown
+|^^^ markup.heading.1.markdown entity.name.section.markdown markup.italic.markdown
+|   ^ markup.heading.1.markdown entity.name.section.markdown - markup.italic
 ====
 | <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
 |^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
@@ -211,9 +211,9 @@ https://spec.commonmark.org/0.30/#example-82
 
   Foo *bar
 baz*  
-| <- markup.heading.1.markdown markup.italic.markdown
-|^^^ markup.heading.1.markdown markup.italic.markdown
-|   ^^ markup.heading.1.markdown - markup.italic
+| <- markup.heading.1.markdown entity.name.section.markdown markup.italic.markdown
+|^^^ markup.heading.1.markdown entity.name.section.markdown markup.italic.markdown
+|   ^^ markup.heading.1.markdown entity.name.section.markdown - markup.italic
 ====
 | <- markup.heading.1.markdown punctuation.definition.heading.setext.markdown
 |^^^ markup.heading.1.markdown punctuation.definition.heading.setext.markdown
@@ -295,7 +295,7 @@ Foo
 https://spec.commonmark.org/0.30/#example-89
 
 Foo  
-|  ^^ markup.heading.2.markdown - meta.hard-line-break
+|  ^^ markup.heading.2.markdown entity.name.section.markdown - meta.hard-line-break
 -----
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 |^^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
@@ -303,7 +303,7 @@ Foo
 https://spec.commonmark.org/0.30/#example-90
 
 Foo\
-|  ^ markup.heading.2.markdown - meta.hard-line-break
+|  ^ markup.heading.2.markdown entity.name.section.markdown - meta.hard-line-break
 ----
 | <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
 |^^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -974,67 +974,231 @@ _ _ _ _ _ _ _
 |  ^ punctuation
 |        ^ punctuation
 
+###[ COMMONMARK AUTOLINKS ]###################################################
+
 <mailto:test+test@test.com>
-| ^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.email.lt-gt markup.underline.link
+| <- meta.link.email.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+|                         ^ meta.link.email.markdown - markup.underline
+|      ^ punctuation.separator.path.markdown
+|                ^ punctuation.separator.path.markdown
+|                         ^ punctuation.definition.link.end.markdown
+
+<foo#bar?@mail.test.com>
+| <- meta.link.email.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+|                      ^ meta.link.email.markdown - markup.underline
+|        ^ punctuation.separator.path.markdown
+|                      ^ punctuation.definition.link.end.markdown
+
 <http://www.test.com/>
-| ^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inet markup.underline.link
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                    ^ meta.link.inet.markdown - markup.underline
+|    ^^^ punctuation.separator.path.markdown
+|                   ^ punctuation.separator.path.markdown
+|                    ^ punctuation.definition.link.end.markdown
+
 <https://test.com/>
-| ^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inet markup.underline.link
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                 ^ meta.link.inet.markdown - markup.underline
+|     ^^^ punctuation.separator.path.markdown
+|                ^ punctuation.separator.path.markdown
+|                 ^ punctuation.definition.link.end.markdown
+
 <ftp://test.com/>
-| ^^^^^^^^^^^^^^ meta.paragraph meta.link.inet markup.underline.link
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|               ^ meta.link.inet.markdown - markup.underline
+|   ^^^ punctuation.separator.path.markdown
+|              ^ punctuation.separator.path.markdown
+|               ^ punctuation.definition.link.end.markdown
+
+<irc://foo%20bar.com:2233/baz>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown - markup.underline
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                            ^ meta.link.inet.markdown - markup.underline
+|   ^^^ punctuation.separator.path.markdown
+|         ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
+|          ^^ constant.character.escape.url.markdown - punctuation
+|                        ^ punctuation.separator.path.markdown
+
+<a+b+c:d>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|       ^ meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.end.markdown
+
+<made-up-scheme://foo,bar>
+| <- meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inet.markdown markup.underline.link.markdown
+|                        ^ meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.end.markdown
+|              ^^^ punctuation.separator.path.markdown
+
+<http://../>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|          ^ meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.end.markdown
+|    ^^^ punctuation.separator.path.markdown
+|         ^ punctuation.separator.path.markdown
+
+<localhost:5001/foo>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                  ^ meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.end.markdown
+|         ^ punctuation.separator.path.markdown
+|              ^ punctuation.separator.path.markdown
+
+<http://foo.bar/baz bim>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                  ^^^^^^ - meta.link
+|    ^^^ punctuation.separator.path.markdown
+|              ^ punctuation.separator.path.markdown
+
+<http://example.com/\[\>
+| <- meta.link.inet.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link.markdown
+|                      ^ meta.paragraph.markdown meta.link.inet.markdown punctuation.definition.link.end.markdown
+|    ^^^ punctuation.separator.path.markdown
+|                  ^ punctuation.separator.path.markdown
+
+###[ GFM AUTOLINKS ]##########################################################
+
+Visit ftp://intra%20net
+|     ^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|        ^^^ punctuation.separator.path.markdown
+|               ^ - constant
+|                ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
+|                 ^^ constant.character.escape.url.markdown - punctuation
+|                   ^^^ - constant
+
+Visit http://intra%20net
+|     ^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|         ^^^ punctuation.separator.path.markdown
+|                ^ - constant
+|                 ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
+|                  ^^ constant.character.escape.url.markdown - punctuation
+|                    ^^^ - constant
+
+Visit https://intra%20net
+|     ^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|          ^^^ punctuation.separator.path.markdown
+|                 ^ - constant
+|                  ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
+|                   ^^ constant.character.escape.url.markdown - punctuation
+|                     ^^^ - constant
+
+Visit www.intra%20net
+|     ^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|             ^ - constant
+|              ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
+|               ^^ constant.character.escape.url.markdown - punctuation
+|                 ^^^ - constant
 
 Visit www.commonmark.org/help for more information.
 |     ^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                       ^ punctuation.separator.path.markdown
 |                            ^^^^^^^^^^^^^^^^^^^^^^^ - markup.underline.link
+
 Visit www.commonmark.org.
 |     ^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
 |                       ^^ - markup.underline.link
+
 Visit www.commonmark.org/a.b.
 |     ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
 |                           ^ - markup.underline.link
+|                       ^ punctuation.separator.path.markdown
+
 www.google.com/search?q=(business))+ok
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
 |                                     ^ - markup.underline.link
+
 www.google.com/search?q=Markup+(business)
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
+
 www.commonmark.org/he<lp>
 |^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                 ^ punctuation.separator.path.markdown
 |                    ^ - markup.underline.link
+
 http://commonmark.org
 |^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|   ^^^ punctuation.separator.path.markdown
+
 www.google.com/search?q=commonmark&hl=en
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
+|                                 ^ punctuation.separator.path.markdown
 |                                       ^ - markup.underline.link
+
 www.google.com/search?q=commonmark&hl;
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
 |                                 ^^^^ constant.character.entity.named.html - markup.underline.link
+
 (Visit https://encrypted.google.com/search?q=Markup+(business))
 |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|           ^^^ punctuation.separator.path.markdown
+|                                  ^ punctuation.separator.path.markdown
+|                                         ^ punctuation.separator.path.markdown
 |                                                             ^^ - markup.underline.link
+
 Anonymous FTP is available at ftp://foo.bar.baz.
 |                             ^^^^^^^^^^^^^^^^^ markup.underline.link
+|                                ^^^ punctuation.separator.path.markdown
 |                                              ^^ - markup.underline.link
+
 (see http://www.google.com/search?q=commonmark&hl=en)
 |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|        ^^^ punctuation.separator.path.markdown
+|                         ^ punctuation.separator.path.markdown
+|                                ^ punctuation.separator.path.markdown
+|                                             ^ punctuation.separator.path.markdown
 |                                                   ^^ - markup.underline.link
 
+
 foo@bar.baz
-|^^^^^^^^^^ markup.underline.link
+| <- meta.link.email.markdown markup.underline.link.markdown
+|^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+|  ^ punctuation.separator.path.markdown
+|          ^ - meta.link - markup.underline.link
+
 hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.underline.link
-|                                       ^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.link - markup.underline.link
+|                                       ^^^^^^^^^^^^^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+
+ test@test.test.me
+| <- - meta.link - markup.underline
+|^^^^^^^^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+|    ^ punctuation.separator.path.markdown
+|                 ^ - meta.link - markup.underline.link
+
  a.b-c_d@a.b
-|^^^^^^^^^^^ markup.underline.link
-|           ^ - markup.underline.link
+| <- - meta.link - markup.underline
+|^^^^^^^^^^^ meta.link.email.markdown markup.underline.link.markdown
+|       ^ punctuation.separator.path.markdown
+|           ^ - meta.link - markup.underline.link
+
 a.b-c_d@a.b.
 |^^^^^^^^^^ markup.underline.link
 |          ^^ - markup.underline.link
+
  a.b-c_d@a.b-
-|^^^^^^^^^^^^^ - markup.underline.link
+| <- - meta.link - markup.underline
+|^^^^^^^^^^^^^ - meta.link - markup.underline.link
+
  a.b-c_d@a.b_
-|^^^^^^^^^^^^^ - markup.underline.link
- test@test.test.me
-|^^^^^^^^^^^^^^^^^ markup.underline.link
+| <- - meta.link - markup.underline
+|^^^^^^^^^^^^^ - meta.link - markup.underline.link
+
+###[ LIGATURES ]##############################################################
 
 this is a raw ampersand & does not require HTML escaping
 |                       ^ meta.other.valid-ampersand

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -708,8 +708,8 @@ Paragraph break.
 |^^^^^^^ punctuation.definition.thematic-break
 
 [1]: https://google.com
-| <- meta.link.reference.def
-|^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def
+| <- meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
 |^ entity.name.reference.link
 |  ^ punctuation.separator.key-value
 |    ^^^^^^^^^^^^^^^^^^ markup.underline.link
@@ -1066,7 +1066,7 @@ _ _ _ _ _ _ _
 ###[ GFM AUTOLINKS ]##########################################################
 
 Visit ftp://intra%20net
-|     ^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|     ^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |        ^^^ punctuation.separator.path.markdown
 |               ^ - constant
 |                ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
@@ -1074,7 +1074,7 @@ Visit ftp://intra%20net
 |                   ^^^ - constant
 
 Visit http://intra%20net
-|     ^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|     ^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |         ^^^ punctuation.separator.path.markdown
 |                ^ - constant
 |                 ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
@@ -1082,7 +1082,7 @@ Visit http://intra%20net
 |                    ^^^ - constant
 
 Visit https://intra%20net
-|     ^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|     ^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |          ^^^ punctuation.separator.path.markdown
 |                 ^ - constant
 |                  ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
@@ -1090,79 +1090,98 @@ Visit https://intra%20net
 |                     ^^^ - constant
 
 Visit www.intra%20net
-|     ^^^^^^^^^^^^^^^ markup.underline.link.markdown-gfm
+|     ^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |             ^ - constant
 |              ^ constant.character.escape.url.markdown punctuation.definition.escape.markdown
 |               ^^ constant.character.escape.url.markdown - punctuation
 |                 ^^^ - constant
 
 Visit www.commonmark.org/help for more information.
-|     ^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|     ^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |                       ^ punctuation.separator.path.markdown
 |                            ^^^^^^^^^^^^^^^^^^^^^^^ - markup.underline.link
 
 Visit www.commonmark.org.
-|     ^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
+|     ^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inet.markdown markup.underline.link
 |                       ^^ - markup.underline.link
 
 Visit www.commonmark.org/a.b.
-|     ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph markup.underline.link
+|     ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inet.markdown markup.underline.link
 |                           ^ - markup.underline.link
 |                       ^ punctuation.separator.path.markdown
 
 www.google.com/search?q=(business))+ok
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |             ^ punctuation.separator.path.markdown
 |                    ^ punctuation.separator.path.markdown
 |                                     ^ - markup.underline.link
 
 www.google.com/search?q=Markup+(business)
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |             ^ punctuation.separator.path.markdown
 |                    ^ punctuation.separator.path.markdown
 
 www.commonmark.org/he<lp>
-|^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |                 ^ punctuation.separator.path.markdown
 |                    ^ - markup.underline.link
 
 http://commonmark.org
-|^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |   ^^^ punctuation.separator.path.markdown
 
 www.google.com/search?q=commonmark&hl=en
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |             ^ punctuation.separator.path.markdown
 |                    ^ punctuation.separator.path.markdown
 |                                 ^ punctuation.separator.path.markdown
 |                                       ^ - markup.underline.link
 
 www.google.com/search?q=commonmark&hl;
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |             ^ punctuation.separator.path.markdown
 |                    ^ punctuation.separator.path.markdown
 |                                 ^^^^ constant.character.entity.named.html - markup.underline.link
 
+www.google.com/search?q=commonmark&hl;&hl;
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
+|                                 ^^^^^^^^ constant.character.entity.named.html - markup.underline.link
+
+www.google.com/search?q=commonmark&hl;!
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
+|                                 ^^^^^^ - meta.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
+|                                 ^^^^ constant.character.entity.named.html - markup.underline.link
+
+www.google.com/search?q=commonmark&hl;f
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
+|                                      ^ - meta.link
+|             ^ punctuation.separator.path.markdown
+|                    ^ punctuation.separator.path.markdown
+|                                 ^^^^ - constant.character
+
 (Visit https://encrypted.google.com/search?q=Markup+(business))
-|      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |           ^^^ punctuation.separator.path.markdown
 |                                  ^ punctuation.separator.path.markdown
 |                                         ^ punctuation.separator.path.markdown
 |                                                             ^^ - markup.underline.link
 
 Anonymous FTP is available at ftp://foo.bar.baz.
-|                             ^^^^^^^^^^^^^^^^^ markup.underline.link
+|                             ^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |                                ^^^ punctuation.separator.path.markdown
 |                                              ^^ - markup.underline.link
 
 (see http://www.google.com/search?q=commonmark&hl=en)
-|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
 |        ^^^ punctuation.separator.path.markdown
 |                         ^ punctuation.separator.path.markdown
 |                                ^ punctuation.separator.path.markdown
 |                                             ^ punctuation.separator.path.markdown
 |                                                   ^^ - markup.underline.link
-
 
 foo@bar.baz
 | <- meta.link.email.markdown markup.underline.link.markdown
@@ -1239,8 +1258,8 @@ these are raw ligatures - -- --- ---- ----- ===== ==== === == =
 |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
 
 [2]: https://github.com/sublimehq/Packages "Packages Repo"
-| <- meta.link.reference.def
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def
+| <- meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
 |^ entity.name.reference.link
 |  ^ punctuation.separator.key-value
 |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
@@ -1249,8 +1268,8 @@ these are raw ligatures - -- --- ---- ----- ===== ==== === == =
 |                                                        ^ punctuation.definition.string.end
 
 [3]: https://github.com/sublimehq/Packages/issues/ 'Issues on Packages Repo'
-| <- meta.link.reference.def
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def
+| <- meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
 |^ entity.name.reference.link
 |  ^ punctuation.separator.key-value
 |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
@@ -2497,18 +2516,18 @@ _foo [**bar**](/url)_
 |                                                                                                                                          ^ punctuation.definition.metadata.end
 
 [img-example]: http://www.sublimetext.com/anim/rename2_packed.png
-|^^^^^^^^^^^ meta.link.reference.def entity.name.reference.link
+|^^^^^^^^^^^ meta.link.reference.def.markdown entity.name.reference.link
 |            ^ punctuation.separator.key-value
 |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
 |                                                                ^ - meta.link - markup
 
 [//]: # (This is a comment without a line-break.)
-|     ^ meta.link.reference.def markup.underline.link
+|     ^ meta.link.reference.def.markdown markup.underline.link
 |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.other.link.description.title
 |                                                ^ - meta.link
 
 [//]: # (This is a comment with a
-|     ^ meta.link.reference.def markup.underline.link
+|     ^ meta.link.reference.def.markdown markup.underline.link
 |       ^ punctuation.definition.string.begin
         line-break.)
 |                  ^ punctuation.definition.string.end
@@ -2523,11 +2542,11 @@ _foo [**bar**](/url)_
 
 [//]: # (testing
 blah
-| <- meta.link.reference.def string.other.link.description.title
+| <- meta.link.reference.def.markdown string.other.link.description.title
 
 | <- invalid.illegal.non-terminated.link-title
 text
-| <- meta.paragraph - meta.link.reference.def
+| <- meta.paragraph - meta.link.reference.def.markdown
 
 [foo]: <bar> "test" 
 |^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
@@ -2550,16 +2569,16 @@ text
 https://michelf.ca/projects/php-markdown/extra/#footnotes
 That's some text with a footnote.[^1]
 |                                ^^^^ meta.paragraph meta.link.reference.footnote.markdown-extra
-|                                ^^ punctuation.definition.link.begin
-|                                  ^ meta.link.reference.literal.footnote-id
+|                                ^ punctuation.definition.link.begin
+|                                 ^^ meta.link.reference.literal.footnote-id
 |                                   ^ punctuation.definition.link.end
 
  [^1]: And that's the footnote.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
-|^ punctuation.definition.constant.begin
-|   ^ punctuation.definition.constant.end
-| ^^ entity.name.reference.link
-|    ^ punctuation.separator.key-value
+|^ punctuation.definition.reference.begin.markdown
+| ^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
 
 [^1]:
     And that's the footnote.
@@ -3195,11 +3214,11 @@ link with a single underscore inside the text : [@_test](http://example.com)
 |            ^^^^^ - meta.link
 
   [001]: https://en.wikipedia.org/wiki/Root-mean-square_deviation "Wikipedia - RMSE"
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.link.reference.def
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.link.reference.def.markdown
 1. another list item
 
 [foo]: /url "title"
-|^^^^^^^^^^^^^^^^^^ meta.link.reference.def
+|^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
 |    ^ punctuation.separator.key-value
 |      ^^^^ markup.underline.link
 |           ^^^^^^^ string.other.link.description.title
@@ -3209,17 +3228,27 @@ link with a single underscore inside the text : [@_test](http://example.com)
 |^^^ meta.paragraph meta.link.reference
 |   ^ meta.link.reference punctuation.definition.link.end
 
+This is literal [Foo*bar\]] but [ref][Foo*bar\]]
+|               ^^^^^^^^^^^ meta.link.reference.description.markdown
+|               ^ punctuation.definition.link.begin.markdown
+|                ^^^^^^^ string.other.link.title.markdown - constant
+|                       ^^ string.other.link.title.markdown constant.character.escape.markdown
+|                         ^ punctuation.definition.link.end.markdown
+|                               ^^^^^ meta.link.reference.description.markdown
+|                                    ^^^^^^^^^^^ meta.link.reference.metadata.markdown
+
  [Foo*bar\]]:my_(url) 'title (with parens)'
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def
-|^ punctuation.definition.constant.begin
-| ^^^^^^^^^ entity.name.reference.link - punctuation
-|          ^ punctuation.definition.constant.end
-|           ^ punctuation.separator.key-value
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|^ punctuation.definition.reference.begin.markdown
+| ^^^^^^^^^ entity.name.reference.link.markdown - punctuation
+|          ^ punctuation.definition.reference.end.markdown
+|           ^ punctuation.separator.key-value.markdown
 |            ^^^^^^^^ markup.underline.link
+|                    ^ - markup - string
 |                     ^^^^^^^^^^^^^^^^^^^^^ string.other.link.description.title
 
  [foo]: <>
-|^^^^^^^^^ meta.link.reference.def
+|^^^^^^^^^ meta.link.reference.def.markdown
 |     ^ punctuation.separator.key-value
 |       ^ punctuation.definition.link.begin
 |        ^ punctuation.definition.link.end

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -1326,6 +1326,35 @@ escaped backtick \`this is not code\`
 |                                  ^^ constant.character.escape
 |                  ^^^^^^^^^^^^^^^^ - markup.raw.inline
 
+This is a [reference] ()
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^ - meta.link
+
+This is a [reference] (followed by parens)
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a [reference] []
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^ - meta.link
+|                     ^^ meta.link.reference
+
+This is a ![reference] ()
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^ - meta.link
+
+This is a ![reference] (followed by parens)
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a ![reference] []
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^ - meta.link
+|                      ^^ meta.link.reference
+
 http://spec.commonmark.org/0.28/#example-322
 *foo`*`
 |^^^^^^^ markup.italic

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -406,7 +406,7 @@ Fenced codeblocks are no no setext heading
 Paragraph of text that should be scoped as meta.paragraph.
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
 A [link](https://example.com){ :_attr = value }, *italic text* and **bold**.
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
+| ^^^^^^ meta.link.inline.description.markdown
 | ^ punctuation.definition.link.begin
 |      ^ punctuation.definition.link.end
 |       ^ punctuation.definition.metadata
@@ -452,17 +452,33 @@ Here is a [](https://example.com){_attr="value"}.
 |                                       ^^^^^^^ string.quoted.double.markdown
 |                                              ^ punctuation.definition.attributes.end.markdown
 
+Not a [link] (url) due to space.
+|     ^^^^^^ meta.link.reference.description.markdown
+|           ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
 Here is a [reference link][name].
-|         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
-|                         ^ punctuation.definition.constant.begin
-|                          ^^^^ constant.other.reference.link
-|                              ^ punctuation.definition.constant.end
+|         ^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                         ^^^^^^ meta.link.reference.metadata.markdown
+|         ^ punctuation.definition.link.begin.markdown
+|          ^^^^^^^^^^^^^^ string.other.link.title.markdown
+|                        ^ punctuation.definition.link.end.markdown
+|                         ^ punctuation.definition.metadata.begin.markdown
+|                          ^^^^ constant.other.reference.link.markdown
+|                              ^ punctuation.definition.metadata.end.markdown
 
 Here is a [reference link][name]{_attr='value' :att2}.
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
-|                         ^ punctuation.definition.constant.begin
-|                          ^^^^ constant.other.reference.link
-|                              ^ punctuation.definition.constant.end
+|         ^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                         ^^^^^^ meta.link.reference.metadata.markdown
+|                               ^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.attributes.markdown
+|                                ^^^^^^^^^^^^^ meta.attribute-with-value.markdown
+|                                             ^ - meta.attribute-with-value
+|                                              ^^^^^ meta.attribute-with-value.markdown
+|         ^ punctuation.definition.link.begin.markdown
+|          ^^^^^^^^^^^^^^ string.other.link.title.markdown
+|                        ^ punctuation.definition.link.end.markdown
+|                         ^ punctuation.definition.metadata.begin.markdown
+|                          ^^^^ constant.other.reference.link.markdown
+|                              ^ punctuation.definition.metadata.end.markdown
 |                               ^ punctuation.definition.attributes.begin.markdown
 |                                ^^^^^ entity.other.attribute-name.markdown
 |                                     ^ punctuation.separator.key-value.markdown
@@ -471,32 +487,43 @@ Here is a [reference link][name]{_attr='value' :att2}.
 |                                                   ^ punctuation.definition.attributes.end.markdown
 
 Here is a [blank reference link][]{}.
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference
-|                               ^ punctuation.definition.constant.begin
-|                                ^ punctuation.definition.constant.end
+|         ^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.literal.description.markdown
+|                               ^^ meta.link.reference.literal.metadata.markdown
+|                                 ^^ meta.link.reference.literal.attributes.markdown
+|         ^ punctuation.definition.link.begin.markdown
+|          ^^^^^^^^^^^^^^^^^^^^ string.other.link.title.markdown
+|                              ^ punctuation.definition.link.end.markdown
+|                               ^ punctuation.definition.metadata.begin.markdown
+|                                ^ punctuation.definition.metadata.end.markdown
 |                                 ^ punctuation.definition.attributes.begin.markdown
 |                                  ^ punctuation.definition.attributes.end.markdown
 
 Here is a footnote[^1][link][] or long[^longnote][link][].
 |                 ^^^^ meta.link.reference.footnote.markdown-extra
-|                     ^^^^^^^^ meta.link.reference.literal
+|                     ^^^^^^ meta.link.reference.literal.description.markdown
+|                           ^^ meta.link.reference.literal.metadata.markdown
 |                                     ^^^^^^^^^^^ meta.link.reference.footnote.markdown-extra
 |                                                ^^^^^^^^ meta.link.reference.literal
 
 Here is a ![](https://example.com/cat.gif).
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
-|          ^ punctuation.definition.image.begin
-|           ^ punctuation.definition.image.end - string
-|            ^ punctuation.definition.metadata
-|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                                        ^ punctuation.definition.metadata
+|         ^^^ meta.image.inline.description.markdown
+|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline.metadata.markdown
+|                                         ^^ - meta.image
+|         ^^ punctuation.definition.image.begin.markdown
+|           ^ punctuation.definition.image.end.markdown - string
+|            ^ punctuation.definition.metadata.begin.markdown
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                                        ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![](https://example.com/cat.gif){_at"r=value :att2}.
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
-|          ^ punctuation.definition.image.begin
-|           ^ punctuation.definition.image.end - string
-|            ^ punctuation.definition.metadata
-|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|         ^^^ meta.image.inline.description.markdown
+|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline.metadata.markdown
+|                                         ^^^^^^^^^^^^^^^^^^^ meta.image.inline.attributes.markdown
+|                                                            ^^ - meta.image
+|         ^^ punctuation.definition.image.begin.markdown
+|           ^ punctuation.definition.image.end.markdown - string
+|            ^ punctuation.definition.metadata.begin.markdown
+|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
 |                                        ^ punctuation.definition.metadata
 |                                         ^ punctuation.definition.attributes.begin.markdown
 |                                          ^^^^^ entity.other.attribute-name.markdown
@@ -507,25 +534,31 @@ Here is a ![](https://example.com/cat.gif){_at"r=value :att2}.
 |                                                           ^ punctuation.definition.attributes.end.markdown
 
 Here is a ![Image Alt Text](https://example.com/cat.gif).
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
-|          ^ punctuation.definition.image.begin
-|                         ^ punctuation.definition.image.end - string
-|                          ^ punctuation.definition.metadata
-|                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                                                      ^ punctuation.definition.metadata
+|         ^^^^^^^^^^^^^^^^^ meta.image.inline.description.markdown
+|                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline.metadata.markdown
+|                                                       ^^ - meta.image
+|         ^^ punctuation.definition.image.begin.markdown
+|                         ^ punctuation.definition.image.end.markdown - string
+|                          ^ punctuation.definition.metadata.begin.markdown
+|                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                                                      ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![Image Alt Text](  https://example.com/cat.gif  ).
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline
-|          ^ punctuation.definition.image.begin
+|         ^^^^^^^^^^^^^^^^^ meta.image.inline.description.markdown
+|                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.image.inline.metadata.markdown
+|                                                           ^^ - meta.image
+|         ^^ punctuation.definition.image.begin.markdown
 |                         ^ punctuation.definition.image.end - string
-|                          ^ punctuation.definition.metadata
-|                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                                                          ^ punctuation.definition.metadata
+|                          ^ punctuation.definition.metadata.begin.markdown
+|                           ^^ - markup.underline
+|                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                                                        ^^ - markup.underline
+|                                                          ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![Image Alt Text](
   https://example.com/cat.gif  ).
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                              ^ punctuation.definition.metadata
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                              ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![Image Alt Text](
   https://example.com/cat.gif
@@ -536,42 +569,44 @@ Here is a ![Image Alt Text](
 
 Here is a ![Image Alt Text](
   <https://example.com/cat.gif> "hello"   ).
-| ^ punctuation.definition.link.begin
-|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                             ^ punctuation.definition.link.end
-|                               ^^^^^^^ string.other.link.description.title
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
-|                                         ^ punctuation.definition.metadata.end
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.image.inline.metadata.markdown
+|                                          ^^ meta.paragraph.markdown - meta.image
+| ^ punctuation.definition.link.begin.markdown
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                             ^ punctuation.definition.link.end.markdown
+|                               ^^^^^^^ string.other.link.description.title.markdown
+|                               ^ punctuation.definition.string.begin.markdown
+|                                     ^ punctuation.definition.string.end.markdown
+|                                         ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![Image Alt Text](
   <https://example .com /cat.gif> (hello)   ).
-| ^ punctuation.definition.link.begin
-|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
-|                 ^ invalid.illegal.unexpected-whitespace
-|                      ^ invalid.illegal.unexpected-whitespace
-|                               ^ punctuation.definition.link.end
-|                                 ^^^^^^^ string.other.link.description.title
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
-|                                           ^ punctuation.definition.metadata.end
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.image.inline.metadata.markdown
+|                                            ^^ meta.paragraph.markdown - meta.image
+| ^ punctuation.definition.link.begin.markdown
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                               ^ punctuation.definition.link.end.markdown
+|                                 ^^^^^^^ string.other.link.description.title.markdown
+|                                 ^ punctuation.definition.string.begin.markdown
+|                                       ^ punctuation.definition.string.end.markdown
+|                                           ^ punctuation.definition.metadata.end.markdown
 
 Here is a ![Image Alt Text](
   https://example .com /cat.gif (hello)   ).
-| ^^^^^^^^^^^^^^^ markup.underline.link.image
-|                ^ invalid.illegal.unexpected-whitespace
-|                 ^^^^ markup.underline.link.image
-|                     ^ invalid.illegal.unexpected-whitespace
-|                      ^^^^^^^^ markup.underline.link.image
-|                               ^^^^^^^ string.other.link.description.title
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.image.inline
-|                                         ^ punctuation.definition.metadata.end
+|^ meta.paragraph.markdown meta.image.inline.metadata.markdown - markup.underline
+| ^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.image.inline.metadata.markdown markup.underline.link.markdown
+|                ^ meta.paragraph.markdown meta.image.inline.metadata.markdown - markup.underline
+|                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.image - markup.underline
 
 Here is a ![Image Ref Alt][1].
-|         ^^^^^^^^^^^^^^^^^^^ meta.image.reference
-|         ^^ punctuation.definition.image.begin
-|                        ^ punctuation.definition.image.end
-|                         ^ punctuation.definition.constant
-|                          ^ constant.other.reference.link
-|                           ^ punctuation.definition.constant
+|         ^^^^^^^^^^^^^^^^ meta.image.reference.description.markdown
+|                         ^^^ meta.image.reference.metadata.markdown
+|         ^^ punctuation.definition.image.begin.markdown
+|           ^^^^^^^^^^^^^ string.other.link.title.markdown
+|                        ^ punctuation.definition.image.end.markdown
+|                         ^ punctuation.definition.metadata.begin.markdown
+|                          ^ constant.other.reference.link.markdown
+|                           ^ punctuation.definition.metadata.end.markdown
 
 now you can access the [The Ever Cool Site: Documentation about Sites](
   www.thecoolsite.com.ca/documentations/about/cool ) for more information about...
@@ -581,12 +616,9 @@ now you can access the [The Ever Cool Site: Documentation about Sites](
 
 now you can access the [The Ever Cool Site: Documentation about Sites](
   www.thecoolsite.com.ca /documentations/about/cool ) for more information about...
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inline
-| ^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                       ^ invalid.illegal.unexpected-whitespace
-|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                                                  ^ - invalid
-|                                                   ^ punctuation.definition.metadata.end
+| ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inline markup.underline.link
+|                       ^ meta.paragraph meta.link.inline - markup.underline.link
+|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.link.inline
 
 now you can access the [The Ever Cool Site: Documentation about Sites](
   www.thecoolsite.com.ca/documentations/about/cool
@@ -1215,7 +1247,7 @@ because it doesn't begin with the number one:
 |               ^^^^^^^^^^^^^ meta.image.inline.description
 |                            ^ punctuation.definition.image.end
 |                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
 |                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
 |                                                           ^ punctuation.definition.string.begin
 |                                                                           ^ punctuation.definition.string.end
@@ -1226,7 +1258,7 @@ because it doesn't begin with the number one:
 |               ^^^^^^^^^^^^^ meta.image.inline.description
 |                            ^ punctuation.definition.image.end
 |                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
 |                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
 |                                                           ^ punctuation.definition.string.begin
 |                                                                           ^ punctuation.definition.string.end
@@ -1237,7 +1269,7 @@ because it doesn't begin with the number one:
 |               ^^^^^^^^^^^^^ meta.image.inline.description
 |                            ^ punctuation.definition.image.end
 |                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
 |                                                           ^^^^^^^^^^^^^^^^^ string.other.link.description.title
 |                                                           ^ punctuation.definition.string.begin
 |                                                                           ^ punctuation.definition.string.end
@@ -2294,7 +2326,7 @@ _foo [**bar**](/url)_
 [![Cool ★ Image - Click to Enlarge](http://www.sublimetext.com/anim/rename2_packed.png)](http://www.sublimetext.com/anim/rename2_packed.png)
 |^ punctuation.definition.image.begin
 |                                  ^ punctuation.definition.metadata.begin
-|                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image
+|                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
 |                                                                                     ^ punctuation.definition.metadata.end
 |                                                                                       ^ punctuation.definition.metadata.begin
 |                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
@@ -3058,16 +3090,12 @@ Additional {++[Link](https://foo.bar)++} and {++![Image](images/image.png)++}.
 |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.critic.addition.markdown
 |                                                                            ^^ - markup.critic
 |          ^^^ punctuation.definition.critic.begin.markdown
-|             ^ meta.link.inline.markdown punctuation.definition.link.begin.markdown 
-|              ^^^^ meta.link.inline.description.markdown
-|                  ^ meta.link.inline.markdown punctuation.definition.link.end.markdown
-|                   ^^^^^^^^^^^^^^^^^ meta.link.inline.markdown
+|             ^^^^^^ meta.link.inline.description.markdown
+|                   ^^^^^^^^^^^^^^^^^ meta.link.inline.metadata.markdown
 |                                    ^^^ punctuation.definition.critic.end.markdown
 |                                            ^^^ punctuation.definition.critic.begin.markdown
-|                                               ^^ meta.image.inline.markdown punctuation.definition.image.begin.markdown
-|                                                 ^^^^^ meta.image.inline.description.markdown
-|                                                      ^ meta.image.inline.markdown punctuation.definition.image.end.markdown
-|                                                       ^^^^^^^^^^^^^^^^^^ meta.image.inline.markdown
+|                                               ^^^^^^^^ meta.image.inline.description.markdown
+|                                                       ^^^^^^^^^^^^^^^^^^ meta.image.inline.metadata.markdown
 |                                                                         ^^^ punctuation.definition.critic.end.markdown
 
 This is a {-- deletion --} and {~~substitute~>with~~striked~~text~~} or {~~~~old~~~>~~new~~~~}.
@@ -3115,6 +3143,7 @@ This is an {== information ==}{>> comment <<}.
 |                                            ^^ - markup.critic
 
 This is a [[wiki link]].
-|         ^^ meta.link.reference.wiki.markdown punctuation.definition.link.begin.markdown
-|           ^^^^^^^^^ meta.link.reference.wiki.description.markdown - punctuation
-|                    ^^ meta.link.reference.wiki.markdown punctuation.definition.link.end.markdown
+|         ^^^^^^^^^^^^^ meta.link.reference.wiki.description.markdown
+|         ^^ punctuation.definition.link.begin.markdown
+|           ^^^^^^^^^ string.other.link.title.markdown
+|                    ^^ punctuation.definition.link.end.markdown

--- a/tests/test_insert_task_list_item.py
+++ b/tests/test_insert_task_list_item.py
@@ -1,0 +1,79 @@
+from MarkdownEditing.tests import DereferrablePanelTestCase
+
+
+class InsertTaskListItemTestCase(DereferrablePanelTestCase):
+
+    def setUp(self):
+        self.setText("")
+
+    def test_insert_unaligned_task_with_asterisk(self):
+        self.view.settings().set("mde.list_align_text", False)
+        self.view.settings().set("mde.list_indent_bullets", ["*", "-", "+"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            * [ ]\x20
+            """
+        )
+
+    def test_insert_unaligned_task_with_minus(self):
+        self.view.settings().set("mde.list_align_text", False)
+        self.view.settings().set("mde.list_indent_bullets", ["-", "*", "+"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            - [ ]\x20
+            """
+        )
+
+    def test_insert_unaligned_task_with_minus(self):
+        self.view.settings().set("mde.list_align_text", False)
+        self.view.settings().set("mde.list_indent_bullets", ["+", "-", "*"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            + [ ]\x20
+            """
+        )
+
+    def test_insert_aligned_task_with_asterisk(self):
+        self.view.settings().set("mde.list_align_text", True)
+        self.view.settings().set("mde.list_indent_bullets", ["*", "-", "+"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            * [ ]\t
+            """
+        )
+
+    def test_insert_aligned_task_with_minus(self):
+        self.view.settings().set("mde.list_align_text", True)
+        self.view.settings().set("mde.list_indent_bullets", ["-", "*", "+"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            - [ ]\t
+            """
+        )
+
+    def test_insert_aligned_task_with_minus(self):
+        self.view.settings().set("mde.list_align_text", True)
+        self.view.settings().set("mde.list_indent_bullets", ["+", "-", "*"])
+
+        self.setCaretTo(1, 1)
+        self.view.run_command("mde_insert_task_list_item")
+        self.assertEqualBlockText(
+            """
+            + [ ]\t
+            """
+        )


### PR DESCRIPTION
## Bug Fixes

* Tweak auto link folding selector (fixes #624)
* Use correct selector for open page key binding (fixes #629)
* Restore Goto Link Reference/Definition functionality (fixes #632)
* Refactor image/link/reference syntax definitions (fixes #633)
* Don't hide inline code-span punctuation im Mariana/Monokai (fixes #633)
* Resolve key binding conflicts (fixes #634)
* Don't move caret to beginning of word after changing formatting (fixes #636)
* Adding task via `alt+t` respects `mde.list_indent_bullets` setting (fixes #636)
* Bootstrapper reassigns Markdown syntaxes from any location
* Remove obsolete keymap selectors (required due to recent syntax changes)
* Add a macro to unbold bold italc text (required due to recent syntax changes)
* Only strip whitespace separated trailing hashes of headings from symbol lists
* Scope inet/email autolinks according to CommonMark 0.30.0

## New Features

* Scope path separators and escapes in urls
* Support fish fenced code (if supported syntax is installed)
* Partially support xonsh fenced code (use Python syntax due to a lack of xonsh syntax support in ST)
