### PR TITLE
No ref name clobber

### DIFF
--- a/messages/3.1.1.md
+++ b/messages/3.1.1.md
@@ -13,6 +13,7 @@ feedback you can use [GitHub issues][issues].
 * fix CommonMark compatibility of indented code blocks (mixed tabs/spaces)
 * fix CommonMark compatibility of reference definitions
 * fix CommonMark compatibility of thematic breaks
+* fix `mde_convert_inline_link_to_reference` producing duplicate definitions (fixes #559)
 * update strikethough markup to use 2 tildes (fixes #637)
 * restore link/image/reference description colors for Mariana/Monokai (fixes #670)
 * fix strikethrough colors in Monokai/Mariana (fixes #678)

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -87,12 +87,12 @@ def getMarkers(view, name=""):
 
 
 def find_by_selector_in_regions(view, regions, selector):
-    def _gen():
-        for sel in view.find_by_selector(selector):
-            if any(s.intersects(sel) for s in regions):
-                yield sel
+    selectors = []
+    for sel in view.find_by_selector(selector):
+        if any(s.intersects(sel) for s in regions):
+            selectors.append(sel)
 
-    return list(_gen())
+    return selectors
 
 
 def getReferences2(view):

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -22,6 +22,7 @@ import urllib.parse
 
 from .view import MdeTextCommand
 from .view import MdeViewEventListener
+from .view import find_by_selector_in_regions
 
 refname_scope_name = "entity.name.reference.link.markdown"
 definition_scope_name = "meta.link.reference.def.markdown"
@@ -84,15 +85,6 @@ def getMarkers(view, name=""):
         else:
             ids[key] = Obj(regions=[reg], label=name)
     return ids
-
-
-def find_by_selector_in_regions(view, regions, selector):
-    selectors = []
-    for sel in view.find_by_selector(selector):
-        if any(s.intersects(sel) for s in regions):
-            selectors.append(sel)
-
-    return selectors
 
 
 def getReferences2(view):
@@ -324,7 +316,16 @@ def append_reference_link(edit, view, name, url):
 
 
 def suggest_default_link_name(name, link, image):
-    """Suggest default link name in camel case."""
+    """Suggest default link name in camel case, if `name` is small.
+
+    Args:
+        name (str): An existing name, used as a fallback
+        link (str): The link href
+        image (bool): Whether the link points to an image or not. Used for fallback.
+
+    Returns:
+        str: A suggested reference name in CamelCase, or `name`.
+    """
     ret = ""
     # string.punctuation minus -.:;<=>_
     no_punctuation = str.maketrans("", "", "!\"#$%&'()*+,/?@[\\]^`{|}~")

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -722,15 +722,20 @@ def convert2ref(view, edit, link_span, name, omit_name=False):
     view.show_at_center(link_span)
 
 
-    if isMarkerDefined(view, name):
-        print("inserted def for", name, "which existed")
-
-    _viewsize = view.size()
-    view.insert(edit, _viewsize, "[%s]: %s\n" % (name, link))
-    reference_span = sublime.Region(_viewsize + 1, _viewsize + 1 + len(name))
-    view.sel().add(reference_span)
+    link_for_name = getReferences2(view).get(name)
+    if link_for_name:
+        if link_for_name != link:
+            raise Exception("Tried to insert a different link with the same name")
+        else:
+            # Skip insertion (no need, name already exists with same link)
+            return 0  # No insertion, no offset.
+    else:
+        _viewsize = view.size()
+        view.insert(edit, _viewsize, "[%s]: %s\n" % (name, link))
+        reference_span = sublime.Region(_viewsize + 1, _viewsize + 1 + len(name))
+        view.sel().add(reference_span)
     
-    return offset
+        return offset
 
 
 class MdeConvertInlineLinkToReferenceCommand(MdeTextCommand):

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -93,13 +93,14 @@ def getReferences2(view):
     Returns:
         dict: {name: link} mapping
     """
+    pattern = re.compile(r"\[(.+)\]:\s+(?:<([^>]+)>|(\S+))", re.MULTILINE)
+
     ret = {}
     for definition_line in view.find_by_selector(definition_scope_name):
-        raw_text = view.substr(definition_line)
-        for reference_def in re.finditer(r"\[(.+)\]: (.+)", raw_text):
-            name, link = reference_def.groups()
+        for reference_def in pattern.finditer(view.substr(definition_line)):
+            name, angled_link, unquoted_link = reference_def.groups()
             assert not ret.get(name)
-            ret[name] = link
+            ret[name] = angled_link or unquoted_link
     return ret
 
 

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -89,6 +89,7 @@ def getMarkers(view, name=""):
 
 def getReferences2(view):
     """Get a dictionary of all references in the document.
+    Only includes real references with scope definition_scope_name, not footnotes.
 
     Returns:
         dict: {name: link} mapping
@@ -420,13 +421,13 @@ class MdeReferenceNewImageCommand(MdeTextCommand):
 
 def get_next_footnote_marker(view):
     """Get the number of the next footnote."""
-    refs = getReferences2(view)
+    refs = getReferences(view)
 
     footnotes = []
-    for refname in refs.keys():
-        if refname[0] == "^":
+    for ref in refs:
+        if ref[0] == "^":
             try:
-                footnotes.append(int(refname[1:]))
+                footnotes.append(int(ref[1:]))
             except ValueError:
                 pass
 

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -22,7 +22,6 @@ import urllib.parse
 
 from .view import MdeTextCommand
 from .view import MdeViewEventListener
-from .view import find_by_selector_in_regions
 
 refname_scope_name = "entity.name.reference.link.markdown"
 definition_scope_name = "meta.link.reference.def.markdown"

--- a/plugins/references.py
+++ b/plugins/references.py
@@ -95,16 +95,11 @@ def getReferences2(view):
     """
     ret = {}
     for definition_line in view.find_by_selector(definition_scope_name):
-
-        def substr(scope, i):
-            return list(
-                map(view.substr, find_by_selector_in_regions(view, [definition_line], scope))
-            )[i]
-
-        name = substr("entity.name.reference.link.markdown", 0)
-        link = substr("markup.underline.link", -1)
-        assert not ret.get(name)
-        ret[name] = link
+        raw_text = view.substr(definition_line)
+        for reference_def in re.finditer(r"\[(.+)\]: (.+)", raw_text):
+            name, link = reference_def.groups()
+            assert not ret.get(name)
+            ret[name] = link
     return ret
 
 
@@ -759,7 +754,7 @@ class MdeConvertInlineLinkToReferenceCommand(MdeTextCommand):
     def run(self, edit, name=None):
         """Run command callback."""
         view = self.view
-        pattern = r"\[([^\]]+)\]\((?!#)([^\)]+)\)"
+        re_link_or_embed = r"\[([^\]]+)\]\((?!#)([^\)]+)\)"
 
         # Remove all whitespace at the end of the file
         whitespace_at_end = view.find(r"\s*\z", 0)
@@ -779,7 +774,7 @@ class MdeConvertInlineLinkToReferenceCommand(MdeTextCommand):
             start = findScopeFrom(view, sel.b, marker_begin_scope_name, backwards=True)
             end = findScopeFrom(view, sel.b, marker_end_scope_name) + 1
             text = view.substr(sublime.Region(start, end))
-            m = re.match(pattern, text)
+            m = re.match(re_link_or_embed, text)
             if m is None:
                 continue
             text = m.group(1)
@@ -791,6 +786,7 @@ class MdeConvertInlineLinkToReferenceCommand(MdeTextCommand):
                 continue
             # Set name based on link.
             # If link already exists, reuse existing reference
+            name = None
             if names_by_link.get(link):
                 name = names_by_link.get(link)
             else:
@@ -810,9 +806,9 @@ class MdeConvertInlineLinkToReferenceCommand(MdeTextCommand):
             names_by_link[link] = name
 
         offset = 0
-        for link_span in link_spans:
-            _link_span = sublime.Region(link_span[0].a + offset, link_span[0].b + offset)
-            offset -= convert2ref(view, edit, _link_span, link_span[1], link_span[2])
+        for span, name, name_is_text in link_spans:
+            _link_span = sublime.Region(span.a + offset, span.b + offset)
+            offset -= convert2ref(view, edit, _link_span, name, name_is_text)
 
 
 class MdeConvertInlineLinksToReferencesCommand(MdeTextCommand):

--- a/plugins/view.py
+++ b/plugins/view.py
@@ -107,3 +107,12 @@ class MdeCenteredLineKeeper(MdeViewEventListener):
         if self.current_line != current_line:
             self.current_line = current_line
             self.view.show_at_center(pt)
+
+
+def find_by_selector_in_regions(view, regions, selector):
+    selectors = []
+    for sel in view.find_by_selector(selector):
+        if any(s.intersects(sel) for s in regions):
+            selectors.append(sel)
+
+    return selectors

--- a/tests/test_convert_inline_link_to_reference.py
+++ b/tests/test_convert_inline_link_to_reference.py
@@ -422,3 +422,25 @@ class TestConvertInlineLinkToReferenceReuseExistingDefinitions(DereferrablePanel
             >     [GitHub]: https://github.com
             """
         )
+
+    def test_reuse_definition_but_create_new_for_differnt_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com/user) link.
+            Third [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com
+            """
+        )
+        self.view.run_command("mde_convert_inline_links_to_references")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][GitHub2] link.
+            Third [GitHub][] link.
+
+            [GitHub]: https://github.com
+            [GitHub2]: https://github.com/user
+            """
+        )

--- a/tests/test_convert_inline_link_to_reference.py
+++ b/tests/test_convert_inline_link_to_reference.py
@@ -108,3 +108,317 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
             [Issues]: https://github.com/user/repo/issues
             """
         )
+
+
+class TestConvertInlineLinkToReferenceReuseExistingDefinitions(DereferrablePanelTestCase):
+    def test_reuse_indented_definition(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+               [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+               [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_with_multiple_spaces(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:       https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:       https://github.com
+            """
+        )
+
+    def test_reuse_multiline_definition(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+            """
+        )
+
+    def test_reuse_definition_with_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: https://github.com "the page description"
+            """
+        )
+
+    def test_reuse_multiline_definition_with_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+                "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+                "the page description"
+            """
+        )
+
+    def test_reuse_definition_with_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: https://github.com (the page description)
+            """
+        )
+
+    def test_reuse_multiline_definition_with_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+                (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+                (the page description)
+            """
+        )
+
+    def test_reuse_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com>
+            """
+        )
+
+    def test_reuse_indended_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+               [GitHub]:    <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+               [GitHub]:    <https://github.com>
+            """
+        )
+
+    def test_reuse_multiline_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+            <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+            <https://github.com>
+            """
+        )
+
+    def test_reuse_definition_with_angled_url_and_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com> "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com> "the page description"
+            """
+        )
+
+    def test_reuse_definition_with_angled_url_and_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com> (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com> (the page description)
+            """
+        )
+
+    def test_reuse_definition_in_blockquote(self):
+        self.setBlockText(
+            """
+            > First [GitHub][] link.
+            > Second [GitHub](https://github.com) link.
+            >
+            > [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 12)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            > First [GitHub][] link.
+            > Second [GitHub][] link.
+            >
+            > [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_in_listitem(self):
+        self.setBlockText(
+            """
+            - First [GitHub][] link.
+              - Second [GitHub](https://github.com) link.
+
+                [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 15)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            - First [GitHub][] link.
+              - Second [GitHub][] link.
+
+                [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_quoted_in_listitem(self):
+        self.setBlockText(
+            """
+            > - First [GitHub][] link.
+            >   - Second [GitHub](https://github.com) link.
+            >
+            >     [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 15)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            > - First [GitHub][] link.
+            >   - Second [GitHub][] link.
+            >
+            >     [GitHub]: https://github.com
+            """
+        )

--- a/tests/test_convert_inline_link_to_reference.py
+++ b/tests/test_convert_inline_link_to_reference.py
@@ -2,7 +2,6 @@ from MarkdownEditing.tests import DereferrablePanelTestCase
 
 
 class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
-
     def setUp(self):
         self.setBlockText(
             """
@@ -15,11 +14,11 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
         )
 
     def test_convert_link1_with_caret_in_description(self):
-        self.setCaretTo(3, 10)
+        self.setCaretTo(2, 10)
         self._test_convert_link1()
 
     def test_convert_link1_with_caret_in_url(self):
-        self.setCaretTo(3, 25)
+        self.setCaretTo(2, 25)
         self._test_convert_link1()
 
     def _test_convert_link1(self):
@@ -31,16 +30,17 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
             [Issues](https://github.com/user/repo/issues) go here.
             [GitHub](https://github.com)
             Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
             [GitHub]: https://github.com
             """
         )
 
     def test_convert_link2_with_caret_in_description(self):
-        self.setCaretTo(5, 2)
+        self.setCaretTo(3, 2)
         self._test_convert_link2()
 
     def test_convert_link2_with_caret_in_url(self):
-        self.setCaretTo(5, 9)
+        self.setCaretTo(3, 9)
         self._test_convert_link2()
 
     def _test_convert_link2(self):
@@ -52,16 +52,17 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
             [Issues][] go here.
             [GitHub](https://github.com)
             Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
             [Issues]: https://github.com/user/repo/issues
             """
         )
 
     def test_convert_link3_with_caret_in_description(self):
-        self.setCaretTo(7, 7)
+        self.setCaretTo(4, 7)
         self._test_convert_link3()
 
     def test_convert_link3_with_caret_in_url(self):
-        self.setCaretTo(7, 27)
+        self.setCaretTo(4, 27)
         self._test_convert_link3()
 
     def _test_convert_link3(self):
@@ -73,20 +74,28 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
             [Issues](https://github.com/user/repo/issues) go here.
             [GitHub][]
             Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
             [GitHub]: https://github.com
             """
         )
 
     def test_convert_link1_to_3(self):
-        self.setCaretTo(3, 10)
+        self.setCaretTo(2, 10)
         self.view.run_command("mde_convert_inline_link_to_reference")
-        self.setCaretTo(5, 2)
+        self.setCaretTo(3, 2)
         self.view.run_command("mde_convert_inline_link_to_reference")
-        self.setCaretTo(7, 7)
+        self.setCaretTo(4, 7)
         self.view.run_command("mde_convert_inline_link_to_reference")
         # try to convert image
-        self.setCaretTo(9, 50)
+        self.setCaretTo(5, 50)
         self.view.run_command("mde_convert_inline_link_to_reference")
+        self._test_convert_all()
+
+    def test_convert_all(self):
+        self.view.run_command("mde_convert_inline_links_to_references")
+        self._test_convert_all()
+
+    def _test_convert_all(self):
         self.assertEqualBlockText(
             """
             # Test 1
@@ -94,6 +103,7 @@ class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
             [Issues][] go here.
             [GitHub][]
             Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
             [GitHub]: https://github.com
             [Issues]: https://github.com/user/repo/issues
             """

--- a/tests/test_convert_inline_link_to_reference.py
+++ b/tests/test_convert_inline_link_to_reference.py
@@ -1,0 +1,100 @@
+from MarkdownEditing.tests import DereferrablePanelTestCase
+
+
+class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
+
+    def setUp(self):
+        self.setBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            """
+        )
+
+    def test_convert_link1_with_caret_in_description(self):
+        self.setCaretTo(3, 10)
+        self._test_convert_link1()
+
+    def test_convert_link1_with_caret_in_url(self):
+        self.setCaretTo(3, 25)
+        self._test_convert_link1()
+
+    def _test_convert_link1(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub][] inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            [GitHub]: https://github.com
+            """
+        )
+
+    def test_convert_link2_with_caret_in_description(self):
+        self.setCaretTo(5, 2)
+        self._test_convert_link2()
+
+    def test_convert_link2_with_caret_in_url(self):
+        self.setCaretTo(5, 9)
+        self._test_convert_link2()
+
+    def _test_convert_link2(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues][] go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            [Issues]: https://github.com/user/repo/issues
+            """
+        )
+
+    def test_convert_link3_with_caret_in_description(self):
+        self.setCaretTo(7, 7)
+        self._test_convert_link3()
+
+    def test_convert_link3_with_caret_in_url(self):
+        self.setCaretTo(7, 27)
+        self._test_convert_link3()
+
+    def _test_convert_link3(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub][]
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            [GitHub]: https://github.com
+            """
+        )
+
+    def test_convert_link1_to_3(self):
+        self.setCaretTo(3, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.setCaretTo(5, 2)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.setCaretTo(7, 7)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        # try to convert image
+        self.setCaretTo(9, 50)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub][] inline link.
+            [Issues][] go here.
+            [GitHub][]
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            [GitHub]: https://github.com
+            [Issues]: https://github.com/user/repo/issues
+            """
+        )


### PR DESCRIPTION
Fixes multiple bugs pointed out in #559, including

- New references clobbering each other's names
- References failing to find existing references for their link and generating a new name
- Duplicate references with the same links and names being added anyway

Resolves #559