### PR TITLE
add full xonsh support in fenced code blocks

### DIFF
--- a/messages/3.1.1.md
+++ b/messages/3.1.1.md
@@ -1,0 +1,14 @@
+# MarkdownEditing {version} Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+## Changes
+
+* Fully support xonsh fenced code instead of using Python syntax (if supported syntax is installed)
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -1961,7 +1961,7 @@ contexts:
         0: meta.code-fence.definition.begin.xonsh.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.python
+      embed: scope:source.xonsh
       embed_scope: markup.raw.code-fence.xonsh.markdown-gfm
       escape: '{{fenced_code_block_escape}}'
       escape_captures:


### PR DESCRIPTION
replaces source.python with source.xonsh since now there is a dedicated xonsh syntax package

Assumed `3.1.1` as the next version for the messages file since didn't find any new tags suggesting otherwise