### PR TITLE
Fix bug parsing nested scopes

### DIFF
--- a/plugins/references.py
+++ b/plugins/references.py
@@ -113,13 +113,17 @@ def isMarkerDefined(view, name):
 
 def getCurrentScopeRegion(view, pt):
     """Extend the region under current scope."""
-    scope = view.scope_name(pt)
+    orig_scope = set(view.scope_name(pt).split())
+    cur_scope = set(view.scope_name(pt).split())
     start = pt
-    while start > 0 and view.scope_name(start - 1).startswith(scope):
+    while start > 0 and orig_scope.issubset(cur_scope):
         start -= 1
+        cur_scope = set(view.scope_name(start - 1).split())
+    cur_scope = orig_scope
     end = pt
-    while end < view.size() and view.scope_name(end).startswith(scope):
+    while end < view.size() and orig_scope.issubset(cur_scope):
         end += 1
+        cur_scope = set(view.scope_name(end).split())
     return sublime.Region(start, end)
 
 

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -115,10 +115,10 @@ def getCurrentScopeRegion(view, pt):
     """Extend the region under current scope."""
     scope = view.scope_name(pt)
     start = pt
-    while start > 0 and view.scope_name(start - 1) == scope:
+    while start > 0 and view.scope_name(start - 1).startswith(scope):
         start -= 1
     end = pt
-    while end < view.size() and view.scope_name(end) == scope:
+    while end < view.size() and view.scope_name(end).startswith(scope):
         end += 1
     return sublime.Region(start, end)
 


### PR DESCRIPTION
**Bug:**
`getCurrentScopeRegion` prematurely ends the region when any part of the scope changes, even if the main scope is the same.

**Example:**
Selecting the full scope region of a link will always return `https` and not the full link. This is because the scope at the beginning of the link is 
`{'meta.link.reference.def.markdown', 'text.html.markdown.multimarkdown', 'markup.underline.link.markdown'}`
but the scope at the colon in the protocol becomes 
`{'text.html.markdown.multimarkdown', 'meta.link.reference.def.markdown', 'markup.underline.link.markdown', 'punctuation.separator.path.markdown'}`
which is not strictly equal and thus ends the expansion prematurely.

**Fix:**
Treat the scope string as a set of scopes and continue expanding the selection until the original set of scopes is no longer a subset of the current set of scopes.
