### PR TITLE
ST4107-3.1.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,6 @@ Here are the used scopes under 3 different markdown flavors. If you are not sure
 * punctuation.definition.string.end.markdown
 * punctuation.definition.string.markdown
 * punctuation.separator.key-value.markdown
-* string.other.link.description.markdown
-* string.other.link.description.title.markdown
-* string.other.link.title.markdown
 
 ### ScopeName: text.html.markdown.gfm
 
@@ -168,9 +165,6 @@ Here are the used scopes under 3 different markdown flavors. If you are not sure
 * __punctuation.definition.tag.begin.html__
 * __punctuation.definition.tag.end.html__
 * punctuation.separator.key-value.markdown
-* string.other.link.description.markdown
-* string.other.link.description.title.markdown
-* string.other.link.title.markdown
 
 ### ScopeName: text.html.markdown.multimarkdown
 

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1188,7 +1188,7 @@
 	// jump to reference
 	{ "keys": ["f12"], "command": "mde_reference_jump", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference string.other.link", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference", "match_all": true }
 		]
 	},
 	{ "keys": ["shift+f12"], "command": "mde_reference_jump", "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1188,7 +1188,7 @@
 	// jump to reference
 	{ "keys": ["f12"], "command": "mde_reference_jump", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference string.other.link", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference", "match_all": true }
 		]
 	},
 	{ "keys": ["shift+f12"], "command": "mde_reference_jump", "context":
@@ -1379,31 +1379,31 @@
 	// Wiki
 	//
 
-	{ "keys": ["super+shift+h"], "command": "mde_open_home_page", "context":
+	{ "keys": ["super+alt+h"], "command": "mde_open_home_page", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_home_page", "operator": "not_equal", "operand": true }
 		]
 	},
-	{ "keys": ["super+shift+d"], "command": "mde_open_page", "context":
+	{ "keys": ["super+alt+d"], "command": "mde_open_page", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "meta.link.reference.wiki.description.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_page", "operator": "not_equal", "operand": true }
 		]
 	},
-	{ "keys": ["super+shift+d"], "command": "mde_make_page_reference", "context":
+	{ "keys": ["super+alt+d"], "command": "mde_make_page_reference", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - (meta.link | markup.underline.link)", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.make_page_reference", "operator": "not_equal", "operand": true }
 		]
 	},
-	{ "keys": ["super+shift+x"], "command": "mde_list_back_links", "context":
+	{ "keys": ["super+alt+x"], "command": "mde_list_back_links", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.list_back_links", "operator": "not_equal", "operand": true }
 		]
 	},
-	{ "keys": ["super+shift+j"], "command": "mde_open_journal", "context":
+	{ "keys": ["super+alt+j"], "command": "mde_open_journal", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.open_journal", "operator": "not_equal", "operand": true }

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1188,7 +1188,7 @@
 	// jump to reference
 	{ "keys": ["f12"], "command": "mde_reference_jump", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference string.other.link", "match_all": true }
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown meta.link.reference", "match_all": true }
 		]
 	},
 	{ "keys": ["shift+f12"], "command": "mde_reference_jump", "context":

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -40,6 +40,16 @@
 	// Adds <Tab> after list items instead of a single <space>.
 	"mde.list_align_text": false,
 
+	// MarkdownEditing (References):
+	// The sorting method used by the Organize References command.
+	// Should be one of
+	//
+	// "reference_order": List in order of appearance in document
+	// "alphabetical": Alphabetical based on reference name, sorting numerals lexagraphically
+	// "numeric": Alphabetical based on reference name, sorting numeral chunks numerically
+	"mde.ref_organize_sort": "reference_order",
+	"mde.ref_organize_sort_reverse": false,
+
 	// MarkdownEditing:
 	// Automatically switches list bullet when indenting blank list item with <Tab>.
 	"mde.list_indent_auto_switch_bullet": true,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ To clean up or restore syntax specific settings...
    a) To clean up, remove no longer needed overrides.  
    b) To restore, paste desired settings from following code block.
 
-```json
+```jsonc
 {
     "color_scheme": "MarkdownEditor.sublime-color-scheme",
     "tab_size": 4,
@@ -126,10 +126,16 @@ When you notice any undesired behaviour introduced by the latest update, your fe
 
 ## Known Bugs
 
-* Setext-style headers (`===` and `---`) do not show up in the symbol list. This is due to a Sublime Text limitation (see [#158][]). However, we are able to put a placeholder to indicate the existence of the header. We encourage you to use Atx-style headers (`#`).
+* Setext-style headers (`===` and `---`) show up in the symbol list of Sublime Text 4 only.  
+  They are not supported by Sublime Text 3 (see [#158][]).
+
+* Indended code block highlighting in list blocks is not supported (see [#663][]).  
+  ST's syntax engine can't count indentation, so reliably highlighting indended code blocks in
+  maybe nested list items is impossible. Use fenced code blocks instead.
 
 * Installing for the first time while having markdown files opened may cause MarkdownEditing to behave unexpectedly on those files. Close and reopen those files to fix it.
 
 [#158]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/158
+[#663]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues/663
 [mdereleases]: https://github.com/SublimeText-Markdown/MarkdownEditing/releases
 [mdeissues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -344,7 +344,9 @@ Lastly the command to open the *home* page is provided, where the home page is j
 
 | Linux/Windows | MacOS | Description
 |---------------|-------|-------------
-| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>H</kbd> | Open home page
-| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>D</kbd> | Open wiki page under the cursor
-| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>J</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>J</kbd> | Open journal page for today
-| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>B</kbd> | List back links
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>H</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>H</kbd> | Open home page
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>D</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>D</kbd> | Open wiki page under the cursor
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>J</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>J</kbd> | Open journal page for today
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>X</kbd> | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>B</kbd> | List back links
+
+_Note: The key bindings are disabled via Preferences by default to prevent conflicts with certain keyboard layouts._

--- a/make.cmd
+++ b/make.cmd
@@ -41,7 +41,7 @@ goto :usage
 
 :LINT
     call :venv
-    black --check .
+    black .
     flake8
     goto :eof
 

--- a/messages.json
+++ b/messages.json
@@ -33,5 +33,7 @@
 	"3.0.4": "messages/3.0.4.md",
 	"3.0.5": "messages/3.0.5.md",
 	"3.0.6": "messages/3.0.6.md",
-	"3.0.7": "messages/3.0.7.md"
+	"3.0.7": "messages/3.0.7.md",
+	"3.1.0": "messages/3.1.0.md",
+	"3.1.1": "messages/3.1.1.md"
 }

--- a/messages/3.1.1.md
+++ b/messages/3.1.1.md
@@ -1,0 +1,14 @@
+# MarkdownEditing 3.1.1 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* fix regression with latex block highlighting in list items
+
+## New Features
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.1.md
+++ b/messages/3.1.1.md
@@ -6,9 +6,30 @@ feedback you can use [GitHub issues][issues].
 ## Bug Fixes
 
 * fix regression with latex block highlighting in list items
+* fix CommonMark compatibility of backslash escapes
+* fix CommonMark compatibility of block quotes
+* fix CommonMark compatibility of html entities
+* fix CommonMark compatibility of fenced code blocks
+* fix CommonMark compatibility of indented code blocks (mixed tabs/spaces)
+* fix CommonMark compatibility of reference definitions
+* fix CommonMark compatibility of thematic breaks
+* fix `mde_convert_inline_link_to_reference` producing duplicate definitions (fixes #559)
+* update strikethough markup to use 2 tildes (fixes #637)
+* restore link/image/reference description colors for Mariana/Monokai (fixes #670)
+* fix strikethrough colors in Monokai/Mariana (fixes #678)
+* fix wiki link bindings and their docs (see #679)
 
 ## New Features
 
+* `Organize References` learned to sort reference definitions using `"mde.ref_organize_sort"` setting
+
 ## Changes
+
+* Fully support xonsh fenced code instead of using Python syntax 
+  (if supported syntax is installed)
+* Removes indended code block highlighting from list blocks (fixes #663)
+  ST's syntax engine can't count indentation, so reliably highlighting
+  indended code blocks in maybe nested list items is impossible.
+  Use fenced code blocks instead.
 
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/plugins/view.py
+++ b/plugins/view.py
@@ -107,3 +107,12 @@ class MdeCenteredLineKeeper(MdeViewEventListener):
         if self.current_line != current_line:
             self.current_line = current_line
             self.view.show_at_center(pt)
+
+
+def find_by_selector_in_regions(view, regions, selector):
+    selectors = []
+    for sel in view.find_by_selector(selector):
+        if any(s.intersects(sel) for s in regions):
+            selectors.append(sel)
+
+    return selectors

--- a/schemes/Mariana.sublime-color-scheme
+++ b/schemes/Mariana.sublime-color-scheme
@@ -10,67 +10,66 @@
 
 		// Basic Formattings
 		{
-			"name": "Bold Content",
+			"name": "Markdown: Bold Content",
 			"scope": "text.html.markdown markup.bold - punctuation.definition.bold",
 			"font_style": "bold"
 		},
 		{
-			"name": "Bold Punctuation",
+			"name": "Markdown: Bold Punctuation",
 			"scope": "text.html.markdown punctuation.definition.bold",
 			"font_style": ""
 		},
 		{
-			"name": "Italic Content",
+			"name": "Markdown: Italic Content",
 			"scope": "text.html.markdown markup.italic - punctuation.definition.italic",
 			"font_style": "italic"
 		},
 		{
-			"name": "Italic Punctuation",
+			"name": "Markdown: Italic Punctuation",
 			"scope": "text.html.markdown punctuation.definition.italic",
 			"font_style": ""
 		},
 		{
-			"name": "Bold Italic Content",
+			"name": "Markdown: Bold Italic Content",
 			"scope": "text.html.markdown markup.bold markup.italic - punctuation.definition.bold - punctuation.definition.italic, text.html.markdown markup.bold_italic - punctuation.definition.bold",
 			"font_style": "bold italic"
 		},
 		{
-			"name": "Underlined Content",
+			"name": "Markdown: Underlined Content",
 			"scope": "text.html.markdown markup.underline",
 			"font_style": "underline"
 		},
 		{
-			"name": "Bold Underlined Content",
+			"name": "Markdown: Bold Underlined Content",
 			"scope": "text.html.markdown & markup.bold & markup.underline - punctuation.definition.bold",
 			"font_style": "bold underline"
 		},
 		{
-			"name": "Italic Underlined Content",
+			"name": "Markdown: Italic Underlined Content",
 			"scope": "text.html.markdown & markup.italic & markup.underline - punctuation.definition.italic",
 			"font_style": "italic underline"
 		},
 		{
-			"name": "Bold Italic Underlined Content",
+			"name": "Markdown: Bold Italic Underlined Content",
 			"scope": "text.html.markdown & markup.bold & markup.italic & markup.underline - punctuation.definition.bold - punctuation.definition.italic",
 			"font_style": "bold underline"
 		},
 		{
-			"name": "Striked Content",
-			"scope": "text.html.markdown markup.strikethrough",
-			"foreground": "var(grey)",
+			"name": "Markdown: Striked Content",
+			"scope": "text.html.markdown markup.strikethrough, text.html.markdown markup.strikethrough string",
+			"foreground": "var(blue4)",
 			"font_style": ""
 		},
 		{
-			"name": "Striked References",
-			"scope": "text.html.markdown markup.strikethrough & (punctuation.definition.constant | punctuation.definition.image | punctuation.definition.link | punctuation.definition.metadata)",
-			"foreground": "var(grey)",
+			"name": "Markdown: Striked Punctuations",
+			"scope": "text.html.markdown markup.strikethrough & (punctuation.definition | punctuation.separator | punctuation.definition.strikethrough | punctuation.definition.constant | punctuation.definition.image | punctuation.definition.link | punctuation.definition.metadata | markup.bold punctuation.definition.bold | markup.italic punctuation.definition.italic | string punctuation.definition.string)",
+			"foreground": "var(blue2)",
 			"font_style": ""
 		},
 		{
-			"name": "Striked Strings",
-			"scope": "text.html.markdown markup.strikethrough string",
-			"foreground": "var(grey)",
-			"font_style": ""
+			"name": "Markdown: Striked URLs",
+			"scope": "text.html.markdown markup.strikethrough & (markup.underline.link.markdown | markup.underline.link.image.markdown)",
+			"foreground": "var(blue4)"
 		},
 		{
 			"name": "Markdown: Hard Line Breaks",
@@ -80,7 +79,7 @@
 
 		// Block Quotes
 		{
-			"name": "Block Quotes",
+			"name": "Markdown: Block Quotes",
 			"scope": "text.html.markdown markup.quote punctuation.definition.blockquote, text.html.markdown markup.quote punctuation.definition.quote",
 			"foreground": "var(blue2)",
 			"background": "var(blue2)"
@@ -88,13 +87,13 @@
 
 		// Code Blocks
 		{
-			"name": "Inline Code Block",
+			"name": "Markdown: Inline Code Block",
 			"scope": "text.html.markdown markup.raw.inline",
 			"foreground": "var(raw_fg)",
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Raw Code Block",
+			"name": "Markdown: Raw Code Block",
 			"scope": "text.html.markdown markup.raw, text.html.markdown meta.code-fence",
 			"foreground": "var(raw_fg)",
 			"background": "var(raw_bg)"
@@ -102,36 +101,41 @@
 
 		// Inline References
 		{
-			"name": "Inline Link URL",
+			"name": "Markdown: Link Description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
+			"foreground": "var(blue)"
+		},
+		{
+			"name": "Markdown: Inline Link URL",
 			"scope": "text.html.markdown meta.link.inline markup.underline.link",
 			"foreground": "var(pink)"
 		},
 
 		// Keyboard Shortcuts
 		{
-			"name": "Keyboard Shortcut Background",
+			"name": "Markdown: Keyboard Shortcut Background",
 			"scope": "text.html.markdown markup.kbd",
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Keyboard Shortcut Tags",
+			"name": "Markdown: Keyboard Shortcut Tags",
 			"scope": "text.html.markdown markup.kbd entity.name.tag, text.html.markdown markup.kbd punctuation.definition.tag",
 			"foreground": "var(raw_fg)"
 		},
 		{
-			"name": "Keyboard Shortcut Content",
+			"name": "Markdown: Keyboard Shortcut Content",
 			"scope": "text.html.markdow markup.kbd.content",
 			"foreground": "var(blue)"
 		},
 
 		// Tables
 		{
-			"name": "Table Separators / Lines",
+			"name": "Markdown: Table Separators / Lines",
 			"scope": "text.html.markdown meta.table.header-separator punctuation.section, text.html.markdown punctuation.section.table-header, text.html.markdown punctuation.separator.table-cell",
 			"foreground": "var(blue4)"
 		},
 		{
-			"name": "Table Cell Content Alignment Operator",
+			"name": "Markdown: Table Cell Content Alignment Operator",
 			"scope": "text.html.markdown meta.table.header-separator punctuation.definition",
 			"foreground": "var(pink)"
 		}

--- a/schemes/MarkdownEditor-ArcDark.sublime-color-scheme
+++ b/schemes/MarkdownEditor-ArcDark.sublime-color-scheme
@@ -257,7 +257,7 @@
 		},
 		{
 			"name": "Markdown: Link Description",
-			"scope": "meta.link.inline.description, meta.link.reference.description, meta.image.reference.description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
 			"foreground": "#5294E2"
 		},
 		{

--- a/schemes/MarkdownEditor-Dark.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Dark.sublime-color-scheme
@@ -264,7 +264,7 @@
 		},
 		{
 			"name": "Markdown: Link Description",
-			"scope": "meta.link.inline.description, meta.link.reference.description, meta.image.reference.description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
 			"foreground": "#cccccc"
 		},
 		{

--- a/schemes/MarkdownEditor-Focus.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Focus.sublime-color-scheme
@@ -286,7 +286,7 @@
 		},
 		{
 			"name": "Markdown: Link Description",
-			"scope": "meta.link.inline.description, meta.link.reference.description, meta.image.reference.description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
 			"foreground": "#333333"
 		},
 		{

--- a/schemes/MarkdownEditor-Yellow.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Yellow.sublime-color-scheme
@@ -263,7 +263,7 @@
 		},
 		{
 			"name": "Markdown: Link Description",
-			"scope": "meta.link.inline.description, meta.link.reference.description, meta.image.reference.description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
 			"foreground": "#533228"
 		},
 		{

--- a/schemes/MarkdownEditor.sublime-color-scheme
+++ b/schemes/MarkdownEditor.sublime-color-scheme
@@ -263,7 +263,7 @@
 		},
 		{
 			"name": "Markdown: Link Description",
-			"scope": "meta.link.inline.description, meta.link.reference.description, meta.image.reference.description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
 			"foreground": "#333333"
 		},
 		{

--- a/schemes/Monokai.sublime-color-scheme
+++ b/schemes/Monokai.sublime-color-scheme
@@ -10,67 +10,66 @@
 
 		// Basic Formattings
 		{
-			"name": "Bold Content",
+			"name": "Markdown: Bold Content",
 			"scope": "text.html.markdown markup.bold - punctuation.definition.bold",
 			"font_style": "bold"
 		},
 		{
-			"name": "Bold Punctuation",
+			"name": "Markdown: Bold Punctuation",
 			"scope": "text.html.markdown punctuation.definition.bold",
 			"font_style": ""
 		},
 		{
-			"name": "Italic Content",
+			"name": "Markdown: Italic Content",
 			"scope": "text.html.markdown markup.italic - punctuation.definition.italic",
 			"font_style": "italic"
 		},
 		{
-			"name": "Italic Punctuation",
+			"name": "Markdown: Italic Punctuation",
 			"scope": "text.html.markdown punctuation.definition.italic",
 			"font_style": ""
 		},
 		{
-			"name": "Bold Italic Content",
+			"name": "Markdown: Bold Italic Content",
 			"scope": "text.html.markdown markup.bold markup.italic - punctuation.definition.bold - punctuation.definition.italic, text.html.markdown markup.bold_italic - punctuation.definition.bold",
 			"font_style": "bold italic"
 		},
 		{
-			"name": "Underlined Content",
+			"name": "Markdown: Underlined Content",
 			"scope": "text.html.markdown markup.underline",
 			"font_style": "underline"
 		},
 		{
-			"name": "Bold Underlined Content",
+			"name": "Markdown: Bold Underlined Content",
 			"scope": "text.html.markdown & markup.bold & markup.underline - punctuation.definition.bold",
 			"font_style": "bold underline"
 		},
 		{
-			"name": "Italic Underlined Content",
+			"name": "Markdown: Italic Underlined Content",
 			"scope": "text.html.markdown & markup.italic & markup.underline - punctuation.definition.italic",
 			"font_style": "italic underline"
 		},
 		{
-			"name": "Bold Italic Underlined Content",
+			"name": "Markdown: Bold Italic Underlined Content",
 			"scope": "text.html.markdown & markup.bold & markup.italic & markup.underline - punctuation.definition.bold - punctuation.definition.italic",
 			"font_style": "bold underline"
 		},
 		{
-			"name": "Striked Content",
-			"scope": "text.html.markdown markup.strikethrough",
+			"name": "Markdown: Striked Content",
+			"scope": "text.html.markdown markup.strikethrough, text.html.markdown markup.strikethrough string",
 			"foreground": "var(grey)",
 			"font_style": ""
 		},
 		{
-			"name": "Striked References",
-			"scope": "text.html.markdown markup.strikethrough & (punctuation.definition.constant | punctuation.definition.image | punctuation.definition.link | punctuation.definition.metadata)",
+			"name": "Markdown: Striked Punctuations",
+			"scope": "text.html.markdown markup.strikethrough & (punctuation.definition | punctuation.separator | punctuation.definition.strikethrough | punctuation.definition.constant | punctuation.definition.image | punctuation.definition.link | punctuation.definition.metadata | punctuation.definition.bold | punctuation.definition.italic | punctuation.definition.string)",
 			"foreground": "var(grey)",
 			"font_style": ""
 		},
 		{
-			"name": "Striked Strings",
-			"scope": "text.html.markdown markup.strikethrough string",
-			"foreground": "var(grey)",
-			"font_style": ""
+			"name": "Markdown: Striked URLs",
+			"scope": "text.html.markdown markup.strikethrough & (markup.underline.link.markdown | markup.underline.link.image.markdown)",
+			"foreground": "var(grey)"
 		},
 		{
 			"name": "Markdown: Hard Line Breaks",
@@ -80,7 +79,7 @@
 
 		// Block Quotes
 		{
-			"name": "Block Quotes",
+			"name": "Markdown: Block Quotes",
 			"scope": "text.html.markdown markup.quote punctuation.definition.blockquote, text.html.markdown markup.quote punctuation.definition.quote",
 			"foreground": "var(grey)",
 			"background": "var(grey)"
@@ -88,13 +87,13 @@
 
 		// Code Blocks
 		{
-			"name": "Inline Code Block",
+			"name": "Markdown: Inline Code Block",
 			"scope": "text.html.markdown markup.raw.inline",
 			"foreground": "var(raw_fg)",
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Raw Code Block",
+			"name": "Markdown: Raw Code Block",
 			"scope": "text.html.markdown markup.raw, text.html.markdown meta.code-fence",
 			"foreground": "var(raw_fg)",
 			"background": "var(raw_bg)"
@@ -102,36 +101,41 @@
 
 		// Inline References
 		{
-			"name": "Inline Link URL",
+			"name": "Markdown: Link Description",
+			"scope": "(meta.image.inline.description.markdown, meta.image.reference.description.markdown, meta.link.inline.description.markdown, meta.link.reference.description.markdown, meta.link.reference.literal.description.markdown, meta.link.reference.wiki.description.markdown) - comment - constant - entity - punctuation - string - markup.strikethrough",
+			"foreground": "var(yellow)"
+		},
+		{
+			"name": "Markdown: Inline Link URL",
 			"scope": "text.html.markdown meta.link.inline markup.underline.link",
 			"foreground": "var(blue)"
 		},
 
 		// Keyboard Shortcuts
 		{
-			"name": "Keyboard Shortcut Background",
+			"name": "Markdown: Keyboard Shortcut Background",
 			"scope": "text.html.markdown markup.kbd",
 			"background": "var(raw_bg)"
 		},
 		{
-			"name": "Keyboard Shortcut Tags",
+			"name": "Markdown: Keyboard Shortcut Tags",
 			"scope": "text.html.markdown markup.kbd entity.name.tag, text.html.markdown markup.kbd punctuation.definition.tag",
 			"foreground": "var(raw_fg)"
 		},
 		{
-			"name": "Keyboard Shortcut Content",
+			"name": "Markdown: Keyboard Shortcut Content",
 			"scope": "text.html.markdow markup.kbd.content",
 			"foreground": "var(blue)"
 		},
 
 		// Tables
 		{
-			"name": "Table Separators / Lines",
+			"name": "Markdown: Table Separators / Lines",
 			"scope": "text.html.markdown meta.table.header-separator punctuation.section, text.html.markdown punctuation.section.table-header, text.html.markdown punctuation.separator.table-cell",
 			"foreground": "var(grey)"
 		},
 		{
-			"name": "Table Cell Content Alignment Operator",
+			"name": "Markdown: Table Cell Content Alignment Operator",
 			"scope": "text.html.markdown meta.table.header-separator punctuation.definition",
 			"foreground": "var(red2)"
 		}

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -19,204 +19,258 @@ file_extensions:
   - markdn
 
 variables:
-    atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
-    atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
-    atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
-    setext_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)            # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
+  atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
+  atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
+  atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
+  setext_escape: ^(?=[ ]{,3}(?:=+|-+)\s*$)            # between 0 and 3 spaces, followed by at least one hyphon or equal sign (setext underline can be of any length)
 
-    block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
-    indented_code_block: (?:[ ]{4}|\t)                  # 4 spaces or a tab
-    list_item: (?:[ ]{,3}(?:\d+[.)]|[*+-])\s)           # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
-    thematic_break: |-
-      (?x:
-        [ ]{,3}                    # between 0 to 3 spaces
-        (?:                        # followed by one of the following:
-          [-](?:[ ]{,2}[-]){2,}    # - a dash,        followed by the following at least twice: between 0 to 2 spaces followed by a dash
-        | [*](?:[ ]{,2}[*]){2,}    # - a star,        followed by the following at least twice: between 0 to 2 spaces followed by a star
-        | [_](?:[ ]{,2}[_]){2,}    # - an underscore, followed by the following at least twice: between 0 to 2 spaces followed by an underscore
-        )
-        [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
-      )
+  block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
+  indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
 
-    backticks: |-
-      (?x:
-        (`{4})(?![\s`])(?:[^`]+(?=`)|(?!`{4})`+(?!`))+(`{4})(?!`)  # 4 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
-      | (`{3})(?![\s`])(?:[^`]+(?=`)|(?!`{3})`+(?!`))+(`{3})(?!`)  # 3 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
-      | (`{2})(?![\s`])(?:[^`]+(?=`)|(?!`{2})`+(?!`))+(`{2})(?!`)  # 2 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
-      | (`{1})(?![\s`])(?:[^`]+(?=`)|(?!`{1})`+(?!`))+(`{1})(?!`)  # 1 backtick,  followed by at least one non whitespace, non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
-      )
-    escape: \\[-`*_#+.!(){}\[\]\\>|~<]
+  first_list_item: (?:[ ]{,3}(?:1[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
+  list_item: (?:[ ]{,3}(?:\d{1,9}[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
 
-    balance_square_brackets: |-
-      (?x:
-        (?:
-          {{escape}}+                       # escape characters
-        | [^\[\]`\\]+(?=[\[\]`\\]|$)        # anything that isn't a square bracket or a backtick or the start of an escape character
-        | {{backticks}}                     # inline code
-        | \[(?:                             # nested square brackets (one level deep)
-            [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
-            {{backticks}}?                  #  balanced backticks
-          )*\]                              #  closing square bracket
-        )+
+  thematic_break: |-
+    (?x:
+      [ ]{,3}                    # between 0 to 3 spaces
+      (?:                        # followed by one of the following:
+        [-](?:[ \t]*[-]){2,}     # - a dash,        followed by the following at least twice: any number of spaces or tabs followed by a dash
+      | [*](?:[ \t]*[*]){2,}     # - a star,        followed by the following at least twice: any number of spaces or tabs followed by a star
+      | [_](?:[ \t]*[_]){2,}     # - an underscore, followed by the following at least twice: any number of spaces or tabs followed by an underscore
       )
-    balance_square_brackets_and_emphasis: |-
-      (?x:
-        (?:
-          {{escape}}+                       # escape characters
-        | [^\[\]`\\_*]+(?=[\[\]`\\_*]|$)    # anything that isn't a square bracket, a backtick, the start of an escape character, or an emphasis character
-        | {{backticks}}                     # inline code
-        | \[(?:                             # nested square brackets (one level deep)
-            [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
-            {{backticks}}?                  #  balanced backticks
-          )*\]                              #  closing square bracket
-        )+                                  # at least one character
-      )
-    balance_square_brackets_pipes_and_emphasis: |-
-      (?x:
-        (?:
-          {{escape}}+                       # escape characters
-        | [^\[\]`\\_*|]+(?=[\[\]`\\_*|]|$)  # anything that isn't a square bracket, a backtick, the start of an escape character, or an emphasis character
-        | {{backticks}}                     # inline code
-        | \[(?:                             # nested square brackets (one level deep)
-            [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
-            {{backticks}}?                  #  balanced backticks
-          )*\]                              #  closing square bracket
-        )+                                  # at least one character
-      )
-    balanced_emphasis: |-
-      (?x:
-        \*  (?!\*){{balance_square_brackets_and_emphasis}}+\*  (?!\*)
-      | \*\*      {{balance_square_brackets_and_emphasis}}+\*\*
-      | _   (?!_) {{balance_square_brackets_and_emphasis}}+_   (?!_)
-      | __        {{balance_square_brackets_and_emphasis}}+__
-      )
+      [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
+    )
 
-    table_cell: |-
-      (?x:
-        # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
-        # emphasis in table cells can't span multiple lines
-        (?:
-          {{balance_square_brackets_pipes_and_emphasis}}
-        | {{balanced_emphasis}}
-        )+  # at least one character
-      )
-    table_first_row: |-
-      (?x:
-        # at least 2 non-escaped pipe chars on the line
-        (?:{{table_cell}}?\|){2}
+  backticks: |-
+    (?x:
+      (`{4})(?![\s`])(?:[^`]+(?=`)|(?!`{4})`+(?!`))+(`{4})(?!`)  # 4 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
+    | (`{3})(?![\s`])(?:[^`]+(?=`)|(?!`{3})`+(?!`))+(`{3})(?!`)  # 3 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
+    | (`{2})(?![\s`])(?:[^`]+(?=`)|(?!`{2})`+(?!`))+(`{2})(?!`)  # 2 backticks, followed by at least one non whitespace, non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
+    | (`{1})(?![\s`])(?:[^`]+(?=`)|(?!`{1})`+(?!`))+(`{1})(?!`)  # 1 backtick,  followed by at least one non whitespace, non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
+    )
+  escapes: \\[-+*/!"#$%&'(),.:;<=>?@\[\\\]^_`{|}~]
 
-        # something other than whitespace followed by a pipe char or hyphon,
-        # followed by something other than whitespace and the end of the line
-      | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
-      )
+  balance_square_brackets: |-
+    (?x:
+      (?:
+        (?:{{escapes}})+                  # escape characters
+      | [^\[\]`\\]+(?=[\[\]`\\]|$)        # anything that isn't a square bracket or a backtick or the start of an escape character
+      | {{backticks}}                     # inline code
+      | \[(?:                             # nested square brackets (one level deep)
+          [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
+          {{backticks}}?                  #  balanced backticks
+        )*\]                              #  closing square bracket
+      )+
+    )
+  balance_square_brackets_and_emphasis: |-
+    (?x:
+      (?:
+        (?:{{escapes}})+                  # escape characters
+      | [^\[\]`\\_*]+(?=[\[\]`\\_*]|$)    # anything that isn't a square bracket, a backtick, the start of an escape character, or an emphasis character
+      | {{backticks}}                     # inline code
+      | \[(?:                             # nested square brackets (one level deep)
+          [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
+          {{backticks}}?                  #  balanced backticks
+        )*\]                              #  closing square bracket
+      )+                                  # at least one character
+    )
+  balance_square_brackets_pipes_and_emphasis: |-
+    (?x:
+      (?:
+        (?:{{escapes}})+                  # escape characters
+      | [^\[\]`\\_*|]+(?=[\[\]`\\_*|]|$)  # anything that isn't a square bracket, a backtick, the start of an escape character, or an emphasis character
+      | {{backticks}}                     # inline code
+      | \[(?:                             # nested square brackets (one level deep)
+          [^\[\]`]+(?=[\[\]`])            #  anything that isn't a square bracket or a backtick
+          {{backticks}}?                  #  balanced backticks
+        )*\]                              #  closing square bracket
+      )+                                  # at least one character
+    )
+  balanced_emphasis: |-
+    (?x:
+      \*  (?!\*){{balance_square_brackets_and_emphasis}}+\*  (?!\*)
+    | \*\*      {{balance_square_brackets_and_emphasis}}+\*\*
+    | _   (?!_) {{balance_square_brackets_and_emphasis}}+_   (?!_)
+    | __        {{balance_square_brackets_and_emphasis}}+__
+    )
 
-    fenced_code_block_start: |-
-      (?x:
-        ([ \t]*)
-        (
-          (`){3,}      #   3 or more backticks
-          (?![^`]*`)   #   not followed by any more backticks on the same line
-        |              # or
-          (~){3,}      #   3 or more tildas
-          (?![^~]*~)   #   not followed by any more tildas on the same line
-        )
-        \s*            # allow for whitespace between code block start and info string
-      )
-    fenced_code_block_language: |-
-      (?x:             # first word of an infostring is used as language specifier
-        (
-          [[:alpha:]]  # starts with a letter to make sure not to hit any attribute annotation
-          [^`\s]*      # optionally followed by any nonwhitespace character (except backticks)
-        )
-      )
-    fenced_code_block_trailing_infostring_characters: |-
-      (?x:
-        (
-          \s*          # any whitespace, or ..
-        |
-          \s[^`]*      # any characters (except backticks), separated by whitespace ...
-        )
-        $\n?           # ... until EOL
-      )
-    fenced_code_block_end: |-
-      (?x:
-        [ \t]*
-        (
-          \2           # the backtick/tilde combination that opened the code fence
-          (?:\3|\4)*   # plus optional additional closing characters
-        )
-        \s*$           # any amount of whitespace until EOL
-      )
-    fenced_code_block_escape: ^{{fenced_code_block_end}}
+  table_cell: |-
+    (?x:
+      # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
+      # emphasis in table cells can't span multiple lines
+      (?:
+        {{balance_square_brackets_pipes_and_emphasis}}
+      | {{balanced_emphasis}}
+      )+  # at least one character
+    )
+  table_first_row: |-
+    (?x:
+      # at least 2 non-escaped pipe chars on the line
+      (?:{{table_cell}}?\|){2}
 
-    # https://spec.commonmark.org/0.30/#email-autolink
-    email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
-    email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
+      # something other than whitespace followed by a pipe char or hyphon,
+      # followed by something other than whitespace and the end of the line
+    | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
+    )
 
-    # https://spec.commonmark.org/0.30/#html-blocks
-    html_block_comment: <!--
-    html_block_cdata: <!\[CDATA\[
-    html_block_decl: <![a-zA-Z]
-    html_block_preprocessor: <\?
-    html_block_open_tag: |-
-      (?xi:
-        <
-        [a-z]             # A tag name consists of an ASCII letter
-        [a-z0-9-]*        # followed by zero or more ASCII letters, digits, or hyphens (-)
-        (?:               # An attribute consists of whitespace, an attribute name, and an optional attribute value specification
-          \s+
-          [a-z_:]         # An attribute name consists of an ASCII letter, _, or :
-          [a-z0-9_.:-]*   # followed by zero or more ASCII letters, digits, _, ., :, or -
-          (?:             # An attribute value specification consists of optional whitespace, a = character, optional whitespace, and an attribute value
-            \s*
-            =
-            \s*
-            (?:
-              [^ @'=<>`]+ # An unquoted attribute value is a nonempty string of characters not including spaces, ", ', =, <, >, or `
-            | '[^']*'     # A single-quoted attribute value consists of ', zero or more characters not including ', and a final '
-            | "[^"]*"     # A double-quoted attribute value consists of ", zero or more characters not including ", and a final "
-            )
-          )?
-        )*
-        \s*
-        /?
-        >
-        \s*$
+  fenced_code_block_start: |-
+    (?x:
+      ([ \t]*)
+      (
+        (`){3,}      #   3 or more backticks
+        (?![^`]*`)   #   not followed by any more backticks on the same line
+      |              # or
+        (~){3,}      #   3 or more tildas
       )
-    html_block_close_tag: |-
-      (?xi:
-        </
-        [a-z]             # A tag name consists of an ASCII letter
-        [a-z0-9-]*        # followed by zero or more ASCII letters, digits, or hyphens (-)
-        \s*
-        >
-        \s*$
+      \s*            # allow for whitespace between code block start and info string
+    )
+  fenced_code_block_language: |-
+    (?x:             # first word of an infostring is used as language specifier
+      (
+        [[:alpha:]]  # starts with a letter to make sure not to hit any attribute annotation
+        [^`\s]*      # optionally followed by any nonwhitespace character (except backticks)
       )
-    html_tag_block_end_at_close_tag: |-
-      <(?xi: pre | script | style | textarea ){{html_tag_break_char}}
-    html_tag_block_end_at_blank_line: |-
-      <(?xi:
-        address | article | aside | base | basefont | blockquote | body | caption
-      | c enter | col | colgroup | dd | details | dialog | dir | div | dl | dt
-      | fieldset | figcaption | figure | footer | form | frame | frameset | h1 | h2
-      | h3 | h4 | h5 | h6 | head | header | hr | html | iframe | legend | li | link
-      | main | menu | menuitem | nav | noframes | ol | optgroup | option | p | param
-      | section | source | summary | table | tbody | td | tfoot | th
-      | thead | title | tr | track | ul
-      ){{html_tag_maybe_selfclosing_break_char}}
-    html_tag_break_char: (?:[ \t>]|$)
-    html_tag_maybe_selfclosing_break_char: (?:[ \t]|/?>|$)
+    )
+  fenced_code_block_trailing_infostring_characters: |-
+    (?x:
+      (
+        \s*          # any whitespace, or ..
+      |
+        \s[^`]*      # any characters (except backticks), separated by whitespace ...
+      )
+      $\n?           # ... until EOL
+    )
+  fenced_code_block_end: |-
+    (?x:
+      [ \t]*
+      (
+        \2           # the backtick/tilde combination that opened the code fence
+        (?:\3|\4)*   # plus optional additional closing characters
+      )
+      \s*$           # any amount of whitespace until EOL
+    )
+  fenced_code_block_escape: ^{{fenced_code_block_end}}
 
-    html_entity: '&([a-zA-Z0-9]+|#\d+|#x\h+);'
+  # https://spec.commonmark.org/0.30/#email-autolink
+  email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
+  email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
 
-    ascii_space: '\t\n\f '
-    tag_attribute_name_start: (?=[^{{ascii_space}}=/>}])
-    tag_attribute_name_break: (?=[{{ascii_space}}=/>}])
-    tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
-    tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
+  # https://spec.commonmark.org/0.30/#html-blocks
+  html_block: |-
+    (?x:
+      [ ]{,3}
+      (?:
+        \$\$                                 # a latex math block begins the line
+      | {{html_tag_block_end_at_close_tag}}  # html block type 1
+      | {{html_tag_block_end_at_blank_line}} # html block type 6
+      | {{html_block_open_tag}}              # html block type 7
+      | {{html_block_close_tag}}             # html block type 7
+      | {{html_block_comment}}               # html block type 2
+      | {{html_block_decl}}                  # html block type 4
+      | {{html_block_cdata}}                 # html block type 5
+      | {{html_block_preprocessor}}          # html block type 3
+      )
+    )
+  html_block_comment: <!--
+  html_block_cdata: <!\[CDATA\[
+  html_block_decl: <![a-zA-Z]
+  html_block_preprocessor: <\?
+  html_block_open_tag: |-
+    (?xi:
+      <
+      [a-z]             # A tag name consists of an ASCII letter
+      [a-z0-9-]*        # followed by zero or more ASCII letters, digits, or hyphens (-)
+      (?:               # An attribute consists of whitespace, an attribute name, and an optional attribute value specification
+        \s+
+        [a-z_:]         # An attribute name consists of an ASCII letter, _, or :
+        [a-z0-9_.:-]*   # followed by zero or more ASCII letters, digits, _, ., :, or -
+        (?:             # An attribute value specification consists of optional whitespace, a = character, optional whitespace, and an attribute value
+          \s*
+          =
+          \s*
+          (?:
+            [^ @'=<>`]+ # An unquoted attribute value is a nonempty string of characters not including spaces, ", ', =, <, >, or `
+          | '[^']*'     # A single-quoted attribute value consists of ', zero or more characters not including ', and a final '
+          | "[^"]*"     # A double-quoted attribute value consists of ", zero or more characters not including ", and a final "
+          )
+        )?
+      )*
+      \s*
+      /?
+      >
+      \s*$
+    )
+  html_block_close_tag: |-
+    (?xi:
+      </
+      [a-z]             # A tag name consists of an ASCII letter
+      [a-z0-9-]*        # followed by zero or more ASCII letters, digits, or hyphens (-)
+      \s*
+      >
+      \s*$
+    )
+  html_tag_block_end_at_close_tag: |-
+    <(?xi: pre | script | style | textarea ){{html_tag_break_char}}
+  html_tag_block_end_at_blank_line: |-
+    <(?xi:
+      address | article | aside | base | basefont | blockquote | body | caption
+    | c enter | col | colgroup | dd | details | dialog | dir | div | dl | dt
+    | fieldset | figcaption | figure | footer | form | frame | frameset | h1 | h2
+    | h3 | h4 | h5 | h6 | head | header | hr | html | iframe | legend | li | link
+    | main | menu | menuitem | nav | noframes | ol | optgroup | option | p | param
+    | section | source | summary | table | tbody | td | tfoot | th
+    | thead | title | tr | track | ul
+    ){{html_tag_maybe_selfclosing_break_char}}
+  html_tag_break_char: (?:[ \t>]|$)
+  html_tag_maybe_selfclosing_break_char: (?:[ \t]|/?>|$)
 
-    footnote_name: (?:\^(?:\\\]|[^]])+)
-    reference_name: (?:(?:\\\]|[^]])+)
+  html_entity: '&([a-zA-Z0-9]+|#\d+|#[Xx]\h+);'
+
+  ascii_space: '\t\n\f '
+  tag_attribute_name_start: (?=[^{{ascii_space}}=/>}])
+  tag_attribute_name_break: (?=[{{ascii_space}}=/>}])
+  tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
+  tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
+
+  reference_definition: (?:\[{{reference_name}}\]\:)
+  footnote_name: (?:\^(?:\\\]|[^]])+)
+  reference_name: (?:(?:\\\]|[^]])+)
+
+  paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?=\s*$                        # the line is blank (or only contains whitespace)
+       |  {{block_quote}}             # a blockquote begins the line
+       |  {{atx_heading}}             # an ATX heading begins the line
+       |  {{fenced_code_block_start}} # a fenced codeblock begins the line
+       |  {{thematic_break}}          # line is a thematic beak
+       |  {{first_list_item}}         # a list item begins the line
+       |  {{html_block}}              # a html block begins the line
+       )
+    )
+
+  # https://spec.commonmark.org/0.30/#left-flanking-delimiter-run
+  bold_italic_asterisk_begin: |-
+    (?x:
+         (\*\*)(\*) {{no_space_nor_punct}}
+    | \B (\*\*)(\*) {{no_space_but_punct}}
+    )
+
+  bold_asterisk_begin: |-
+    (?x:
+         \*{2} {{no_space_nor_punct}}
+    | \B \*{2} {{no_space_but_punct}}
+    )
+
+  italic_asterisk_begin: |-
+    (?x:
+         \* {{no_space_nor_punct}}
+    | \B \* {{no_space_but_punct}}
+    )
+
+  # not followed by Unicode whitespace and not followed by a Unicode punctuation character
+  no_space_nor_punct: (?![\s*\p{P}])
+  # not followed by Unicode whitespace and followed by a Unicode punctuation character
+  no_space_but_punct: (?=[[^\s*]&&\p{P}])
 
 ##############################################################################
 
@@ -279,45 +333,75 @@ contexts:
 
   block-quotes:
     # https://spec.commonmark.org/0.30/#block-quotes
-    - match: '{{block_quote}}'
-      comment: |-
-        We terminate the block quote when seeing an empty line, a
-        separator or a line with leading > characters. The latter is
-        to “reset” the quote level for quoted lines.
-        The idea here is to match block level elements first, then once
-        we have confirmed there are no block level elements left, move to
-        matching inline markdown. This prevents block level elements being
-        detected when they shouldn't be.
+    - match: '[ \t]{,3}(>)[ ]?'
       captures:
         1: punctuation.definition.blockquote.markdown
       push:
         - block-quote-meta
-        - block-quote-content
-
-  block-quote-nested:
-    - match: '{{block_quote}}'
-      captures:
-        1: punctuation.definition.blockquote.markdown
-      set:
-        - block-quote-meta
-        - block-quote-content
+        - block-quote-body
+        - block-quote-punctuation-body
 
   block-quote-meta:
     - meta_include_prototype: false
     - meta_scope: markup.quote.markdown
     - include: immediately-pop
 
-  block-quote-content:
-    - include: block-quote-nested
-    - include: block-quote-code-block
-    - include: block-quote-list-item
-    - include: atx-headings
-    - include: indented-code-blocks
-    - include: thematic-breaks
-    - match: ''
-      set: block-quote-text
+  block-quote-body:
+    - include: block-quote-end
+    - include: block-quote-punctuations
+    - include: block-quote-content
 
-  block-quote-code-block:
+  block-quote-content:
+    - include: indented-code-blocks
+    - include: block-quote-common
+    - include: block-quote-paragraph
+
+  block-quote-common:
+    - include: thematic-breaks
+    - include: atx-headings
+    - include: block-quote-reference-definitions
+    - include: block-quote-fenced-code-block
+    - include: block-quote-list-block
+
+  block-quote-end:
+    - match: ^(?!(?:[ \t]*>))
+      pop: true
+
+  block-quote-punctuations:
+    - match: ^[ \t]{,3}(>)[ ]?
+      captures:
+        1: punctuation.definition.blockquote.markdown
+      push: block-quote-punctuation-body
+
+  block-quote-punctuation-body:
+    - include: block-quote-punctuation-content
+    - include: immediately-pop
+
+  block-quote-punctuation-content:
+    - match: '[ \t]{,3}(>)[ ]?'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+
+  block-quote-nested-punctuations:
+    # Quotes signs in list items are not restricted by indentation level
+    # for technical reasons.
+    - match: ^[ \t]*(>)[ ]?
+      captures:
+        1: punctuation.definition.blockquote.markdown
+      push: block-quote-nested-punctuation-body
+
+  block-quote-nested-punctuation-body:
+    - include: block-quote-nested-punctuation-content
+    - include: immediately-pop
+
+  block-quote-nested-punctuation-content:
+    - match: '[ \t]*(>)[ ]?'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+
+###[ CONTAINER BLOCKS: BLOCK QUOTES > FENCED CODE BLOCKS ]####################
+
+  block-quote-fenced-code-block:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
@@ -327,76 +411,221 @@ contexts:
         0: meta.code-fence.definition.begin.text.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      set: block-quote-code-block-content
+      push: block-quote-fenced-code-block-body
 
-  block-quote-code-block-content:
-    - match: ^(?!\s*{{block_quote}})
-      pop: true
+  block-quote-fenced-code-block-body:
+    - include: block-quote-fenced-code-block-end
+    - include: block-quote-fenced-code-block-content
+
+  block-quote-fenced-code-block-content:
+    - include: block-quote-punctuation-content
+    - match: .*$\n?
+      scope: markup.raw.code-fence.markdown-gfm
+
+  block-quote-fenced-code-block-end:
+    - include: block-quote-end
     - match: '{{fenced_code_block_end}}'
       captures:
         0: meta.code-fence.definition.end.text.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
       pop: true
-    - match: '{{block_quote}}'
-      captures:
-        1: punctuation.definition.blockquote.markdown
-    - match: ''
-      push: block-quote-code-block-text
 
-  block-quote-code-block-text:
-    - meta_include_prototype: false
-    - meta_content_scope: markup.raw.code-fence.markdown-gfm
-    - match: ^
+###[ CONTAINER BLOCKS: BLOCK QUOTES > REFERENCE DEFINITIONS ]#################
+
+  block-quote-reference-definitions:
+    # https://spec.commonmark.org/0.30/#link-reference-definitions
+    - include: block-quote-footnote-definitions
+    - include: block-quote-link-definitions
+
+  block-quote-footnote-definitions:
+    # Mardown Extras Footnotes
+    - match: '([ \t]*)(\[)({{footnote_name}})(\])(:)'
+      captures:
+        2: punctuation.definition.reference.begin.markdown
+        3: entity.name.reference.link.markdown
+        4: punctuation.definition.reference.end.markdown
+        5: punctuation.separator.key-value.markdown
+      push: block-quote-footnote-def-body
+
+  block-quote-footnote-def-body:
+    - meta_scope: meta.link.reference.def.footnote.markdown-extra
+    - include: block-quote-footnote-def-end
+    - include: block-quote-punctuations
+    - include: block-quote-footnote-paragraphs
+
+  block-quote-footnote-def-end:
+    # A footnote definition is terminated by blocks not indented by at least 4 characters.
+    # Note: The first space after a quotation punctuation is not counted for simplicity reasons.
+    - match: ^(?!(?:[ \t]*>)+[ ](?:\1[ ]{4}|\s*$))
       pop: true
 
-  block-quote-list-item:
-    - match: ([ ]{,3})(\d+([.)]))(\s)
+  block-quote-footnote-paragraphs:
+    - match: '[ \t]*(?=\S)'
+      push: block-quote-footnote-paragraph-body
+
+  block-quote-footnote-paragraph-body:
+    - include: block-quote-footnote-paragraph-end
+    - include: block-quote-punctuations
+    - include: footnote-paragraph-common
+
+  block-quote-footnote-paragraph-end:
+    - match: |-
+        (?x)
+        # pop out of this context if one of the following conditions are met:
+        ^(?= (?:[ \t]*>)* [ \t]*
+           (?: $                           # the line is blank (or only contains whitespace)
+           |   {{reference_definition}}    # a reference definition begins the line
+           |   {{atx_heading}}             # an ATX heading begins the line
+           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{thematic_break}}          # line is a thematic beak
+           |   {{list_item}}               # a list item begins the line
+           |   {{html_block}}              # a html block begins the line
+           )
+        )
+      pop: true
+
+  block-quote-link-definitions:
+    # https://spec.commonmark.org/0.30/#link-reference-definition
+    - match: '[ \t]*(\[)({{reference_name}})(\])(:)'
+      captures:
+        1: punctuation.definition.reference.begin.markdown
+        2: entity.name.reference.link.markdown
+        3: punctuation.definition.reference.end.markdown
+        4: punctuation.separator.key-value.markdown
+      push:
+        - block-quote-link-def-meta
+        - block-quote-link-def-title
+        - block-quote-link-def-url
+
+  block-quote-link-def-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.link.reference.def.markdown
+    - include: immediately-pop
+
+  block-quote-link-def-title:
+    - include: block-quote-nested-paragraph-end
+    - include: block-quote-punctuations
+    - include: link-title-begin
+    - include: else-pop
+
+  block-quote-link-def-url:
+    - include: block-quote-nested-paragraph-end
+    - include: block-quote-punctuations
+    - match: <
+      scope: punctuation.definition.link.begin.markdown
+      set: block-quote-link-def-url-angled
+    - match: (?=\S)
+      set: link-def-url-unquoted
+
+  block-quote-link-def-url-angled:
+    - meta_content_scope: markup.underline.link.markdown
+    - include: block-quote-punctuations
+    - include: link-url-angled
+
+###[ CONTAINER BLOCKS: BLOCK QUOTES > LIST BLOCKS ]###########################
+
+  block-quote-list-block:
+    - match: ([ \t]*)([*+-])((?:[ ](\[)([ xX])(\]))?\s)
+      captures:
+        1: markup.list.unnumbered.markdown
+        2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+        3: markup.list.unnumbered.markdown
+        4: markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+        5: markup.checkbox.mark.markdown-gfm
+        6: markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+      set: block-quote-unordered-list-block-body
+    - match: ([ \t]*)(\d{1,9}([.)]))(\s)
       captures:
         1: markup.list.numbered.markdown
         2: markup.list.numbered.bullet.markdown
         3: punctuation.definition.list_item.markdown
         4: markup.list.numbered.markdown
-      set:
-        - block-quote-ordered-list-content
-        - list-content
-    - match: ([ ]{,3})([*+-])((?:[ ](\[)([ xX])(\]))?\s)
-      captures:
-        1: markup.list.unnumbered.markdown
-        2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
-        3: markup.list.unnumbered.markdown
-        4: markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-        5: markup.checkbox.mark.markdown-gfm
-        6: markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-      set:
-        - block-quote-unordered-list-content
-        - list-content
+      set: block-quote-ordered-list-block-body
 
-  block-quote-ordered-list-content:
-    - meta_content_scope: markup.list.numbered.markdown meta.paragraph.list.markdown
-    - include: block-quote-text
+  block-quote-ordered-list-block-body:
+    - meta_content_scope: markup.list.numbered.markdown
+    - include: block-quote-list-block-end
+    - include: block-quote-list-block-content
 
-  block-quote-unordered-list-content:
-    - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown
-    - include: block-quote-text
+  block-quote-unordered-list-block-body:
+    - meta_content_scope: markup.list.unnumbered.markdown
+    - include: block-quote-list-block-end
+    - include: block-quote-list-block-content
 
-  block-quote-text:
+  block-quote-list-block-content:
+    - include: list-block-common
+    - include: block-quote-fenced-code-block
+    - include: block-quote-nested-punctuation-content
+    - include: block-quote-reference-definitions
+    - include: block-quote-list-paragraphs
+
+  block-quote-list-block-end:
+    - include: block-quote-end
+    # A list block ends with the first unindented text block.
+    # Note:
+    #  This is a simplification as we can't count indentation levels.
+    #  According to CommonMark, a list block ends as soon as a new paragraph
+    #  starts which is less indented than the first list item's text.
+    - match: ^(?=(?:[ \t]*>)+[ ]?\S)
+      pop: true
+
+  block-quote-list-paragraphs:
+    # A list paragraph doesn't support indented code blocks.
+    - match: '[ \t]*(?=\S)'
+      push: block-quote-list-paragraph-body
+
+  block-quote-list-paragraph-body:
+    - meta_scope: meta.paragraph.list.markdown
+    - include: block-quote-nested-paragraph-end
+    - include: block-quote-nested-punctuations
+    - include: inlines
+
+  block-quote-nested-paragraph-end:
     - match: |-
         (?x)
-        ^
-        (?= \s*$
-        |   {{atx_heading}}
-        |   {{block_quote}}
-        |   {{fenced_code_block_start}}
-        |   {{list_item}}
-        |   {{thematic_break}}
+        # pop out of this context if one of the following conditions are met:
+        ^(?= (?:[ \t]*>)* [ \t]*
+           (?: $                           # the line is blank (or only contains whitespace)
+           |   {{atx_heading}}             # an ATX heading begins the line
+           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{thematic_break}}          # line is a thematic beak
+           |   {{list_item}}               # a list item begins the line
+           |   {{html_block}}              # a html block begins the line
+           )
         )
       pop: true
+
+###[ CONTAINER BLOCKS: BLOCK QUOTES > PARAGRAPHS ]############################
+
+  block-quote-paragraph:
+    - match: '[ \t]*(?=\S)'
+      set: block-quote-paragraph-body
+
+  block-quote-paragraph-body:
+    - meta_scope: markup.paragraph.markdown
+    - include: block-quote-paragraph-end
+    - include: block-quote-punctuations
     - include: inlines
+
+  block-quote-paragraph-end:
+    - match: |-
+        (?x)
+        # pop out of this context if one of the following conditions are met:
+        ^(?= (?:[ \t]{,3}>)*
+           (?: \s* $                       # the line is blank (or only contains whitespace)
+           |   {{atx_heading}}             # an ATX heading begins the line
+           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{thematic_break}}          # line is a thematic beak
+           |   {{list_item}}               # a list item begins the line
+           |   {{html_block}}              # a html block begins the line
+           )
+        )
+      pop: true
 
 ###[ CONTAINER BLOCKS: LISTS ]################################################
 
   list-blocks:
-    - match: ^([ ]{,3})([*+-])( (\[)([ xX])(\]))?(?=\s)
+    - match: ([ \t]*)([*+-])((?:[ ](\[)([ xX])(\]))?\s)
       captures:
         1: markup.list.unnumbered.markdown
         2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
@@ -404,43 +633,45 @@ contexts:
         4: markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
         5: markup.checkbox.mark.markdown-gfm
         6: markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-      push: unordered-list-paragraph
-    - match: ^([ ]{,3})(\d+([.)]))(?=\s)
+      push: unordered-list-block
+    - match: ([ \t]*)(\d{1,9}([.)]))(\s)
       captures:
         1: markup.list.numbered.markdown
         2: markup.list.numbered.bullet.markdown
         3: punctuation.definition.list_item.markdown
-      push: ordered-list-paragraph
+        4: markup.list.numbered.markdown
+      push: ordered-list-block
 
-  unordered-list-paragraph:
+  unordered-list-block:
     - meta_content_scope: markup.list.unnumbered.markdown
-    - include: list-paragraph
+    - include: list-block-end
+    - include: list-block-content
 
-  ordered-list-paragraph:
+  ordered-list-block:
     - meta_content_scope: markup.list.numbered.markdown
-    - include: list-paragraph
+    - include: list-block-end
+    - include: list-block-content
 
-  list-paragraph:
-    - match: ^(?=\S|{{atx_heading}})
+  list-block-end:
+    - match: ^(?=\S)
       pop: true
-    - include: list-indended-code-blocks
-    - include: block-quotes
+
+  list-block-content:
     - include: fenced-code-blocks
+    - include: latex-blocks
     - include: html-blocks
     - include: reference-definitions
-    - include: thematic-breaks
-    - match: (?=\S)
-      push: list-items
+    - include: list-block-common
+    - include: list-block-quotes
+    - include: list-paragraphs
 
-  list-indended-code-blocks:
-    # at least 8 chars / 2 tabs
-    - match: ^{{indented_code_block}}{2,}[^>+*\s-].*$\n?
-      scope: markup.raw.block.markdown
+  list-block-common:
+    - include: thematic-breaks
+    - include: atx-headings
+    - include: list-items
 
   list-items:
-    - match: ^(?=\s*$|{{atx_heading}})
-      pop: true
-    - match: ([ ]*)([*+-])((?:[ ](\[)([ xX])(\]))?\s)
+    - match: ([ \t]*)([*+-])((?:[ ](\[)([ xX])(\]))?\s)
       captures:
         1: markup.list.unnumbered.markdown
         2: markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
@@ -448,46 +679,71 @@ contexts:
         4: markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
         5: markup.checkbox.mark.markdown-gfm
         6: markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-      push: unordered-list-content
-    - match: ([ ]*)(\d+([.)]))(?=\s)
+    - match: ([ \t]*)(\d{1,9}([.)]))(\s)
       captures:
         1: markup.list.numbered.markdown
         2: markup.list.numbered.bullet.markdown
         3: punctuation.definition.list_item.markdown
-      push: ordered-list-content
-    - match: \s+
-      scope: meta.paragraph.list.markdown
-    - match: (?=\S)
-      push: list-content
+        4: markup.list.numbered.markdown
 
-  unordered-list-content:
-    - clear_scopes: 1
-    - meta_content_scope: markup.list.unnumbered.markdown meta.paragraph.list.markdown
-    - include: list-content
+  list-block-quotes:
+    - match: '[ \t]*(>)[ ]?'
+      captures:
+        1: punctuation.definition.blockquote.markdown
+      push:
+        - block-quote-meta
+        - list-block-quote-body
+        - block-quote-punctuation-body
 
-  ordered-list-content:
-    - clear_scopes: 1
-    - meta_content_scope: markup.list.numbered.markdown meta.paragraph.list.markdown
-    - include: list-content
+  list-block-quote-body:
+    - include: block-quote-end
+    - include: list-block-quote-punctuations
+    - include: list-block-quote-content
 
-  list-content:
-    - meta_content_scope: meta.paragraph.list.markdown
-    - include: block-quotes
-    - include: fenced-code-blocks
-    - include: html-blocks
-    - include: latex-blocks
-    - include: reference-definitions
-    - include: thematic-breaks
-    - match: ^
-      pop: true
-    - match: (?=\S)
-      push: list-text
+  list-block-quote-content:
+    - include: indented-code-blocks
+    - include: block-quote-common
+    - include: list-block-quote-paragraph
 
-  list-text:
+  list-block-quote-punctuations:
+    - match: ^[ \t]*(>)[ ]?
+      captures:
+        1: punctuation.definition.blockquote.markdown
+      push: block-quote-punctuation-body
+
+  list-block-quote-paragraph:
+    - match: '[ \t]*(?=\S)'
+      set: list-block-quote-paragraph-body
+
+  list-block-quote-paragraph-body:
+    - meta_scope: markup.paragraph.markdown
+    - include: block-quote-nested-paragraph-end
+    - include: list-block-quote-punctuations
     - include: inlines
-    - match: $
-      pop: true
-    - match: (?={{list_item}})
+
+  list-paragraphs:
+    - match: '[ \t]*(?=\S)'
+      push: list-paragraph-body
+
+  list-paragraph-body:
+    - meta_scope: meta.paragraph.list.markdown
+    - include: list-paragraph-end
+    - include: inlines
+
+  list-paragraph-end:
+    - match: |-
+        (?x)
+        # pop out of this context if one of the following conditions are met:
+        ^(?= [ \t]*
+          (?: $                           # the line is blank (or only contains whitespace)
+          |   {{block_quote}}             # a blockquote begins the line
+          |   {{atx_heading}}             # an ATX heading begins the line
+          |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+          |   {{thematic_break}}          # line is a thematic beak
+          |   {{list_item}}               # a list item begins the line
+          |   {{html_block}}              # a html block begins the line
+          )
+        )
       pop: true
 
 ###[ LEAF BLOCKS: ATX HEADINGS ]##############################################
@@ -499,27 +755,27 @@ contexts:
     #   starts with first non-whitespace character,
     #   but don't do so if directly followed by closing hashes
     #   as terminator pattern requires them to match then.
-    - match: '[ ]{,3}(#{1}){{atx_heading_space}}'
+    - match: '[ \t]*(#{1}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading1-content
-    - match: '[ ]{,3}(#{2}){{atx_heading_space}}'
+    - match: '[ \t]*(#{2}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading2-content
-    - match: '[ ]{,3}(#{3}){{atx_heading_space}}'
+    - match: '[ \t]*(#{3}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading3-content
-    - match: '[ ]{,3}(#{4}){{atx_heading_space}}'
+    - match: '[ \t]*(#{4}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading4-content
-    - match: '[ ]{,3}(#{5}){{atx_heading_space}}'
+    - match: '[ \t]*(#{5}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading5-content
-    - match: '[ ]{,3}(#{6}){{atx_heading_space}}'
+    - match: '[ \t]*(#{6}){{atx_heading_space}}'
       captures:
         1: punctuation.definition.heading.begin.markdown
       push: atx-heading6-content
@@ -619,29 +875,7 @@ contexts:
     - include: inlines
 
   paragraph-end:
-    - match: |-
-        (?x)
-        ^(?= # pop out of this context if one of the following conditions are met:
-            \s*$                        # the line is blank (or only contains whitespace)
-          | {{atx_heading}}             # an ATX heading begins the line
-          | {{block_quote}}             # a blockquote begins the line
-          | {{fenced_code_block_start}} # a fenced codeblock begins the line
-          | {{thematic_break}}          # line is a thematic beak
-          | [ ]{,3}
-            (?:
-              1[.)]\s                   # an ordered list item with number "1" begins the line
-            | [*+-]\s                   # an unordered list item begins the line
-            | \$\$                      # a latex math block begins the line
-            | {{html_tag_block_end_at_close_tag}}  # html block type 1
-            | {{html_tag_block_end_at_blank_line}} # html block type 6
-            | {{html_block_open_tag}}              # html block type 7
-            | {{html_block_close_tag}}             # html block type 7
-            | {{html_block_comment}}               # html block type 2
-            | {{html_block_decl}}                  # html block type 4
-            | {{html_block_cdata}}                 # html block type 5
-            | {{html_block_preprocessor}}          # html block type 3
-            )
-          )
+    - match: '{{paragraph_end}}'
       pop: true
 
 ###[ LEAF BLOCKS: INDENTED CODE BLOCKS ]######################################
@@ -655,7 +889,7 @@ contexts:
 
   fenced-code-blocks:
     # https://spec.commonmark.org/0.30/#fenced-code-blocks
-    - match: ^(?={{fenced_code_block_start}})
+    - match: (?={{fenced_code_block_start}})
       push: fenced-code-block-content
 
   fenced-code-block-content:
@@ -1960,7 +2194,7 @@ contexts:
         0: meta.code-fence.definition.begin.xonsh.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
-      embed: scope:source.python
+      embed: scope:source.xonsh
       embed_scope: markup.raw.code-fence.xonsh.markdown-gfm
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
@@ -1972,35 +2206,35 @@ contexts:
   # https://spec.commonmark.org/0.30/#html-blocks
   html-blocks:
     # Markdown formatting is disabled inside block-level tags.
-    - match: ^[ ]*(?=<((?i:pre|textarea)){{html_tag_break_char}})
+    - match: ^[ \t]*(?=<((?i:pre|textarea)){{html_tag_break_char}})
       push:
         - html-block-pop-at-eol
         - html-block-type-1a
     # Markdown formatting is disabled inside block-level tags.
-    - match: ^[ ]*(?=<((?i:script|style)){{html_tag_break_char}})
+    - match: ^[ \t]*(?=<((?i:script|style)){{html_tag_break_char}})
       push:
         - html-block-pop-at-eol
         - html-block-type-1b
     # Markdown formatting is disabled inside block level tags and if a complete HTML tag is the only thing on the line.
-    - match: ^[ ]*(?={{html_tag_block_end_at_blank_line}}|{{html_block_open_tag}}|{{html_block_close_tag}})
+    - match: ^[ \t]*(?={{html_tag_block_end_at_blank_line}}|{{html_block_open_tag}}|{{html_block_close_tag}})
       push: html-block-type-6
     # Markdown formatting is disabled inside comments.
-    - match: ^[ ]*(?={{html_block_comment}})
+    - match: ^[ \t]*(?={{html_block_comment}})
       push:
         - html-block-pop-at-eol
         - html-block-type-2
     # Markdown formatting is disabled inside preprocessor instructions.
-    - match: ^[ ]*(?={{html_block_preprocessor}})
+    - match: ^[ \t]*(?={{html_block_preprocessor}})
       push:
         - html-block-pop-at-eol
         - html-block-type-3
     # Markdown formatting is disabled inside doctype declarations.
-    - match: ^[ ]*(?={{html_block_decl}})
+    - match: ^[ \t]*(?={{html_block_decl}})
       push:
         - html-block-pop-at-eol
         - html-block-type-4
     # Markdown formatting is disabled inside CDATA.
-    - match: ^[ ]*(?={{html_block_cdata}})
+    - match: ^[ \t]*(?={{html_block_cdata}})
       push:
         - html-block-pop-at-eol
         - html-block-type-5
@@ -2060,6 +2294,10 @@ contexts:
   html-content:
     - include: scope:text.html.basic
 
+  html-entities:
+    # https://spec.commonmark.org/0.30/#entity-and-numeric-character-references
+    - include: scope:text.html.basic#entities
+
   html-kbd-tags:
     # A simple implementation to add dedicated `markup.kbd` scopes.
     # Note: Doesn't (intent to) support bold/italic/striked content.
@@ -2084,26 +2322,56 @@ contexts:
 
   footnote-definitions:
     # Mardown Extras Footnotes
-    - match: '[ ]{,3}(\[)({{footnote_name}})(\])(:)'
+    - match: '([ \t]*)(\[)({{footnote_name}})(\])(:)'
       captures:
-        1: punctuation.definition.reference.begin.markdown
-        2: entity.name.reference.link.markdown
-        3: punctuation.definition.reference.end.markdown
-        4: punctuation.separator.key-value.markdown
+        2: punctuation.definition.reference.begin.markdown
+        3: entity.name.reference.link.markdown
+        4: punctuation.definition.reference.end.markdown
+        5: punctuation.separator.key-value.markdown
       push: footnote-def-body
 
   footnote-def-body:
     - meta_scope: meta.link.reference.def.footnote.markdown-extra
-    - match: ^(?![ ]{4}|$)
+    - include: footnote-def-end
+    - include: footnote-paragraphs
+
+  footnote-def-end:
+    - match: ^(?!(?:\1[ ]{4}|\s*$))
       pop: true
+
+  footnote-paragraphs:
+    - match: '[ \t]*(?=\S)'
+      push: footnote-paragraph-body
+
+  footnote-paragraph-body:
+    - include: footnote-paragraph-end
+    - include: footnote-paragraph-common
+
+  footnote-paragraph-common:
     - include: emphasis
     - include: images
     - include: literals
     - include: links
 
+  footnote-paragraph-end:
+    - match: |-
+        (?x)
+        # pop out of this context if one of the following conditions are met:
+        ^(?= [ \t]*
+           (?: $                           # the line is blank (or only contains whitespace)
+           |   {{reference_definition}}    # a reference definition begins the line
+           |   {{atx_heading}}             # an ATX heading begins the line
+           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+           |   {{thematic_break}}          # line is a thematic beak
+           |   {{list_item}}               # a list item begins the line
+           |   {{html_block}}              # a html block begins the line
+           )
+        )
+      pop: true
+
   link-definitions:
     # https://spec.commonmark.org/0.30/#link-reference-definition
-    - match: '[ ]{,3}(\[)({{reference_name}})(\])(:)'
+    - match: '[ \t]*(\[)({{reference_name}})(\])(:)'
       captures:
         1: punctuation.definition.reference.begin.markdown
         2: entity.name.reference.link.markdown
@@ -2111,13 +2379,22 @@ contexts:
         4: punctuation.separator.key-value.markdown
       push:
         - link-def-end
-        - link-title
+        - link-def-title
         - link-def-url
 
   link-def-end:
+    - meta_include_prototype: false
     - meta_scope: meta.link.reference.def.markdown
-    - include: eol-pop
-    - match: \s*\S+
+    - include: immediately-pop
+
+  link-def-title:
+    - match: ^(?!\s*["'(])
+      pop: true
+    - match: (?=["'(])
+      set:
+        - expect-eol
+        - link-title
+    - match: \S.+
       scope: invalid.illegal.expected-eol.markdown
 
   link-def-url:
@@ -2126,20 +2403,14 @@ contexts:
       set: link-def-url-angled
     - match: (?=\S)
       set: link-def-url-unquoted
-    - include: eol-pop
+    - include: paragraph-end
 
   link-def-url-angled:
     - meta_content_scope: markup.underline.link.markdown
-    - match: \>
-      scope: punctuation.definition.link.end.markdown
-      pop: true
-    - include: link-def-url-common
+    - include: link-url-angled
 
   link-def-url-unquoted:
     - meta_scope: markup.underline.link.markdown
-    - include: link-def-url-common
-
-  link-def-url-common:
     # URLs are terminated by whitespace or newline in reference definitions
     # Note: \s includes \n
     - match: (?=\s)
@@ -2219,6 +2490,7 @@ contexts:
       push: thematic-break-body
 
   thematic-break-body:
+    - meta_include_prototype: false
     - meta_scope: meta.separator.thematic-break.markdown
     - match: '[-_*]+'
       scope: punctuation.definition.thematic-break.markdown
@@ -2266,7 +2538,6 @@ contexts:
     - match: '[<>]?(-+|=+)[<>]'
     - match: '<<+|<>|>>+'
     - match: <(?![A-Za-z/?!])
-    - match: (?!{{html_entity}})&
     - include: html-kbd-tags
     - include: html-content
 
@@ -2293,12 +2564,14 @@ contexts:
 
   bold:
     # https://spec.commonmark.org/0.30/#emphasis-and-strong-emphasis
-    - match: (\*\*)(\*)(?=\S)(?!\*)
+    - match: '{{bold_italic_asterisk_begin}}'
       captures:
         1: punctuation.definition.bold.begin.markdown
         2: markup.italic.markdown punctuation.definition.italic.begin.markdown
+        3: punctuation.definition.bold.begin.markdown
+        4: markup.italic.markdown punctuation.definition.italic.begin.markdown
       push: bold-italic-asterisk
-    - match: \*\*(?=\S)(?!\*\*|\*\s)
+    - match: '{{bold_asterisk_begin}}'
       scope: punctuation.definition.bold.begin.markdown
       push: bold-asterisk
     - match: \b(__)(_)(?=\S)(?!_)
@@ -2314,9 +2587,9 @@ contexts:
     - meta_scope: markup.bold.markdown
     - match: |-
         (?x)
-            [ \t]*\*{4,}     # if there are more than 3 its not applicable to be bold or italic
-        |   [ \t]+\*\*+      # whitespace followed by 2 or more is also not applicable
-        |   ^\*\*            # emphasis can't be closed at the start of the line
+          [ \t]*\*{4,}    # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+\*\*+     # whitespace followed by 2 or more is also not applicable
+        | ^\*\*           # emphasis can't be closed at the start of the line
     - match: (?:_)?(\*\*)
       captures:
         1: punctuation.definition.bold.end.markdown
@@ -2329,10 +2602,10 @@ contexts:
   bold-underscore:
     - meta_scope: markup.bold.markdown
     - match: |-
-          (?x)
-              [ \t]*_{4,}    # if there are more than 3 its not applicable to be bold or italic
-          |   [ \t]+__+      # whitespace followed by 2 or more is also not applicable
-          |   ^__            # emphasis can't be closed at the start of the line
+        (?x)
+          [ \t]*_{4,}     # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+__+       # whitespace followed by 2 or more is also not applicable
+        | ^__             # emphasis can't be closed at the start of the line
     - match: (?:\*)?(__\b)
       captures:
         1: punctuation.definition.bold.end.markdown
@@ -2347,9 +2620,9 @@ contexts:
     - meta_content_scope: markup.italic.markdown
     - match: |-
         (?x)
-            [ \t]*\*{4,}    # if there are more than 3 its not applicable to be bold or italic
-        |   [ \t]+\*(?!\*)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        |   ^\*(?!\*)       # emphasis can't be closed at the start of the line
+          [ \t]*\*{4,}    # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+\*(?!\*)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^\*(?!\*)       # emphasis can't be closed at the start of the line
     - match: (\*)(\*\*)
       captures:
         1: markup.italic.markdown punctuation.definition.italic.end.markdown
@@ -2368,9 +2641,9 @@ contexts:
     - meta_content_scope: markup.bold.markdown
     - match: |-
         (?x)
-            [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
-        |   [ \t]+\*\*+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        |   ^\*\*           # emphasis can't be closed at the start of the line
+          [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+\*\*+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^\*\*           # emphasis can't be closed at the start of the line
     - match: \*\*
       scope: markup.bold.markdown punctuation.definition.bold.end.markdown
       pop: true
@@ -2380,9 +2653,9 @@ contexts:
     - meta_content_scope: markup.italic.markdown
     - match: |-
         (?x)
-            [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
-        |   [ \t]+\*\*+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        |   ^\*\*           # emphasis can't be closed at the start of the line
+          [ \t]*\*{3,}    # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+\*\*+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^\*\*           # emphasis can't be closed at the start of the line
     - match: \*
       scope: markup.italic.markdown punctuation.definition.italic.end.markdown
       pop: true
@@ -2393,9 +2666,9 @@ contexts:
     - meta_content_scope: markup.italic.markdown
     - match: |-
         (?x)
-            [ \t]*_{4,}   # if there are more than 3 its not applicable to be bold or italic
-        |   [ \t]+_(?!_)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-        |   ^_(?!_)       # emphasis can't be closed at the start of the line
+          [ \t]*_{4,}     # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+_(?!_)    # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^_(?!_)         # emphasis can't be closed at the start of the line
     - match: (_)(__)\b
       captures:
         1: markup.italic.markdown punctuation.definition.italic.end.markdown
@@ -2413,10 +2686,10 @@ contexts:
   bold-after-bold-italic-underscore:
     - meta_content_scope: markup.bold.markdown
     - match: |-
-          (?x)
-              [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
-          |   [ \t]+__+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-          |   ^__           # emphasis can't be closed at the start of the line
+        (?x)
+          [ \t]*_{3,}     # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+__+       # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^__             # emphasis can't be closed at the start of the line
     - match: __\b
       scope: markup.bold.markdown punctuation.definition.bold.end.markdown
       pop: true
@@ -2425,10 +2698,10 @@ contexts:
   italic-after-bold-italic-underscore:
     - meta_content_scope: markup.italic.markdown
     - match: |-
-          (?x)
-              [ \t]*_{3,}   # if there are more than 3 its not applicable to be bold or italic
-          |   [ \t]+__+     # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-          |   ^__           # emphasis can't be closed at the start of the line
+        (?x)
+          [ \t]*_{3,}     # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+__+       # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^__             # emphasis can't be closed at the start of the line
     - match: _\b
       scope: markup.italic.markdown punctuation.definition.italic.end.markdown
       pop: true
@@ -2440,7 +2713,7 @@ contexts:
     - include: strikethrough
 
   italic:
-    - match: \*(?=\S)(?!\*)
+    - match: '{{italic_asterisk_begin}}'
       scope: punctuation.definition.italic.begin.markdown
       push: italic-asterisk
     - match: \b_(?=\S)(?!_)
@@ -2451,10 +2724,10 @@ contexts:
   italic-asterisk:
     - meta_scope: markup.italic.markdown
     - match: |-
-          (?x)
-              [ \t]*\*{4,}   # if there are more than 3 its not applicable to be bold or italic
-          |   [ \t]+\*(?!\*) # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-          |   ^\*(?!\*)      # emphasis can't be closed at the start of the line
+        (?x)
+          [ \t]*\*{4,}    # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+\*(?!\*)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^\*(?!\*)       # emphasis can't be closed at the start of the line
     - match: \*(?!\*[^*])
       scope: punctuation.definition.italic.end.markdown
       pop: true
@@ -2464,10 +2737,10 @@ contexts:
   italic-underscore:
     - meta_scope: markup.italic.markdown
     - match: |-
-          (?x)
-              [ \t]*_{4,}   # if there are more than 3 its not applicable to be bold or italic
-          |   [ \t]+_(?!_)  # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
-          |   ^_(?!_)       # emphasis can't be closed at the start of the line
+        (?x)
+          [ \t]*_{4,}     # if there are more than 3 its not applicable to be bold or italic
+        | [ \t]+_(?!_)    # whitespace followed by 1 is also not applicable (but whitespace followed by 2 could be bold punctuation)
+        | ^_(?!_)         # emphasis can't be closed at the start of the line
     - match: _\b
       scope: punctuation.definition.italic.end.markdown
       pop: true
@@ -2479,15 +2752,18 @@ contexts:
     - include: strikethrough
 
   strikethrough:
-    - match: (?:~(?!~}|>|\s))+  # any number of ~ up to ~> or ~~} critic markers
+    # https://github.github.com/gfm/#strikethrough-extension-
+    - match: ~~(?![~}>\s])  # 2x ~ but no ~> or ~~}
       scope: punctuation.definition.strikethrough.begin.markdown
       push: strikethrough-content
+    - match: ~+(?![~}>\s])  # any number of ~ not looking like ~> or ~~}
 
   strikethrough-content:
     - meta_scope: markup.strikethrough.markdown-gfm
-    - match: (?:~(?!~}|>))+     # any number of ~ up to ~> or ~~} critic markers
+    - match: ~~(?:(?!~)|(?=~~}|~>))  # 2x ~ maybe followed by ~> or ~~}
       scope: punctuation.definition.strikethrough.end.markdown
       pop: true
+    - match: ~+(?:(?!~)|(?=~~}|~>))  # any number of ~ maybe followed by ~> or ~~}
     - include: emphasis-common
     - include: bold
     - include: italic
@@ -2767,6 +3043,11 @@ contexts:
     - include: images
 
   link-title:
+    - include: link-title-begin
+    - include: eol-pop
+    - include: else-pop
+
+  link-title-begin:
     - match: \'
       scope: punctuation.definition.string.begin.markdown
       set: link-title-single-quoted-content
@@ -2776,8 +3057,6 @@ contexts:
     - match: \(
       scope: punctuation.definition.string.begin.markdown
       set: link-title-other-quoted-content
-    - match: $|(?=\S)
-      pop: true
 
   link-title-double-quoted-content:
     - meta_scope: meta.string.title.markdown string.quoted.double.markdown
@@ -2804,6 +3083,8 @@ contexts:
     - match: ^\s*$\n?
       scope: invalid.illegal.non-terminated.link-title.markdown
       pop: true
+    - include: escapes
+    - include: html-entities
 
   link-url-angled:
     - match: \>
@@ -2825,6 +3106,7 @@ contexts:
 
   link-url-common:
     - include: escapes
+    - include: html-entities
     - include: link-url-path-separators
     - include: link-url-scheme-separators
     - include: link-url-escapes
@@ -2996,10 +3278,12 @@ contexts:
 ###[ INLINE: OTHER ]##########################################################
 
   escapes:
-    - match: '{{escape}}'
+    # https://spec.commonmark.org/0.30/#backslash-escapes
+    - match: '{{escapes}}'
       scope: constant.character.escape.markdown
 
   hard-line-breaks:
+    # https://spec.commonmark.org/0.30/#hard-line-breaks
     - match: '[ ]{2,}$'
       scope: meta.hard-line-break.markdown punctuation.definition.hard-line-break.markdown
     - match: (\\)\n
@@ -3128,8 +3412,9 @@ contexts:
     - include: latex-content
 
   latex-blocks:
-    - match: \$\$
-      scope: string.other.math.latex punctuation.definition.string.begin.latex
+    - match: '[ \t]*(\$\$)'
+      captures:
+        1: string.other.math.latex punctuation.definition.string.begin.latex
       push: latex-block-content
 
   latex-block-content:
@@ -3153,6 +3438,12 @@ contexts:
     - match: $
       pop: true
 
+  expect-eol:
+    - include: eol-pop
+    - match: \S.+
+      scope: invalid.illegal.expected-eol.markdown
+
   immediately-pop:
     - match: ''
       pop: true
+

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -263,7 +263,7 @@ contexts:
         1: punctuation.section.block.end.frontmatter.markdown
 
   markdown:
-    - include: indented-code-block
+    - include: indented-code-blocks
     - include: thematic-breaks
     - include: block-quotes
     - include: list-blocks
@@ -272,7 +272,7 @@ contexts:
     - include: html-blocks
     - include: latex-blocks
     - include: reference-definitions
-    - include: atx-heading
+    - include: atx-headings
     - include: setext-heading-or-paragraph
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES ]#########################################
@@ -311,8 +311,8 @@ contexts:
     - include: block-quote-nested
     - include: block-quote-code-block
     - include: block-quote-list-item
-    - include: atx-heading
-    - include: indented-code-block
+    - include: atx-headings
+    - include: indented-code-blocks
     - include: thematic-breaks
     - match: ''
       set: block-quote-text
@@ -391,7 +391,7 @@ contexts:
         |   {{thematic_break}}
         )
       pop: true
-    - include: inline
+    - include: inlines
 
 ###[ CONTAINER BLOCKS: LISTS ]################################################
 
@@ -427,7 +427,6 @@ contexts:
     - include: block-quotes
     - include: fenced-code-blocks
     - include: html-blocks
-    - include: latex-blocks
     - include: reference-definitions
     - include: thematic-breaks
     - match: (?=\S)
@@ -485,7 +484,7 @@ contexts:
       push: list-text
 
   list-text:
-    - include: inline
+    - include: inlines
     - match: $
       pop: true
     - match: (?={{list_item}})
@@ -493,7 +492,7 @@ contexts:
 
 ###[ LEAF BLOCKS: ATX HEADINGS ]##############################################
 
-  atx-heading:
+  atx-headings:
     # https://spec.commonmark.org/0.30/#atx-headings
     # Note:
     #   Consume spaces and tabs after opening hashes so entity.name
@@ -617,7 +616,7 @@ contexts:
     - match: '{{setext_escape}}'
       fail: setext-heading-or-paragraph
     - include: paragraph-end
-    - include: inline
+    - include: inlines
 
   paragraph-end:
     - match: |-
@@ -647,7 +646,7 @@ contexts:
 
 ###[ LEAF BLOCKS: INDENTED CODE BLOCKS ]######################################
 
-  indented-code-block:
+  indented-code-blocks:
     # https://spec.commonmark.org/0.30/#indented-code-blocks
     - match: '{{indented_code_block}}.*$\n?'
       scope: markup.raw.block.markdown
@@ -2061,7 +2060,7 @@ contexts:
   html-content:
     - include: scope:text.html.basic
 
-  tag-kbd:
+  html-kbd-tags:
     # A simple implementation to add dedicated `markup.kbd` scopes.
     # Note: Doesn't (intent to) support bold/italic/striked content.
     - match: ((<)(kbd)(>))([^<]+)((</)(kbd)(>))
@@ -2202,7 +2201,7 @@ contexts:
     - include: images
     - include: literals
     - include: links
-    - include: markup
+    - include: markups
 
   table-cell-emphasis:
     - include: emphasis
@@ -2228,13 +2227,13 @@ contexts:
 
 ###[ INLINE ]#################################################################
 
-  inline:
+  inlines:
     - include: hard-line-breaks
     - include: emphasis
     - include: images
     - include: literals
     - include: links
-    - include: markup
+    - include: markups
 
   emphasis:
     - include: bold
@@ -2260,7 +2259,7 @@ contexts:
     - include: link-inline
     - include: link-ref
 
-  markup:
+  markups:
     # Markdown will convert this for us. We match it so that the
     # HTML grammar will not mark it up as invalid.
     - match: '[<>](-+|=+)[<>]?'
@@ -2268,7 +2267,7 @@ contexts:
     - match: '<<+|<>|>>+'
     - match: <(?![A-Za-z/?!])
     - match: (?!{{html_entity}})&
-    - include: tag-kbd
+    - include: html-kbd-tags
     - include: html-content
 
 ###[ INLINE: CODE SPANS ]#####################################################
@@ -2504,7 +2503,7 @@ contexts:
     - include: images
     - include: literals
     - include: links
-    - include: markup
+    - include: markups
 
 ###[ INLINE: IMAGES ]#########################################################
 
@@ -2756,7 +2755,7 @@ contexts:
     - match: \b\*\*?(?=[^]*]+\]) # eat asterisks where there is no pair before the end of the square brackets - it's not a formatting mark
     - include: emphasis
     - include: literals
-    - include: markup
+    - include: markups
 
   link-text-nested:
     - include: link-text

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -273,7 +273,7 @@ contexts:
     - include: latex-blocks
     - include: reference-definitions
     - include: atx-headings
-    - include: setext-heading-or-paragraph
+    - include: setext-headings-or-paragraphs
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES ]#########################################
 
@@ -567,13 +567,13 @@ contexts:
 
 ###[ LEAF BLOCKS: SETEXT HEADINGS OR PARAGRAPH ]##############################
 
-  setext-heading-or-paragraph:
+  setext-headings-or-paragraphs:
     # A paragraph may start with a line of equal signs which must not be matched
     # as heading underline. This is achieved by consuming them here, which also
     # applies `meta.paragraph` scope as expected.
     # A line of dashes is already matched as thematic break and thus ignored.
     - match: ^[ ]{,3}(?:=+|(?=\S))
-      branch_point: setext-heading-or-paragraph
+      branch_point: setext-headings-or-paragraphs
       branch:
         - paragraph
         - setext-heading2
@@ -603,18 +603,18 @@ contexts:
 
   setext-heading-content:
     - match: '{{setext_escape}}'
-      fail: setext-heading-or-paragraph
+      fail: setext-headings-or-paragraphs
     - include: emphasis
     - include: images
     - include: literals
     - include: links
-    - include: markup
+    - include: markups
 
   paragraph:
     # https://spec.commonmark.org/0.30/#paragraphs
     - meta_scope: meta.paragraph.markdown
     - match: '{{setext_escape}}'
-      fail: setext-heading-or-paragraph
+      fail: setext-headings-or-paragraphs
     - include: paragraph-end
     - include: inlines
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -106,7 +106,7 @@ class DereferrablePanelTestCase(DeferrableTestCase):
             Triple quoted text, which is detented and stripped
             before being compared with view's content.
         """
-        self.assertEqual(self.getText(), dedent(text).strip("\n"))
+        self.assertEqual(self.getText().strip("\n"), dedent(text).strip("\n"))
 
     def assertEqualText(self, text):
         """

--- a/tests/syntax_test_latex.md
+++ b/tests/syntax_test_latex.md
@@ -24,17 +24,16 @@ $$
 1. Numbered List
 
    $$
-| <- markup.list.numbered.markdown
-|^^^^^ markup.list.numbered.markdown
-|  ^^ string.other.math.latex punctuation.definition.string.begin.latex
+   | <- markup.list.numbered.markdown string.other.math.latex punctuation.definition.string.begin.latex
+   |^ markup.list.numbered.markdown string.other.math.latex punctuation.definition.string.begin.latex
    foo = 1 + 2
-| <- markup.list.numbered.markdown text.tex.latex
+   | <- markup.list.numbered.markdown text.tex.latex
    $$
-| <- markup.list.numbered.markdown
-|^^^^^ markup.list.numbered.markdown
-|  ^^ string.other.math.latex punctuation.definition.string.end.latex
+   | <- markup.list.numbered.markdown string.other.math.latex punctuation.definition.string.end.latex
+   |^ markup.list.numbered.markdown string.other.math.latex punctuation.definition.string.end.latex
 
-    $$1+1$$
-|   ^^^^^^^ markup.list.numbered.markdown meta.paragraph.list.markdown text.tex.latex meta.environment.math.block.dollar.latex
-|   ^^ string.other.math.latex punctuation.definition.string.begin.latex
-|        ^^ string.other.math.latex punctuation.definition.string.end.latex
+   $$1+1$$
+   | <- markup.list.numbered.markdown string.other.math.latex punctuation.definition.string.begin.latex
+   |^^^^^^ markup.list.numbered.markdown text.tex.latex meta.environment.math.block.dollar.latex
+   |^ string.other.math.latex punctuation.definition.string.begin.latex
+   |    ^^ string.other.math.latex punctuation.definition.string.end.latex

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -1956,6 +1956,20 @@ FROM TableName
 | <- meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 |^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
+```ts
+declare type foo = 'bar'
+| <- markup.raw.code-fence.typescript.markdown-gfm source.ts
+```
+| <- meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```tsx
+
+| <- markup.raw.code-fence.tsx.markdown-gfm
+```
+| <- meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
 ```xml
 |^^^^^ meta.code-fence.definition.begin.xml
 |  ^^^ constant.other.language-name

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -1,65 +1,1017 @@
 | SYNTAX TEST "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax"
 
-# Heading
-| <- markup.heading.1 punctuation.definition.heading
-|^^^^^^^^^ markup.heading.1.markdown
-|^ - entity.name.section
-|  ^^^^^^ entity.name.section
-|        ^ meta.whitespace.newline.markdown - entity.name.section
+# TEST: Tabs ##################################################################
 
-## Second Heading #
-| <- markup.heading.2 punctuation.definition.heading
-|^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown
-|^^ - entity.name.section
-|  ^^^^^^^^^^^^^^ entity.name.section
-|                ^^ - entity.name.section
-|                 ^ punctuation.definition.heading.end.markdown
+## https://spec.commonmark.org/0.30/#example-1
 
-https://spec.commonmark.org/0.30/#example-71
+	foo	baz		bim
+| <- markup.raw.block.markdown
+|^^^^^^^^^^^^^ markup.raw.block.markdown
 
-  ## Heading ##
-|^^^^^^^^^^^^^^^ markup.heading.2.markdown
-|^ - punctuation
-| ^^ punctuation.definition.heading.begin.markdown
-|   ^^^^^^^^^ - punctuation
-|            ^^ punctuation.definition.heading.end.markdown
-|              ^ - punctuation
-|^^^^ - entity.name.section
-|    ^^^^^^^ entity.name.section.markdown
-|           ^^^^ - entity.name.section
+## https://spec.commonmark.org/0.30/#example-2
 
-https://spec.commonmark.org/0.30/#example-73
-## Example 73 (trailing spaces!) #####    
-|                                    ^ punctuation.definition.heading.end.markdown
-|                                         ^ meta.whitespace.newline.markdown
+  	foo	baz		bim
+| <- markup.raw.block.markdown
+|^^^^^^^^^^^^^ markup.raw.block.markdown
 
-https://spec.commonmark.org/0.30/#example-74
-## Example 74 ####    >
-|^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.2.markdown
-|^^ - entity.name.section
-|  ^^^^^^^^^^^^^^^^^^^^ entity.name.section.markdown
-|                      ^ - entity.name.section
+   	foo	baz		bim
+| <- markup.raw.block.markdown
+|^^^^^^^^^^^^^ markup.raw.block.markdown
 
-https://spec.commonmark.org/0.30/#example-75
-# #heading# #
+## https://spec.commonmark.org/0.30/#example-3
+
+    a	a
+    ὐ	a
+| <- markup.raw.block.markdown
+|^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-4
+
+  - foo
+
+	bar
+| <- markup.list.unnumbered.markdown
+|^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-5
+
+- foo
+
+		bar
+| <- markup.list.unnumbered.markdown - markup.raw.block.markdown
+|^^^^^ markup.list.unnumbered.markdown - markup.raw.block.markdown
+
+> Note: `bar` should be indented code block, but ST can't reliably highlight it!
+
+## https://spec.commonmark.org/0.30/#example-6
+
+>		foo
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-7
+
+-		foo
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+
+## https://spec.commonmark.org/0.30/#example-8
+
+    foo
+	bar
+| <- markup.raw.block.markdown
+|^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-9
+
+ - foo
+   - bar
+	 - baz
+|^ markup.list.unnumbered.markdown
+| ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|   ^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-10
+
+#	Foo
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
-|^^^^^^^^^^^^^ markup.heading.1.markdown
-|^ - entity.name.section
-| ^^^^^^^^^ entity.name.section.markdown
-|          ^^ - entity.name.section
-|           ^ punctuation.definition.heading.end.markdown
+|^^^^^ markup.heading.1.markdown - punctuation
 
-https://spec.commonmark.org/0.30/#example-76
-## heading \##
+## https://spec.commonmark.org/0.30/#example-11
+
+*	*	*	
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^ meta.separator.thematic-break.markdown
+| ^ punctuation.definition.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break.markdown
+
+-	-	-	
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^ meta.separator.thematic-break.markdown
+| ^ punctuation.definition.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break.markdown
+
+_	_	_	
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^ meta.separator.thematic-break.markdown
+| ^ punctuation.definition.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break.markdown
+
+
+# TEST: LIGATURES #############################################################
+
+this is a raw ampersand & does not require HTML escaping
+|                       ^ - entity - illegal
+
+this is a raw bracket < > does not require HTML escaping
+|                     ^^^ - meta.tag - punctuation
+
+these are raw ligatures << <<< <<<< <<<<< >>>>> >>>> >>> >>
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures <- <-- <--- <---- <-< <--< <---< <----<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures -> --> ---> ----> >-> >--> >---> >---->
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >- >-- >--- >---- ----< ---< --< -<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >< >-< >--< >---< <---> <--> <-> <>
+|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures <= <== <=== <==== <=< <==< <===< <====<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures => ==> ===> ====> >=> >==> >===> >====>
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >= >== >=== >==== ====< ===< ==< =<
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures >< >=< >==< >===< <===> <==> <=> <>
+|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+these are raw ligatures - -- --- ---- ----- ===== ==== === == =
+|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
+
+-= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  - constant - keyword - variable
+
+    -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
+|   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw - constant - keyword - variable - punctuation
+
+>  -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant - keyword - variable
+
+> > -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
+| ^ markup.quote.markdown punctuation.definition.blockquote.markdown
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant - keyword - variable
+
+
+# TEST: BACKSLASH ESCAPES #####################################################
+
+## https://spec.commonmark.org/0.30/#example-12
+
+\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
+| <- constant.character.escape.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.escape.markdown
+
+## https://spec.commonmark.org/0.30/#example-13
+
+\	\A\a\ \3\φ\«
+| <- - constant.character.escape
+|^^^^^^^^^^^^^ - constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-14
+
+\*not emphasized*
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^^^^^^^^ - markup.italic
+
+\<br/> not a tag
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^ - markup.tag
+
+\<br/\> not a tag
+| <- constant.character.escape.markdown
+|^^^^^^ - meta.tag
+|    ^^ constant.character.escape
+
+\[not a link](/foo)
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^^^^^^^^^^ - markup.link
+
+\`not code`
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^ - markup.raw
+
+1\. not a list
+|^^ constant.character.escape.markdown
+|^^^^^^^^^^^^^ - markup.list
+
+\* not a list
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^^^^ - markup.list
+
+\# not a heading
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^^^^^^^ - markup.heading
+
+\[foo]: /url "not a reference"
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+\&ouml; not a character entity
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+|^^^^^^ - entity
+
+\~/.bashrc
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+
+## https://spec.commonmark.org/0.30/#example-15
+
+\\*emphasis*
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+| ^^^^^^^^^^ markup.italic.markdown
+
+\\_emphasis_
+| <- constant.character.escape.markdown
+|^ constant.character.escape.markdown
+| ^^^^^^^^^^ markup.italic.markdown
+
+## https://spec.commonmark.org/0.30/#example-16
+
+foo\
+|  ^ meta.hard-line-break.markdown constant.character.escape.markdown
+|   ^ meta.hard-line-break.markdown - constant
+bar
+
+## https://spec.commonmark.org/0.30/#example-17
+
+`` \[\` ``
+|^^^^^^^^^ markup.raw.inline.markdown - constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-18
+
+    \[\]
+|^^^^^^^^ markup.raw.block.markdown - constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-19
+
+~~~
+\[\]
+|^^^^ markup.raw.code-fence.markdown-gfm - constant.character.escape
+~~~
+
+## https://spec.commonmark.org/0.30/#example-20
+
+<http://example.com?find=\*>
+|                        ^^ - constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-21
+
+<a href="/bar\/)">
+|            ^^ - constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-22
+
+[foo](/bar\* "ti\*tle")
+|         ^^ markup.underline.link.markdown constant.character.escape
+|               ^^ constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-23
+
+[foo]
+
+[foo]: /bar\* "ti\*tle"
+|          ^^ markup.underline.link.markdown constant.character.escape
+|                ^^ constant.character.escape
+
+## https://spec.commonmark.org/0.30/#example-24
+
+Note: current design doesn't support highlighting escapes in info strings
+``` foo\+bar
+|      ^^ - constant.character.escape
+foo
+```
+
+
+# TEST: HTML ENTITIES #########################################################
+
+## https://spec.commonmark.org/0.30/#example-25
+
+  &nbsp; &amp; &copy; &AElig; &Dcaron;
+| ^^^^^^ constant.character.entity.named.html
+|       ^ - constant
+|        ^^^^^ constant.character.entity.named.html
+|             ^ - constant
+|              ^^^^^^ constant.character.entity.named.html
+|                    ^ - constant
+|                     ^^^^^^^ constant.character.entity.named.html
+|                            ^ - constant
+|                             ^^^^^^^^ constant.character.entity.named.html
+|                                     ^ - constant
+  
+  &frac34; &HilbertSpace; &DifferentialD;
+| ^^^^^^^^ constant.character.entity.named.html
+|         ^ - constant
+|          ^^^^^^^^^^^^^^ constant.character.entity.named.html
+|                        ^ - constant
+|                         ^^^^^^^^^^^^^^^ constant.character.entity.named.html
+|                                        ^ - constant
+
+  &ClockwiseContourIntegral; &ngE;
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.character.entity.named.html
+|                           ^ - constant
+|                            ^^^^^ constant.character.entity.named.html
+|                                 ^ - constant
+
+## https://spec.commonmark.org/0.30/#example-26
+
+  &#35; &#1234; &#992; &#0;
+| ^^^^^ constant.character.entity.decimal.html
+|      ^ - constant
+|       ^^^^^^^ constant.character.entity.decimal.html
+|              ^ - constant
+|               ^^^^^^ constant.character.entity.decimal.html
+|                     ^ - constant
+|                      ^^^^ constant.character.entity.decimal.html
+|                          ^ - constant
+
+## https://spec.commonmark.org/0.30/#example-27
+
+  &#X22; &#XD06; &#xcab;
+| ^^^^^^ constant.character.entity.hexadecimal.html
+|       ^ - constant
+|        ^^^^^^^ constant.character.entity.hexadecimal.html
+|               ^ - constant
+|                ^^^^^^^ constant.character.entity.hexadecimal.html
+|                       ^ - constant
+
+## https://spec.commonmark.org/0.30/#example-28
+
+  &
+| ^ - constant - invalid
+
+  &nbsp &x; &#; &#x;
+| ^^^^^^ - constant
+|       ^^^ constant.character.entity.named.html
+|          ^^^^^^^^^ - constant
+
+  &#87654321;
+
+  &#abcdef0;
+| ^^^^^^^^^^ - constant
+
+  &hi?;
+| ^^^^^ - constant
+
+Note: ST's HTML or Markdown don't maintain a full list of valid html5 entities
+      for simplicity reasons and therefore invalid entities are highlighted.
+
+## https://spec.commonmark.org/0.30/#example-29
+
+Although HTML5 does accept some entity references without a trailing semicolon
+(such as &copy), these are not recognized here, because it makes the grammar
+too ambiguous:
+
+  &copy
+| ^^^^^ - constant
+
+## https://spec.commonmark.org/0.30/#example-30
+
+Strings that are not on the list of HTML5 named entities are not recognized as
+entity references either:
+
+  &MadeUpEntity;
+| ^^^^^^^^^^^^^^ constant.character.entity.named.html
+
+Note: ST's HTML or Markdown don't maintain a full list of valid html5 entities
+      for simplicity reasons and therefore invalid entities are highlighted.
+
+## https://spec.commonmark.org/0.30/#example-31
+
+<a href="&ouml;&ouml;.html">
+|        ^^^^^^^^^^^^ constant.character.entity.named.html
+
+## https://spec.commonmark.org/0.30/#example-32
+
+[foo](/f&ouml;&ouml; "f&ouml;&ouml;")
+|       ^^^^^^^^^^^^ constant.character.entity.named.html
+|                      ^^^^^^^^^^^^ constant.character.entity.named.html
+
+## https://spec.commonmark.org/0.30/#example-33
+
+[foo]
+
+[foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
+|        ^^^^^^^^^^^^ constant.character.entity.named.html
+|                       ^^^^^^^^^^^^ constant.character.entity.named.html
+
+## https://spec.commonmark.org/0.30/#example-34
+
+``` f&ouml;&ouml;
+foo
+```
+Note: current design doesn't support highlighting entities in info strings
+
+## https://spec.commonmark.org/0.30/#example-35
+
+`f&ouml;&ouml;`
+|^^^^^^^^^^^^^ - constant.character.entity
+
+## https://spec.commonmark.org/0.30/#example-36
+
+    f&ouml;f&ouml;
+|   ^^^^^^^^^^^^^^ - constant.character.entity
+
+## https://spec.commonmark.org/0.30/#example-37
+
+&#42;foo&#42;
+| <- meta.paragraph.markdown constant.character.entity.decimal.html
+|^^^^^^^^^^^^^ meta.paragraph.markdown - markup.italic
+|^^^^ constant.character.entity.decimal.html
+|       ^^^^^ constant.character.entity.decimal.html
+
+*foo*
+| <- meta.paragraph.markdown markup.italic.markdown
+|^^^^ meta.paragraph.markdown markup.italic.markdown
+
+## https://spec.commonmark.org/0.30/#example-38
+
+&#42; foo
+| <- meta.paragraph.markdown constant.character.entity.decimal.html
+|^^^^^^^^^ meta.paragraph.markdown
+|^^^^ constant.character.entity.decimal.html
+
+* foo
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-39
+
+foo&#10;&#10;bar
+| <- meta.paragraph.markdown
+|^^^^^^^^^^^^^^^^ meta.paragraph.markdown
+|  ^^^^^^^^^^ constant.character.entity.decimal.html
+
+## https://spec.commonmark.org/0.30/#example-40
+
+&#9;foo
+| <- meta.paragraph.markdown constant.character.entity.decimal.html
+|^^^ meta.paragraph.markdown constant.character.entity.decimal.html
+|   ^^^^ meta.paragraph.markdown - constant
+
+## https://spec.commonmark.org/0.30/#example-41
+
+[a](url &quot;tit&quot;)
+|       ^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.link
+|       ^^^^^^ constant.character.entity.named.html
+|             ^^^ - constant
+|                ^^^^^^ constant.character.entity.named.html
+
+
+# TEST: THEMATIC BREAKS #######################################################
+
+## https://spec.commonmark.org/0.30/#example-43
+
+***
+|^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+
+---
+|^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+
+___
+|^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+
+## https://spec.commonmark.org/0.30/#example-44
+
++++
+| <- - meta.separator
+|^^^ - meta.separator
+
+## https://spec.commonmark.org/0.30/#example-45
+
+===
+| <- - meta.separator
+|^^^ - meta.separator
+
+## https://spec.commonmark.org/0.30/#example-46
+
+**
+| <- - meta.separator
+|^ - meta.separator
+
+--
+| <- - meta.separator
+|^ - meta.separator
+
+__
+| <- - meta.separator
+|^ - meta.separator
+
+## https://spec.commonmark.org/0.30/#example-47
+
+ ***
+|<- meta.separator.thematic-break.markdown - punctuation
+|^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+  ***
+|<- meta.separator.thematic-break.markdown - punctuation
+|^ meta.separator.thematic-break.markdown - punctuation
+| ^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+   ***
+|<- meta.separator.thematic-break.markdown - punctuation
+|^^ meta.separator.thematic-break.markdown - punctuation
+|  ^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+## https://spec.commonmark.org/0.30/#example-48
+
+    ***
+|<- markup.raw.block.markdown
+|^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-49
+
+Foo
+    ***
+| <- meta.paragraph.markdown
+|^^^^^^^ meta.paragraph.markdown
+
+## https://spec.commonmark.org/0.30/#example-50
+
+**************************************
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+--------------------------------------
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+_____________________________________
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+## https://spec.commonmark.org/0.30/#example-51
+
+ * * *
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^ meta.separator.thematic-break.markdown
+|^ punctuation.definition.thematic-break.markdown
+| ^ - punctuation
+|  ^ punctuation.definition.thematic-break.markdown
+|   ^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+
+ - - -
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^ meta.separator.thematic-break.markdown
+|^ punctuation.definition.thematic-break.markdown
+| ^ - punctuation
+|  ^ punctuation.definition.thematic-break.markdown
+|   ^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+
+ _ _ _
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^ meta.separator.thematic-break.markdown
+|^ punctuation.definition.thematic-break.markdown
+| ^ - punctuation
+|  ^ punctuation.definition.thematic-break.markdown
+|   ^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-52
+
+ **  * ** * ** * **
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+|  ^^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+|      ^^ punctuation.definition.thematic-break.markdown
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break.markdown
+|          ^ - punctuation
+|           ^^ punctuation.definition.thematic-break.markdown
+|             ^ - punctuation
+|              ^ punctuation.definition.thematic-break.markdown
+|               ^ - punctuation
+|                ^^ punctuation.definition.thematic-break.markdown
+|                  ^ - punctuation
+
+ --  - -- - -- - --
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+|  ^^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+|      ^^ punctuation.definition.thematic-break.markdown
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break.markdown
+|          ^ - punctuation
+|           ^^ punctuation.definition.thematic-break.markdown
+|             ^ - punctuation
+|              ^ punctuation.definition.thematic-break.markdown
+|               ^ - punctuation
+|                ^^ punctuation.definition.thematic-break.markdown
+|                  ^ - punctuation
+
+ __  _ __ _ __ _ __
+| <- meta.separator.thematic-break.markdown - punctuation
+|^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^ punctuation.definition.thematic-break.markdown
+|  ^^ - punctuation
+|    ^ punctuation.definition.thematic-break.markdown
+|     ^ - punctuation
+|      ^^ punctuation.definition.thematic-break.markdown
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break.markdown
+|          ^ - punctuation
+|           ^^ punctuation.definition.thematic-break.markdown
+|             ^ - punctuation
+|              ^ punctuation.definition.thematic-break.markdown
+|               ^ - punctuation
+|                ^^ punctuation.definition.thematic-break.markdown
+|                  ^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-53
+
+*     *      *      *
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^^^^ - punctuation
+|     ^ punctuation.definition.thematic-break.markdown 
+|      ^^^^^^ - punctuation
+|            ^ punctuation.definition.thematic-break.markdown 
+|             ^^^^^^ - punctuation
+|                   ^ punctuation.definition.thematic-break.markdown 
+|                    ^ - punctuation
+
+-     -      -      -
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^^^^ - punctuation
+|     ^ punctuation.definition.thematic-break.markdown 
+|      ^^^^^^ - punctuation
+|            ^ punctuation.definition.thematic-break.markdown 
+|             ^^^^^^ - punctuation
+|                   ^ punctuation.definition.thematic-break.markdown 
+|                    ^ - punctuation
+
+_     _      _      _
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|^^^^^ - punctuation
+|     ^ punctuation.definition.thematic-break.markdown 
+|      ^^^^^^ - punctuation
+|            ^ punctuation.definition.thematic-break.markdown 
+|             ^^^^^^ - punctuation
+|                   ^ punctuation.definition.thematic-break.markdown 
+|                    ^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-54
+
+* * * *
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^ meta.separator.thematic-break.markdown
+|^ - punctuation
+| ^ punctuation.definition.thematic-break
+|  ^ - punctuation
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+
+- - - -
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^ meta.separator.thematic-break.markdown
+|^ - punctuation
+| ^ punctuation.definition.thematic-break
+|  ^ - punctuation
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+
+_ _ _ _
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^^^ meta.separator.thematic-break.markdown
+|^ - punctuation
+| ^ punctuation.definition.thematic-break
+|  ^ - punctuation
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-55
+
+_ _ _ _ a
+| <- meta.paragraph.markdown - meta.separator
+|^^^^^^^^^ meta.paragraph.markdown - meta.separator
+
+a------
+| <- meta.paragraph.markdown - meta.separator
+|^^^^^^^ meta.paragraph.markdown - meta.separator
+
+---a---
+| <- meta.paragraph.markdown - meta.separator
+|^^^^^^^ meta.paragraph.markdown - meta.separator
+
+## https://spec.commonmark.org/0.30/#example-56
+
+ *-*
+| <- meta.paragraph.markdown - meta.separator
+|^^^ meta.paragraph.markdown - meta.separator
+
+## https://spec.commonmark.org/0.30/#example-57
+
+- foo
+***
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+- bar
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+## https://spec.commonmark.org/0.30/#example-58
+
+Foo
+***
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+bar
+| <- meta.paragraph.markdown
+
+## https://spec.commonmark.org/0.30/#example-59
+
+Foo
+---
+| <- markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+|^^ markup.heading.2.markdown punctuation.definition.heading.setext.markdown
+bar
+| <- meta.paragraph.markdown
+
+## https://spec.commonmark.org/0.30/#example-60
+
+* Foo
+* * *
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^^^ meta.separator.thematic-break.markdown
+| ^ punctuation.definition.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break.markdown
+* Bar
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+## https://spec.commonmark.org/0.30/#example-61
+
+- Foo
+- * * *
+| ^^^^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown
+
+
+# TEST: ATX HEADINGS ##########################################################
+
+## https://spec.commonmark.org/0.30/#example-62
+
+# foo
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^ markup.heading.1.markdown - punctuation
+
+## foo
 | <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
-|^^^^^^^^^^^^^^ markup.heading.2.markdown
-|^^ - entity
-|  ^^^^^^^^^^^ entity.name.section.markdown
-|          ^^ constant.character.escape.markdown
-|          ^^^ - punctuation
-|             ^ - entity.name.section
+|^ markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+| ^^^^^ markup.heading.2.markdown - punctuation
 
-https://spec.commonmark.org/0.30/#example-79
+### foo
+| <- markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|^^ markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|  ^^^^^ markup.heading.3.markdown - punctuation
+
+#### foo
+| <- markup.heading.4.markdown punctuation.definition.heading.begin.markdown
+|^^^ markup.heading.4.markdown punctuation.definition.heading.begin.markdown
+|   ^^^^^ markup.heading.4.markdown - punctuation
+
+##### foo
+| <- markup.heading.5.markdown punctuation.definition.heading.begin.markdown
+|^^^^ markup.heading.5.markdown punctuation.definition.heading.begin.markdown
+|    ^^^^^ markup.heading.5.markdown - punctuation
+
+###### foo
+| <- markup.heading.6.markdown punctuation.definition.heading.begin.markdown
+|^^^^^ markup.heading.6.markdown punctuation.definition.heading.begin.markdown
+|     ^^^^^ markup.heading.6.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-63
+
+####### foo
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^^^^^ meta.paragraph.markdown - markup.heading
+
+## https://spec.commonmark.org/0.30/#example-64
+
+#5 bolt
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^ meta.paragraph.markdown - markup.heading
+
+#hashtag
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^^ meta.paragraph.markdown - markup.heading
+
+## https://spec.commonmark.org/0.30/#example-65
+
+\## foo
+| <- meta.paragraph.markdown constant.character.escape.markdown - markup
+|^ meta.paragraph.markdown constant.character.escape.markdown - markup
+| ^^^^^^ meta.paragraph.markdown - constant - markup
+
+## https://spec.commonmark.org/0.30/#example-66
+
+# foo *bar* \*baz\*
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^ markup.heading.1.markdown - entity.name - markup.italic
+| ^^^^ markup.heading.1.markdown entity.name.section.markdown - markup.italic
+|     ^^^^^ markup.heading.1.markdown entity.name.section.markdown markup.italic.markdown
+|          ^^^^^^^^ markup.heading.1.markdown entity.name.section.markdown - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-67
+
+#                  foo                     
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown - entity.name
+|                  ^^^ markup.heading.1.markdown entity.name.section.markdown
+|                     ^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown - entity.name
+
+## https://spec.commonmark.org/0.30/#example-68
+
+ ### foo
+| <- markup.heading.3.markdown
+|^^^^^^^^ markup.heading.3.markdown 
+  ## foo
+| <- markup.heading.2.markdown
+|^^^^^^^^ markup.heading.2.markdown  
+   # foo
+| <- markup.heading.1.markdown
+|^^^^^^^^ markup.heading.1.markdown   
+
+## https://spec.commonmark.org/0.30/#example-69
+
+    # foo
+| <- markup.raw.block.markdown
+|^^^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-70
+
+foo
+    # bar
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^^^ meta.paragraph.markdown - markup.heading
+
+## https://spec.commonmark.org/0.30/#example-71
+
+## foo ##
+  ###   bar    ###
+| <- markup.heading.3.markdown
+|^^^^^^^^^^^^^^^^^^ markup.heading.3.markdown
+| ^^^ punctuation.definition.heading.begin.markdown
+|    ^^^ - entity - punctuation 
+|       ^^^ entity.name.section.markdown
+|          ^^^^ - entity - punctuation 
+|              ^^^ punctuation.definition.heading.end.markdown
+|                 ^ - punctuation 
+
+## https://spec.commonmark.org/0.30/#example-72
+
+# foo ##################################
+##### foo ##
+| <- markup.heading.5.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^ markup.heading.5.markdown
+|^^^^ punctuation.definition.heading.begin.markdown
+|    ^ - entity - punctuation 
+|     ^^^ entity.name.section.markdown
+|        ^ - entity - punctuation 
+|         ^^ punctuation.definition.heading.end.markdown
+|           ^ - punctuation 
+
+## https://spec.commonmark.org/0.30/#example-73
+
+### foo ###     
+| <- markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^^^ markup.heading.3.markdown
+|^^ punctuation.definition.heading.begin.markdown
+|  ^ - entity - punctuation 
+|   ^^^ entity.name.section.markdown
+|      ^ - entity - punctuation 
+|       ^^^ punctuation.definition.heading.end.markdown
+|          ^^^^^^ - punctuation 
+
+## https://spec.commonmark.org/0.30/#example-74
+
+### foo ### b
+| <- markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^ markup.heading.3.markdown
+|^^ punctuation.definition.heading.begin.markdown
+|  ^ - entity - punctuation 
+|   ^^^^^^^^^ entity.name.section.markdown
+|            ^ - entity
+
+## https://spec.commonmark.org/0.30/#example-75
+
+# foo#
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^ markup.heading.1.markdown
+|^ - entity - punctuation 
+| ^^^^ entity.name.section.markdown
+|     ^ - entity
+
+# foo# #
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^ markup.heading.1.markdown
+|^ - entity - punctuation 
+| ^^^^ entity.name.section.markdown
+|     ^ - entity - punctuation 
+|      ^ punctuation.definition.heading.end.markdown
+|       ^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-76
+
+### foo \###
+| <- markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^ markup.heading.3.markdown
+|^^ punctuation.definition.heading.begin.markdown
+|   ^^^^^^^^ entity.name.section.markdown
+|       ^^ constant.character.escape.markdown
+|           ^ - constant - entity - punctuation
+
+## foo #\##
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^ markup.heading.2.markdown
+|^ punctuation.definition.heading.begin.markdown
+|  ^^^^^^^^ entity.name.section.markdown
+|       ^^ constant.character.escape.markdown
+|          ^ - constant - entity - punctuation
+
+# foo \#
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^ markup.heading.1.markdown
+| ^^^^^^ entity.name.section.markdown
+|     ^^ constant.character.escape.markdown
+|       ^ - constant - entity - punctuation
+
+## https://spec.commonmark.org/0.30/#example-77
+
+****
+## foo
+| <- markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^ markup.heading.2.markdown
+
+****
+## foo
+****
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+|^^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+## https://spec.commonmark.org/0.30/#example-78
+
+Foo bar
+# baz
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^ markup.heading.1.markdown
+
+Foo bar
+# baz
+Bar foo
+| <- meta.paragraph.markdown - markup.heading
+|^^^^^^^ meta.paragraph.markdown - markup.heading
+
+Foo **bar
+# baz
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold
+|^^^^^ markup.heading.1.markdown
+this must not be bold**
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Foo *bar
+# baz
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.italic
+|^^^^ markup.heading.1.markdown
+this must not be italic*
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
+
+Foo ***bar
+# baz
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold - markup.italic
+|^^^^^ markup.heading.1.markdown
+this must not be bold italic***
+| <- - meta.bold - markup.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-79
+
 #
 | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
 
@@ -100,38 +1052,8 @@ https://spec.commonmark.org/0.30/#example-79
 |      ^^^ - entity.name.section
 |       ^^ punctuation.definition.heading.end.markdown
 
-#NotAHeading
-| <- - markup.heading
-|^^^^^^^^^^^^ - markup.heading
 
-Headings terminate paragraphs
-# Heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold
-|^^^^^^^^ markup.heading.1.markdown
-
-Headings terminate **bold text
-# Heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold
-|^^^^^^^^ markup.heading.1.markdown
-this must not be bold**
-| <- - meta.bold
-|^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
-
-Headings terminate *italic text
-# Heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.italic
-|^^^^^^^^ markup.heading.1.markdown
-this must not be italic*
-| <- - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
-
-Headings terminate ***bold italic text
-# Heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.bold - markup.italic
-|^^^^^^^^ markup.heading.1.markdown
-this must not be bold italic***
-| <- - meta.bold - markup.italic
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - markup.italic
+# TEST: SETEXT HEADINGS #######################################################
 
 SETEXT Heading Level 1
 | <- markup.heading.1.markdown entity.name.section.markdown
@@ -403,8 +1325,5702 @@ Fenced codeblocks are no no setext heading
 |^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
 
 
-Paragraph of text that should be scoped as meta.paragraph.
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph
+# TEST: INDENTED CODE BLOCKS ##################################################
+
+Code block below:
+
+    this is code!
+| ^^^^^^^^^^^^^^^^ markup.raw.block
+
+    more code
+    spanning multiple lines
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block
+
+paragraph
+| <- meta.paragraph
+
+
+# TEST: FENCED CODE BLOCKS ####################################################
+
+## https://spec.commonmark.org/0.30/#example-119
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+<
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+ >
+|^^ markup.raw.code-fence.markdown-gfm - punctuation
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-120
+
+~~~
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+<
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+ >
+|^^ markup.raw.code-fence.markdown-gfm - punctuation
+~~~
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-121
+
+``
+foo
+``
+| <- - meta.code-fence - punctuation.definition.raw.code-fence
+|^ - meta.code-fence - punctuation.definition.raw.code-fence
+
+## https://spec.commonmark.org/0.30/#example-122
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+~~~
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-123
+
+~~~
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+```
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+~~~
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+~~~~ 
+| <- punctuation.definition.raw.code-fence.begin
+ ~~~~
+| ^^^ punctuation.definition.raw.code-fence.end
+
+## https://spec.commonmark.org/0.30/#example-124
+
+````
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+```
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+``````
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-125
+
+~~~~
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|
+aaa
+~~~
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+~~~~
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-128
+
+> ```
+> aaa
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - markup.raw
+| ^^^^ markup.quote.markdown markup.raw.code-fence.markdown-gfm
+
+bbb
+| <- meta.paragraph.markdown - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-129
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+
+  
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-130
+
+```
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-131
+
+ ```
+ aaa
+aaa
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-132
+
+  ```
+aaa
+  aaa
+aaa
+  ```
+| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-133
+
+   ```
+   aaa
+    aaa
+  aaa
+   ```
+| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-134
+
+    ```
+    aaa
+    ```
+| <- markup.raw.block.markdown
+|^^^^^^^ markup.raw.block.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-135
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+| <- markup.raw.code-fence.markdown-gfm
+  ```
+| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-136
+
+   ```
+| <- meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|     ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+| <- markup.raw.code-fence.markdown-gfm
+  ```
+| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-137
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+aaa
+| <- markup.raw.code-fence.markdown-gfm
+    ```
+| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|^^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+|   ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|      ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-138
+
+``` ```
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^ markup.raw.inline.markdown
+
+``` ```
+aaa
+| <- meta.paragraph.markdown - meta.code-fence - markup
+|^^ meta.paragraph.markdown - meta.code-fence - markup
+
+## https://spec.commonmark.org/0.30/#example-139
+
+~~~~~~
+aaa
+~~~ ~~
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+|^^^^^^ markup.raw.code-fence.markdown-gfm - punctuation
+
+~~~~~~
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
+
+## https://spec.commonmark.org/0.30/#example-140
+
+foo
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+bar
+```
+baz
+| <- meta.paragraph.markdown - meta.code-fence - markup
+|^^ meta.paragraph.markdown - meta.code-fence - markup
+
+## https://spec.commonmark.org/0.30/#example-140-including-emphasis-termination
+
+Paragraph is terminated by fenced code blocks.
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+Code blocks terminate **bold text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold**
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Code blocks terminate __bold text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold__
+| <- - meta.bold
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
+
+Code blocks terminate *italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be italic*
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
+
+Code blocks terminate _italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be italic_
+| <- - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate ***bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic***
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate ___bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic___
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+Code blocks terminate **_bold italic text
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+this must not be bold italic_**
+| <- - meta.bold - meta.italic
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
+
+## https://spec.commonmark.org/0.30/#example-141
+
+foo
+---
+~~~
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+bar
+|^^^ markup.raw.code-fence.markdown-gfm
+~~~
+# baz
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^ markup.heading.1.markdown
+
+## https://spec.commonmark.org/0.30/#example-142
+
+```ruby
+| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.ruby.markdown-gfm - constant
+def foo(x)
+| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+  return 3
+end
+| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+```
+| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-143
+
+~~~~    ruby startline=3 $%@#$
+| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - punctuation - constant
+|       ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
+|           ^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - constant
+def foo(x)
+| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+  return 3
+end
+| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+~~~~~~~
+| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-144
+
+````;
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^ meta.code-fence.definition.begin.text.markdown-gfm
+````
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-145
+
+``` aa ```
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^^^^ meta.paragraph.markdown markup.raw.inline.markdown
+|^^ punctuation.definition.raw.begin.markdown
+|      ^^^ punctuation.definition.raw.end.markdown
+foo
+| <- meta.paragraph.markdown - markup
+
+## https://spec.commonmark.org/0.30/#example-146
+
+~~~ aa ``` ~~~
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
+|     ^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
+foo
+~~~
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+~~~~~foo~
+|^^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
+
+~~~~~
+|^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-147
+
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+``` aaa
+| <- markup.raw.code-fence.markdown-gfm - punctuation
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://fenced-code-block-embedded-syntaxes-tests
+
+```bash
+# test
+| ^^^^^ source.shell comment.line.number-sign
+echo hello, \
+|           ^^ punctuation.separator.continuation.line
+echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
+|                       ^^ constant.character.escape
+```
+| <- meta.code-fence.definition.end.shell-script punctuation.definition.raw.code-fence.end
+|^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```clojure
+|^^^^^^^^^ meta.code-fence.definition.begin.clojure
+|  ^^^^^^^ constant.other.language-name
+ (/ 10 3.0)
+| <- source.clojure
+|^^^^^^^^^^ source.clojure
+```
+| <- meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```cmd
+
+| <- markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
+```
+| <- meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```css
+
+| <- markup.raw.code-fence.css.markdown-gfm source.css
+```
+| <- meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```diff
++ inserted
+| <- source.diff markup.inserted.diff punctuation.definition.inserted.diff
+- deleted
+| <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
+```
+| <- meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```Graphviz
+graph n {}
+| ^^^ storage.type.dot
+```
+| <- meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```haskell
+
+| <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
+```
+| <- meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```html
+  <html>
+| <- markup.raw.code-fence.html.markdown-gfm text.html
+| ^^^^^^ text.html meta.tag
+```
+| <- meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```html+php
+<div></div>
+|^^^ entity.name.tag.block.any.html
+<?php
+| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html.basic meta.embedded.block.php punctuation.section.embedded.begin.php
+var_dump(expression);
+| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html.basic meta.embedded.block.php source.php meta.function-call
+```
+| <- meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```js
+| <- punctuation.definition.raw.code-fence.begin
+|  ^^ constant.other.language-name
+for (var i = 0; i < 10; i++) {
+| ^ source.js keyword.control.loop
+    console.log(i);
+}
+```
+| <- meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```jsx
+
+| <- markup.raw.code-fence.jsx.markdown-gfm
+```
+| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```lisp
+
+| <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
+```
+| <- meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```lua
+
+| <- markup.raw.code-fence.lua.markdown-gfm source.lua
+```
+| <- meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```matlab
+
+| <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
+```
+| <- meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```ocaml
+
+| <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
+```
+| <- meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```php
+var_dump(expression);
+| <- markup.raw.code-fence.php.markdown-gfm source.php meta.function-call.php
+```
+| <- meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```python
+|^^ punctuation.definition.raw.code-fence.begin
+|^^^^^^^^^ meta.code-fence.definition.begin.python - markup
+|  ^^^^^^ constant.other.language-name
+def function():
+    pass
+|   ^^^^ keyword.control.flow
+unclosed_paren = (
+|                ^ meta.group.python punctuation.section.group.begin.python
+```
+| <- meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```regex
+(?x)
+\s+
+| <- markup.raw.code-fence.regexp.markdown-gfm source.regexp
+```
+| <- meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```scala
+
+| <- markup.raw.code-fence.scala.markdown-gfm source.scala
+```
+| <- meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```sh
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+| <- meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```shell
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+| <- meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```shell-script
+
+| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
+```
+| <- meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.shell-script.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```sql
+|^^^^^ meta.code-fence.definition.begin.sql
+|  ^^^ constant.other.language-name
+SELECT TOP 10 *
+|^^^^^^^^^^^^^^^ markup.raw.code-fence.sql source.sql
+FROM TableName
+```
+| <- meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```xml
+|^^^^^ meta.code-fence.definition.begin.xml
+|  ^^^ constant.other.language-name
+<?xml version="1.0" ?>
+|^^^^^^^^^^^^^^^^^^^^^^ markup.raw.code-fence.xml
+|     ^^^^^^^ meta.tag.preprocessor.xml entity.other.attribute-name.localname.xml
+<example>
+    <foobar />
+</example>
+```
+| <- meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+```R%&?! weired language name
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|  ^^^^^ constant.other.language-name.markdown
+|        ^^^^^^^^^^^^^^^^^^^^^ - constant
+```
+
+```{key: value}
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|  ^^^^^^^^^^^^ - constant
+```
+
+``` {key: value}
+|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+|   ^^^^^^^^^^^^ - constant
+```
+
+
+# TEST: HTML BLOCKS ###########################################################
+
+## https://spec.commonmark.org/0.30/#example-148
+
+<table><tr><td>
+<pre>
+**Hello**,
+| ^^^^^^^^^ meta.disable-markdown - markup
+
+_world_.
+| ^^^^ markup.italic - meta.disable-markdown
+</pre>
+</td></tr></table>
+
+## https://spec.commonmark.org/0.30/#example-149
+
+<table>
+  <tr>
+    <td>
+           hi
+|^^^^^^^^^^^^^ meta.disable-markdown
+    </td>
+  </tr>
+</table>
+
+okay.
+| <- meta.paragraph.markdown
+|^^^^^ meta.paragraph.markdown
+
+## https://spec.commonmark.org/0.30/#example-150
+
+ <div>
+  *hello*
+         <foo><a>
+| <- meta.disable-markdown
+|^^^^^^^^^^^^^^^^^ meta.disable-markdown
+|        ^^^^^^^^ meta.tag
+
+## https://spec.commonmark.org/0.30/#example-151
+
+</div>
+*foo*
+| <- meta.disable-markdown - markup.italic
+|^^^^^ meta.disable-markdown - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-152
+
+<DIV CLASS="foo">
+| ^^^^^^^^^^^^^^^^ meta.disable-markdown
+
+*Markdown*
+| ^^^^^^^ meta.paragraph markup.italic - meta.disable-markdown
+
+</DIV>
+| ^^^ meta.disable-markdown meta.tag.block.any.html
+
+## https://spec.commonmark.org/0.30/#example-153
+
+<div id="foo"
+  class="bar">
+|^^^^^^^^^^^^^ meta.disable-markdown meta.tag.block  
+</div>
+|^^^^^ meta.disable-markdown meta.tag.block
+
+## https://spec.commonmark.org/0.30/#example-154
+
+<div id="foo" class="bar
+  baz">
+|^^^^^^ meta.disable-markdown meta.tag.block  
+</div>
+|^^^^^ meta.disable-markdown meta.tag.block
+
+## https://spec.commonmark.org/0.30/#example-155
+
+<div>
+*foo*
+| <- meta.disable-markdown - markup.italic
+
+<div>
+*foo*
+
+*bar*
+| <- meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.begin.markdown
+
+## https://spec.commonmark.org/0.30/#example-159
+
+<div><a href="bar">*foo*</a></div>
+|                  ^^^^^ meta.disable-markdown - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-161
+
+<div></div>
+``` c
+int x = 33;
+```
+|^^^ meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-162
+
+<a href="foo">
+*bar*
+| <- meta.disable-markdown - markup.italic - punctuation
+|^^^^^ meta.disable-markdown - markup.italic
+</a>
+
+## https://spec.commonmark.org/0.30/#example-163
+
+<Warning>
+*bar*
+| <- meta.disable-markdown - markup.italic - punctuation
+|^^^^^ meta.disable-markdown - markup.italic
+</Warning>
+| ^^^^^^^ meta.disable-markdown meta.tag.other.html entity.name.tag.other.html
+
+## https://spec.commonmark.org/0.30/#example-164
+
+<i class="foo">
+*bar*
+| <- meta.disable-markdown - markup.italic - punctuation
+|^^^^^ meta.disable-markdown - markup.italic
+</i>
+| <- meta.disable-markdown meta.tag punctuation.definition.tag
+|^^^ meta.disable-markdown meta.tag
+|   ^ meta.disable-markdown - meta.tag
+
+## https://spec.commonmark.org/0.30/#example-165
+
+</ins>
+*bar*
+| <- meta.disable-markdown - markup.italic - punctuation
+|^^^^^ meta.disable-markdown - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-166
+
+<del>
+*foo*
+| <- meta.disable-markdown - markup.italic - punctuation
+|^^^^^ meta.disable-markdown - markup.italic
+</del>
+| <- meta.disable-markdown meta.tag punctuation.definition.tag
+|^^^^^ meta.disable-markdown meta.tag
+|     ^ meta.disable-markdown - meta.tag
+
+## https://spec.commonmark.org/0.30/#example-167
+
+<del>
+| <- meta.disable-markdown meta.tag punctuation.definition.tag
+|^^^^ meta.disable-markdown meta.tag
+|    ^ meta.disable-markdown - meta.tag
+
+*foo*
+| <- meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^ meta.paragraph.markdown markup.italic.markdown - punctuation
+|   ^ meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.end.markdown
+
+</del>
+| <- meta.disable-markdown meta.tag punctuation.definition.tag
+|^^^^^ meta.disable-markdown meta.tag
+|     ^ meta.disable-markdown - meta.tag
+
+## https://spec.commonmark.org/0.30/#example-168
+
+<del>*foo*</del>
+|^^^^^^^^^^^^^^^ meta.paragraph - meta.disable-markdown
+|^^^^ meta.tag.inline
+|    ^^^^^ markup.italic
+|         ^^^^^^ meta.tag.inline
+
+## https://spec.commonmark.org/0.30/#example-169
+
+<pre language="haskell"><code>
+| ^^ meta.disable-markdown meta.tag.block.any.html entity.name.tag.block.any.html
+import Text.HTML.TagSoup
+
+main :: IO ()
+| ^^^^^^^^^^^^ meta.disable-markdown
+main = print $ parseTags tags
+</code></pre>
+| ^^^^^^^^^^^ meta.disable-markdown
+|        ^^^ meta.tag.block.any.html entity.name.tag.block.any.html
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-170
+
+<script type="text/javascript">
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.script.begin.html
+// JavaScript example
+| ^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown source.js.embedded.html comment.line.double-slash.js
+
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+| ^^^^^^ meta.disable-markdown source.js.embedded.html support.type.object.dom.js
+</script>
+| ^^^^^^ meta.disable-markdown meta.tag.script.end.html entity.name.tag.script.html
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-171
+
+<style
+  type="text/css">
+| ^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.style.begin.html meta.attribute-with-value.html
+h1 {color:red;}
+|   ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
+
+p {color:blue;}
+|  ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
+</style>
+| ^^^^^ meta.disable-markdown meta.tag.style.end.html entity.name.tag.style.html
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-172
+
+<style
+  type="text/css">
+h1 {color:red;}
+| <- meta.disable-markdown source.css.embedded.html meta.selector.css entity.name.tag
+
+p {color:blue;}
+| <- meta.disable-markdown source.css.embedded.html meta.selector.css entity.name.tag
+</style>
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-174
+
+> <div>
+> foo
+
+bar
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-175
+
+- <div>
+- foo
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-176
+
+<style>p{color:red;}</style>
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+*foo*
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-177
+
+<!-- foo -->*bar*
+| ^^^^^^^^^^ comment.block.html
+|           ^^^^^ meta.disable-markdown
+*baz*
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-178
+
+<script>
+foo
+</script>1. *bar*
+| ^^^^^^^^^^^^^^^^ meta.disable-markdown
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-179
+
+<!-- Foo
+| ^^ meta.disable-markdown comment.block.html punctuation.definition.comment
+
+bar
+   baz -->
+| ^^^^^^^^ meta.disable-markdown comment.block.html
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-180
+
+<?php
+| ^^^^ meta.disable-markdown
+
+  echo '>';
+
+?>
+|^^ meta.disable-markdown
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-181
+
+<!DOCTYPE html>
+| ^^^^^^^ meta.disable-markdown meta.tag.sgml.doctype.html
+okay
+| <- - meta.disable-markdown
+
+<!ENTITY html>
+| ^^^^^^^^^^^^^ meta.disable-markdown
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-182
+
+<![CDATA[
+| ^^^^^^^^ meta.disable-markdown meta.tag.sgml
+function matchwo(a,b)
+{
+  if (a < b && a < 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]>
+|^^ meta.disable-markdown meta.tag.sgml
+okay
+| <- - meta.disable-markdown
+
+## https://spec.commonmark.org/0.30/#example-183
+
+  <!-- foo -->
+| ^^^^^^^^^^^^ meta.disable-markdown comment.block.html
+
+    <!-- foo -->
+|^^^^^^^^^^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-184
+
+  <div>
+
+    <div>
+|^^^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-188
+
+<div>
+
+*Emphasized* text.
+|^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^ markup.italic.markdown
+
+</div>
+| <- meta.disable-markdown meta.tag.block
+|^^^^^ meta.disable-markdown meta.tag.block
+
+## https://spec.commonmark.org/0.30/#example-189
+
+<div>
+*Emphasized* text.
+| <- meta.disable-markdown - markup.italic
+|^^^^^^^^^^^^^^^^^^ meta.disable-markdown - markup.italic
+</div>
+| <- meta.disable-markdown meta.tag.block
+|^^^^^ meta.disable-markdown meta.tag.block
+
+## https://spec.commonmark.org/0.30/#example-190
+
+<table>
+| <- meta.disable-markdown meta.tag
+|^^^^^^ meta.disable-markdown meta.tag
+
+<tr>
+| <- meta.disable-markdown meta.tag
+|^^^ meta.disable-markdown meta.tag
+
+<td>
+Hi
+</td>
+| <- meta.disable-markdown meta.tag
+|^^^^ meta.disable-markdown meta.tag
+
+</tr>
+| <- meta.disable-markdown meta.tag
+|^^^^ meta.disable-markdown meta.tag
+
+</table>
+| <- meta.disable-markdown meta.tag
+|^^^^^^^ meta.disable-markdown meta.tag
+
+## https://spec.commonmark.org/0.30/#example-191
+
+<table>
+| <- meta.disable-markdown meta.tag
+|^^^^^^ meta.disable-markdown meta.tag
+
+  <tr>
+| <- meta.disable-markdown
+|^^^^^^^ meta.disable-markdown
+
+    <td>
+      Hi
+    </td>
+| <- markup.raw.block.markdown
+|^^^^^^^^^ markup.raw.block.markdown
+
+  </tr>
+| <- meta.disable-markdown
+|^^^^^^^ meta.disable-markdown
+
+</table>
+| <- meta.disable-markdown meta.tag
+|^^^^^^^ meta.disable-markdown meta.tag
+
+## https://custom-tests/html-blocks
+
+<div>this is HTML until <span>there are two</span> blank lines</div>
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+disabled markdown
+| <- meta.disable-markdown
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+<div>this is HTML until there are two blank lines
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+still <span>HTML</span>
+|      ^^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+</div>
+| ^^^^ meta.disable-markdown
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+<pre>nested tags don't count <pre>test</pre>
+|                                     ^^^^^^ meta.disable-markdown meta.tag.block.any.html
+non-disabled markdown
+| <- - meta.disable-markdown
+
+<div>nested tags don't count <div>test
+|                                 ^^^^^ meta.disable-markdown
+</div>
+| ^^^ meta.disable-markdown entity.name.tag.block.any.html
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+<div>two blank lines needed</div> to stop disabled markdown
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+disabled markdown
+| <- meta.disable-markdown
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+<div>another</div> <span>disable</span> test
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+|                  ^^^^^^ meta.tag.inline.any.html
+disabled markdown
+| <- meta.disable-markdown
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+*a*
+| ^ markup.italic
+<p>*a*</p>
+| ^^^^^^^^^ meta.disable-markdown - markup.italic
+*a*
+| ^^ meta.disable-markdown
+
+non-disabled markdown
+| <- - meta.disable-markdown
+
+
+# TEST: LINK REFERENCE DEFINITIONS ############################################
+
+## https://spec.commonmark.org/0.30/#example-192
+
+[foo]: /url "title"
+|^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|    ^ punctuation.separator.key-value
+|      ^^^^ markup.underline.link
+|           ^^^^^^^ string.quoted.double
+
+## https://spec.commonmark.org/0.30/#example-193
+
+   [foo]: 
+      /url  
+           'the title'  
+|^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|          ^^^^^^^^^^^ string.quoted.single
+
+## https://spec.commonmark.org/0.30/#example-194
+
+ [Foo*bar\]]:my_(url) 'title (with parens)'
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|^ punctuation.definition.reference.begin.markdown
+| ^^^^^^^^^ entity.name.reference.link.markdown - punctuation
+|          ^ punctuation.definition.reference.end.markdown
+|           ^ punctuation.separator.key-value.markdown
+|            ^^^^^^^^ markup.underline.link
+|                    ^ - markup - string
+|                     ^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
+
+## https://spec.commonmark.org/0.30/#example-195
+
+[Foo bar]:
+<my url>
+| <- meta.link.reference.def.markdown punctuation.definition.link.begin.markdown
+|^^^^^^ meta.link.reference.def.markdown markup.underline.link.markdown
+|      ^ meta.link.reference.def.markdown punctuation.definition.link.end.markdown
+
+[Foo bar]:
+<my url>
+'title'
+| <- meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+|^^^^^^ meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+
+## https://spec.commonmark.org/0.30/#example-196
+
+[foo]: /url '
+|           ^ meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown punctuation.definition.string.begin.markdown
+title
+| <- meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+|^^^^^ meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+line1
+| <- meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+|^^^^^ meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+line2
+| <- meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+|^^^^^ meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown
+'
+| <- meta.link.reference.def.markdown meta.string.title.markdown string.quoted.single.markdown punctuation.definition.string.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-197
+
+[foo]: /url 'title
+
+with blank line'
+| <- meta.paragraph.markdown - meta.link
+|^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.link
+
+## https://spec.commonmark.org/0.30/#example-198
+
+[foo]:
+/url
+| <- meta.link.reference.def.markdown markup.underline.link.markdown punctuation.separator.path.markdown
+|^^^ meta.link.reference.def.markdown markup.underline.link.markdown
+
+## https://spec.commonmark.org/0.30/#example-199
+
+[foo]:
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^ meta.link.reference.def.markdown entity.name.reference.link.markdown
+|   ^ meta.link.reference.def.markdown punctuation.definition.reference.end.markdown
+|    ^ meta.link.reference.def.markdown punctuation.separator.key-value.markdown
+|     ^ meta.link.reference.def.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-200
+
+[foo]: <>
+|^^^^^^^^ meta.link.reference.def.markdown
+|    ^ punctuation.separator.key-value
+|      ^ punctuation.definition.link.begin
+|       ^ punctuation.definition.link.end
+
+## https://spec.commonmark.org/0.30/#example-201
+
+[foo]: <bar>(baz)
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^ punctuation.definition.link.begin.markdown
+|       ^^^ markup.underline.link.markdown
+|          ^ punctuation.definition.link.end.markdown
+|           ^^^^^ meta.string.title.markdown string.quoted.other.markdown
+|           ^ punctuation.definition.string.begin.markdown
+|               ^ punctuation.definition.string.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-202
+
+[foo]: /url\bar\*baz "foo\"bar\baz"
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^^^^^^^^^^^^^ markup.underline.link.markdown
+|      ^ punctuation.separator.path.markdown
+|          ^^ - constant.character.escape
+|              ^^ constant.character.escape.markdown
+|                    ^^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+|                    ^ punctuation.definition.string.begin.markdown
+|                        ^^ constant.character.escape.markdown
+|                             ^^ - constant.character.escape
+|                                 ^ punctuation.definition.string.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-203
+
+[foo]: url
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^^^ markup.underline.link.markdown
+
+## https://spec.commonmark.org/0.30/#example-204
+
+[foo]: first
+[foo]: second
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^^^^^^ markup.underline.link.markdown
+
+## https://spec.commonmark.org/0.30/#example-205
+
+[FOO]: /url
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^^^^ markup.underline.link.markdown
+
+## https://spec.commonmark.org/0.30/#example-206
+
+[ΑΓΩ]: /φου
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^ meta.link.reference.def.markdown
+|^^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+|      ^^^^ markup.underline.link.markdown
+
+## https://spec.commonmark.org/0.30/#example-208
+
+[
+foo
+]: /url
+bar
+| <- meta.paragraph.markdown - meta.link
+|^^^ meta.paragraph.markdown - meta.link
+
+## https://spec.commonmark.org/0.30/#example-209
+
+This is not a link reference definition, because there are characters other than spaces or tabs after the title:
+
+[foo]: /url "title" ok
+|^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|                   ^^ invalid.illegal.expected-eol.markdown
+
+## https://spec.commonmark.org/0.30/#example-210
+
+This is a link reference definition, but it has no title:
+
+[foo]: /url
+"title" ok
+|^^^^^^^^^ meta.link.reference.def.markdown
+|       ^^ invalid.illegal.expected-eol.markdown
+
+[foo]: <bar> "baz" 
+|^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|      ^ punctuation.definition.link.begin
+|       ^^^ markup.underline.link
+|          ^ punctuation.definition.link.end
+|            ^^^^^ string.quoted.double
+|                 ^ - invalid.illegal.expected-eol
+
+[foo]: <bar>> "baz" 
+|^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|      ^ punctuation.definition.link.begin
+|       ^^^ markup.underline.link
+|          ^ punctuation.definition.link.end
+|           ^^^^^^^ invalid.illegal.expected-eol.markdown
+
+## https://spec.commonmark.org/0.30/#example-211
+
+This is not a link reference definition, because it is indented four spaces:
+
+    [foo]: /url "title"
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block.markdown - meta.link
+
+## https://spec.commonmark.org/0.30/#example-212
+
+This is not a link reference definition, because it occurs inside a code block:
+
+```
+[foo]: /url
+| <- markup.raw.code-fence.markdown-gfm - meta.link
+|^^^^^^^^^^^ markup.raw.code-fence.markdown-gfm - meta.link
+```
+
+## https://spec.commonmark.org/0.30/#example-213
+
+A link reference definition cannot interrupt a paragraph.
+
+Foo
+[bar]: /baz
+| <- meta.paragraph.markdown meta.link.reference.description.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^ meta.paragraph.markdown
+|^^^^ meta.link.reference.description.markdown
+|    ^^^^^^^ - punctuation - markup.underline
+
+## https://spec.commonmark.org/0.30/#example-214
+
+### [Foo]
+[foo]: /url
+| <- meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^^ meta.link.reference.def.markdown
+
+### [Foo]
+[foo]: /url
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-218
+
+> [foo]: /url
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.link
+| ^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
+| ^ punctuation.definition.reference.begin.markdown
+|  ^^^ entity.name.reference.link.markdown
+|     ^ punctuation.definition.reference.end.markdown
+|      ^ punctuation.separator.key-value.markdown
+|        ^^^^ markup.underline.link.markdown
+
+## https://custom-tests/link-reference-definitions/in-block-quotes
+
+> [foo]: /url "description"
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
+| ^ punctuation.definition.reference.begin.markdown
+|  ^^^ entity.name.reference.link.markdown
+|     ^ punctuation.definition.reference.end.markdown
+|      ^ punctuation.separator.key-value.markdown
+|        ^^^^ markup.underline.link.markdown
+|             ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> [foo]: 
+> /url
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown meta.link.reference.def.markdown - markup.underline
+| ^^^^ markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+
+> [foo]: 
+> /url
+> "description"
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown meta.link.reference.def.markdown - meta.string - string
+| ^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+
+> [foo]:
+> </url-with
+> -continuation>
+| <- markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^ markup.underline.link.markdown
+|              ^ punctuation.definition.link.end.markdown
+
+> [foo]: 
+  /url
+| <- markup.quote.markdown - markup.underline - punctuation
+|^ markup.quote.markdown meta.link.reference.def.markdown - markup.underline
+| ^^^^ markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+
+> [foo]: 
+  /url
+  "description"
+| <- markup.quote.markdown - meta.string - string - punctuation
+|^ markup.quote.markdown meta.link.reference.def.markdown - meta.string - string
+| ^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+
+> [foo]:
+  </url-with
+  -continuation>
+| <- markup.quote.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^ markup.underline.link.markdown
+|              ^ punctuation.definition.link.end.markdown
+
+## https://custom-tests/link-reference-definitions
+
+[//]: # (This is a comment without a line-break.)
+|     ^ meta.link.reference.def.markdown markup.underline.link
+|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other
+
+[//]: # (This is a comment with a
+|     ^ meta.link.reference.def.markdown markup.underline.link
+|       ^ punctuation.definition.string.begin
+        line-break.)
+|                  ^ punctuation.definition.string.end
+
+[//]: # (testing)blah
+|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
+|       ^ punctuation.definition.string.begin
+|               ^ punctuation.definition.string.end
+|                ^^^^ invalid.illegal.expected-eol
+|                    ^ - invalid
+
+[//]: # (testing
+blah
+| <- meta.link.reference.def.markdown string.quoted.other
+
+| <- invalid.illegal.non-terminated.link-title
+text
+| <- meta.paragraph - meta.link.reference.def.markdown
+
+## https://custom-tests/footnote-reference-definitions
+
+ [^1]: And that's the footnote.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
+|^ punctuation.definition.reference.begin.markdown
+| ^^ entity.name.reference.link.markdown
+|   ^ punctuation.definition.reference.end.markdown
+|    ^ punctuation.separator.key-value.markdown
+
+  [^1]: And that's the footnote.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
+| ^ punctuation.definition.reference.begin.markdown
+|  ^^ entity.name.reference.link.markdown
+|    ^ punctuation.definition.reference.end.markdown
+|     ^ punctuation.separator.key-value.markdown
+
+   [^1]: And that's the footnote.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
+|  ^ punctuation.definition.reference.begin.markdown
+|   ^^ entity.name.reference.link.markdown
+|     ^ punctuation.definition.reference.end.markdown
+|      ^ punctuation.separator.key-value.markdown
+
+     [^1]: And that's no footnote.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block.markdown
+
+[^1]:
+    And that's the footnote
+with a *second* line.
+|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra - markup.raw
+
+[^1]:
+    And that's the footnote.
+
+    That's the *second* footnote paragraph.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra - markup.raw
+|              ^^^^^^^^ markup.italic
+
+[^1]:
+    And that's the footnote.
+
+   Not a footnote paragraph.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.link
+
+[^1]:
+    And that's the footnote
+with a *second* line.
+[^2]: second
+| <- meta.link.reference.def.footnote.markdown-extra punctuation.definition.reference.begin.markdown
+|^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
+|^^ entity.name.reference.link.markdown
+|  ^ punctuation.definition.reference.end.markdown
+|   ^ punctuation.separator.key-value.markdown
+
+## https://custom-tests/footnote-reference-definitions/in-block-quotes
+
+> [^1]: And that's the footnote.
+|^ markup.quote.markdown - meta.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
+| ^ punctuation.definition.reference.begin.markdown
+|  ^^ entity.name.reference.link.markdown
+|    ^ punctuation.definition.reference.end.markdown
+|     ^ punctuation.separator.key-value.markdown
+
+>  [^1]: And that's the footnote.
+|^ markup.quote.markdown - meta.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
+|  ^ punctuation.definition.reference.begin.markdown
+|   ^^ entity.name.reference.link.markdown
+|     ^ punctuation.definition.reference.end.markdown
+|      ^ punctuation.separator.key-value.markdown
+
+>   [^1]: And that's the footnote.
+|^ markup.quote.markdown - meta.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
+|   ^ punctuation.definition.reference.begin.markdown
+|    ^^ entity.name.reference.link.markdown
+|      ^ punctuation.definition.reference.end.markdown
+|       ^ punctuation.separator.key-value.markdown
+
+>     [^1]: And that's no footnote.
+|^ markup.quote.markdown - meta.link - markup.raw
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+> [^1]: And that's the footnote.
+> with a *second* line.
+| <- markup.quote.markdown meta.link.reference.def.footnote.markdown-extra punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
+
+> [^1]:
+>     And that's the footnote.
+> 
+>     That's the *second* paragraph.
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.link.reference.def.footnote.markdown-extra
+|                ^^^^^^^^ markup.italic
+
+> [^1]:
+>     And that's the footnote.
+> 
+>    Not a footnote paragraph.
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.paragraph.markdown - markup.link
+
+>   [^1]: And that's the footnote.
+> 
+>     code block
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.raw
+|^ markup.quote.markdown - markup.raw
+| ^^^^^^^^^^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+> [^1]:
+>     And that's the footnote.
+> 
+      That's not a *second* paragraph.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block.markdown
+
+# TEST: TABLES ################################################################
+
+| foo | bar |
+|^^^^^^^^^^^^^ meta.table.header
+| <- punctuation.separator.table-cell
+|     ^ punctuation.separator.table-cell
+|           ^ punctuation.separator.table-cell
+| ^^^^ - punctuation.separator.table-cell
+
+| foo | bar |
+| --- | --- |
+| baz | bim <kbd>Ctrl+C</kbd> |
+| <- meta.table punctuation.separator.table-cell
+|           ^^^^^ meta.tag.inline.any
+|                             ^ punctuation.separator.table-cell
+
+| <- - meta.table
+
+| abc | defghi |
+:-: | -----------:
+|^^^^^^^^^^^^^^^^^ meta.table.header-separator
+| <- punctuation.definition.table-cell-alignment
+|^ punctuation.section.table-header
+|   ^ punctuation.separator.table-cell
+|     ^^^^^^^^^^^ punctuation.section.table-header
+|                ^ punctuation.definition.table-cell-alignment - punctuation.section.table-header
+bar | baz
+|   ^ meta.table punctuation.separator.table-cell
+
+| f\|oo  |
+| <- meta.table punctuation.separator.table-cell
+|  ^^ meta.table constant.character.escape - punctuation.separator.table-cell
+|        ^ meta.table punctuation.separator.table-cell
+
+| f\|oo  |
+| ------ |
+| b `|` az |
+|   ^^^ meta.table markup.raw.inline - meta.table.header-separator
+|          ^ meta.table punctuation.separator.table-cell
+| b **|** im |
+| <- meta.table punctuation.separator.table-cell
+|   ^^^^^ meta.table markup.bold - punctuation.separator.table-cell
+|            ^ meta.table punctuation.separator.table-cell
+
+| abc | def |
+| --- | --- |
+| bar | baz |
+|^^^^^^^^^^^^^ meta.table
+test
+|^^^^ meta.table
+> bar
+| <- markup.quote punctuation.definition.blockquote - meta.table
+
+`|` this `|` example `|` is not a table `|`
+| ^ punctuation.definition.raw.end - meta.table
+| nor is this | because it is not at block level, it immediately follows a paragraph |
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.table
+
+| First Header  | Second Header | Third Header         |
+| :------------ | :-----------: | -------------------: |
+| First row     | Data          | Very long data entry |
+| Second row    | **Cell**      | *Cell*               |
+| Third row     | Cell that spans across two columns  ||
+| ^^^^^^^^^^^^^^ meta.table
+|                                                     ^^ punctuation.separator.table-cell
+
+ | table that doesn't start at column 0 |
+  | ---- |
+  | blah |
+| ^^^^^^^^ meta.table
+| ^ punctuation.separator.table-cell
+
+not a table | 
+| ^^^^^^^^^^^^^ - meta.table
+
+ abc | def
+ --- | ---
+ --- | ---
+| ^^^^ meta.table - meta.table.header
+
+ a | b
+ - | -
+|^^^^^^ meta.table.header-separator.markdown-gfm
+|^ punctuation.section.table-header.markdown
+|  ^ punctuation.separator.table-cell.markdown
+|    ^ punctuation.section.table-header.markdown
+ - | -
+|^^^^^^ meta.table.markdown-gfm
+
+ a | b
+ -:| -
+|^^^^^^ meta.table.header-separator.markdown-gfm
+|^ punctuation.section.table-header.markdown
+| ^ punctuation.definition.table-cell-alignment.markdown
+|  ^ punctuation.separator.table-cell.markdown
+|    ^ punctuation.section.table-header.markdown
+ - | -
+|^^^^^^ meta.table.markdown-gfm
+
+| test | me |
+|------|----|
+|^^^^^^ punctuation.section.table-header
+|*test | me |
+|^^^^^^ - markup.bold
+|      ^ punctuation.separator.table-cell
+|           ^ punctuation.separator.table-cell
+|`test | me |
+|^ invalid.deprecated.unescaped-backticks
+|      ^ punctuation.separator.table-cell
+
+| table | followed by
+paragraph
+| <- meta.paragraph.markdown
+|^^^^^^^^^ meta.paragraph.markdown
+
+| table | followed by
+https://foo.bar/baz
+| <- meta.paragraph.markdown meta.link.inet.markdown markup.underline.link.markdown-gfm
+|^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inet.markdown markup.underline.link.markdown-gfm
+
+| table | followed by
+# heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^ markup.heading.1.markdown
+
+| table | followed by
+> quote
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^ markup.quote.markdown
+
+| table | followed by
+    quote
+| <- markup.raw.block.markdown
+|^^^^^^^^^ markup.raw.block.markdown
+
+| table | followed by
+```fenced
+| <- meta.code-fence.definition.begin.text.markdown-gfm
+|^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+code block
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm
+|^^ meta.code-fence.definition.end.text.markdown-gfm
+
+A line without bolded |
+|                     ^ - punctuation.separator.table-cell
+
+A line with bolded **|**
+|                    ^ - punctuation.separator.table-cell
+
+
+# TEST: BLOCK QUOTES ##########################################################
+
+## https://spec.commonmark.org/0.30/#example-228
+
+> # Foo
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - markup.heading
+| ^^^^^^ markup.quote.markdown markup.heading.1.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|   ^^^ entity.name.section.markdown
+
+> # Foo
+bar
+| <- meta.paragraph.markdown - markup.quote
+|^^ meta.paragraph.markdown - markup.quote
+
+> # Foo
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+> # Foo
+> bar
+> baz
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-229
+
+># Foo
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^ markup.quote.markdown markup.heading.1.markdown
+|^ punctuation.definition.heading.begin.markdown
+|  ^^^ entity.name.section.markdown
+
+># Foo
+>bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^ markup.quote.markdown
+
+># Foo
+>bar
+> baz
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-230
+
+   > # Foo
+| <- markup.quote.markdown
+|^^^^^^^^^^ markup.quote.markdown
+|  ^ punctuation.definition.blockquote.markdown
+|    ^^^^^^ markup.heading.1.markdown
+|    ^ punctuation.definition.heading.begin.markdown
+|      ^^^ entity.name.section.markdown
+
+   > # Foo
+   > bar
+| <- markup.quote.markdown - punctuation
+|^^ markup.quote.markdown - punctuation
+|  ^ markup.quote.markdown punctuation.definition.blockquote.markdown
+|   ^^^^^ markup.quote.markdown - punctuation
+
+   > # Foo
+   > bar
+ > baz
+| <- markup.quote.markdown - punctuation
+|^ markup.quote.markdown punctuation.definition.blockquote.markdown
+| ^^^^^ markup.quote.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-231
+
+    > # Foo
+    > bar
+    > baz
+| <- markup.raw.block.markdown
+|^^^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-232
+
+> # Foo
+> bar
+baz
+| <- markup.quote.markdown
+|^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-233
+
+> bar
+baz
+| <- markup.quote.markdown
+|^^^ markup.quote.markdown
+> foo
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-234
+
+> foo
+***
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+
+> foo
+---
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+
+> foo
+___
+| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+|^^ meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - markup.quote
+
+## https://spec.commonmark.org/0.30/#example-235
+
+> - foo
+- bar
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown - markup.quote
+|^^^^^ markup.list.unnumbered.markdown - markup.quote
+
+## https://spec.commonmark.org/0.30/#example-236
+
+>     foo
+    bar
+| <- markup.raw.block.markdown
+|^^^^^^^ markup.raw.block.markdown
+
+## https://spec.commonmark.org/0.30/#example-237
+
+> ```
+foo
+| <- meta.paragraph.markdown - markup.quote - markup.raw
+|^^^ meta.paragraph.markdown - markup.quote - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-238
+
+> foo
+    - bar
+| <- markup.quote.markdown - markup.list - markup.raw
+|^^^^^^^^^ markup.quote.markdown - markup.list - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-239
+
+>
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-240
+
+>
+>  
+> 
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-241
+
+>
+> foo
+>  
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-242
+
+> foo
+
+| <- - markup.quote
+> foo
+
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-243
+
+> foo
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-244
+
+> foo
+>
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+
+## https://spec.commonmark.org/0.30/#example-245
+
+foo
+> bar
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-246
+
+> aaa
+***
+> bbb
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-247
+
+> bar
+baz
+| <- markup.quote.markdown
+|^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-248
+
+> bar
+
+baz
+| <- meta.paragraph.markdown - markup.quote
+|^^ meta.paragraph.markdown - markup.quote
+
+## https://spec.commonmark.org/0.30/#example-249
+
+> bar
+>
+baz
+| <- meta.paragraph.markdown - markup.quote
+|^^ meta.paragraph.markdown - markup.quote
+
+## https://spec.commonmark.org/0.30/#example-250
+
+> > > foo
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^ markup.quote.markdown
+| ^ punctuation.definition.blockquote.markdown
+|   ^ punctuation.definition.blockquote.markdown
+|    ^^^^^ - punctuation
+
+> > > foo
+bar
+| <- markup.quote.markdown
+|^^^ markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-251
+
+>>> foo
+> bar
+>>baz
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown punctuation.definition.blockquote.markdown
+| ^^^^ markup.quote.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-252
+
+>     code
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - markup.raw
+| ^^^^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+>    not code
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.raw
+|^^^^^^^^^^^^^ markup.quote.markdown - markup.raw
+
+## https://custom-tests/block-quotes/block-quote-starts
+
+>=
+| <- punctuation.definition.blockquote.markdown 
+
+>==
+| <- punctuation.definition.blockquote.markdown
+
+  >=
+| ^ punctuation.definition.blockquote.markdown
+    >=
+| ^^^^^ markup.quote.markdown - punctuation
+
+    >=
+|   ^^ markup.raw.block.markdown - markup.quote - punctuation
+
+## https://custom-tests/block-quotes/block-quote-nesting
+
+> > Nested block quote
+| <- markup.quote punctuation.definition.blockquote
+| ^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+|^ - punctuation
+| ^ punctuation.definition.blockquote
+|  ^ - punctuation
+
+> > Nested quote
+> Followed by more quoted text that is not nested
+| <- markup.quote punctuation.definition.blockquote - markup.quote markup.quote
+
+>    > this is a nested quote but no code in a block quote
+| <- punctuation.definition.blockquote
+|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+
+>    > this is a nested quote but no code in a block quote
+>     > with a second line of content
+| <- punctuation.definition.blockquote
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.paragraph.markdown
+|     ^ - punctuation
+
+>     > this is code in a block quote, not a nested quote
+| <- punctuation.definition.blockquote
+|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block - markup.quote markup.quote
+
+## https://custom-tests/block-quotes/block-quote-terminations
+
+> Block quote followed by heading
+# heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^ markup.heading.1.markdown - meta.quote
+| ^^^^^^^ entity.name.section.markdown
+
+> Block quote followed by unordered list
+* list item
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
+
+> Block quote followed by unordered list
++ list item
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
+
+> Block quote followed by unordered list
+- list item
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
+
+> Block quote followed by ordered list
+1. list item
+| <- markup.list.numbered.bullet.markdown - punctuation
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+> Block quote followed by ordered list
+2. list item
+| <- markup.list.numbered.bullet.markdown - punctuation
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+> Block quote followed by invalid list
+1234567890. no list item
+| <- markup.quote.markdown - markup.list
+|^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown - markup.list
+
+> Block quote followed by html block
+<p>*no-markdown</p>
+| <- meta.disable-markdown meta.tag.block
+|^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+
+## https://custom-tests/block-quotes/thematic-breaks
+
+> * * *
+paragraph
+| <- meta.paragraph.markdown - markup.quote
+
+> - - -
+paragraph
+| <- meta.paragraph.markdown - markup.quote
+
+> _ _ _
+paragraph
+| <- meta.paragraph.markdown - markup.quote
+
+> paragraph
+> * * *
+| ^^^^^^ markup.quote.markdown meta.separator.thematic-break.markdown
+
+> paragraph
+> - - -
+| ^^^^^^ markup.quote.markdown meta.separator.thematic-break.markdown
+
+> paragraph
+> _ _ _
+| ^^^^^^ markup.quote.markdown meta.separator.thematic-break.markdown
+
+## https://custom-tests/block-quotes/fenced-code-blocks
+
+> Quoted fenced code block begin
+> ```
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.code-fence
+| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^ punctuation.definition.raw.code-fence.begin.markdown
+
+> Quoted fenced code block language identifier
+> ```C++
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.code-fence
+| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+|    ^^^ constant.other.language-name.markdown
+
+> Quoted fenced code block language identifier
+> ```C++ info string
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.code-fence
+| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+|    ^^^ constant.other.language-name.markdown
+|       ^^^^^^^^^^^^^ - constant
+
+> Quoted fenced code block content
+> ```
+> code block
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.code-fence
+| ^^^^^^^^^^^ markup.quote.markdown markup.raw.code-fence.markdown-gfm
+
+> Quoted fenced code block end
+> ```
+> ```
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown - meta.code-fence
+| ^^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^ punctuation.definition.raw.code-fence.end.markdown
+
+> > 2nd level quoted fenced code block
+> > ```
+> > code block ```
+|              ^^^ - punctuation
+
+> > 2nd level quoted fenced code block
+> > ```
+> > code block ```
+> > ```
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^ markup.quote.markdown - meta.code-fence
+|   ^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+> Block quote followed by fenced code block
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
+
+> Quoted fenced code block is terminated by missing > at bol
+> ```
+no code block
+| <- meta.paragraph.markdown - meta.quote - meta.code-fence
+|^^^^^^^^^^^^^ meta.paragraph.markdown - meta.quote - meta.code-fence
+
+> Quoted fenced code block is terminated by missing > at bol
+> ```
+> content
+no code block
+| <- meta.paragraph.markdown - meta.quote - meta.code-fence
+|^^^^^^^^^^^^^ meta.paragraph.markdown - meta.quote - meta.code-fence
+
+> Unterminated quoted fenced code block followed by unquoted fenced code block
+> ```
+```
+| <- meta.code-fence.definition.begin.text.markdown-gfm - markup.quote
+```
+| <- meta.code-fence.definition.end.text.markdown-gfm - markup.quote
+
+> > ```
+> This is a paragraph highlight as code,
+> because nested block quotes can't be counted.
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+
+## https://custom-tests/block-quotes/list-blocks/basics
+
+> Block quote with lists
+> - list item 1
+| ^ markup.quote punctuation.definition.list_item
+> - list item 2
+| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
+| ^^^^^^^^^^^^^^ markup.quote markup.list.unnumbered
+>   1. sub list item
+| <- markup.quote punctuation.definition.blockquote
+|^^^^^^^^^^^^^^^^^^ markup.quote
+| ^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
+|    ^ punctuation.definition.list_item
+|   ^^ markup.list.numbered.bullet
+> - list item 3
+  continued
+| ^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown
+
+## https://custom-tests/block-quotes/list-blocks/items-with-line-continuation
+
+> * list item
+> second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown punctuation.definition.blockquote.markdown
+>   + subitem
+> second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown punctuation.definition.blockquote.markdown
+>     - subitem
+> second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown punctuation.definition.blockquote.markdown
+>       - subitem
+> second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown punctuation.definition.blockquote.markdown
+
+> * list item
+second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown
+>   + subitem
+  second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown
+>     - subitem
+   second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown
+>       - subitem
+     second line
+| <- markup.quote.markdown markup.list.unnumbered.markdown
+
+> 1. list item
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>    2. subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>       3. subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>          4. subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+
+> 1. list item
+second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>    2. subitem
+  second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>       3. subitem
+   second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>          4. subitem
+    second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+
+> 1. list item
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>    + subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>      - subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+>        - subitem
+> second line
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+
+> 1. list item
+second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>    + subitem
+  second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>      - subitem
+   second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+>        - subitem
+    second line
+| <- markup.quote.markdown markup.list.numbered.markdown
+
+## https://custom-tests/block-quotes/list-blocks/items-with-thematic-breaks
+
+> - * * * * * * *
+| ^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered
+| ^ punctuation.definition.list_item.markdown
+|   ^^^^^^^^^^^^^^ meta.separator.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+|       ^ punctuation.definition.thematic-break
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break
+|          ^ - punctuation
+|           ^ punctuation.definition.thematic-break
+|            ^ - punctuation
+|             ^ punctuation.definition.thematic-break
+|              ^ - punctuation
+|               ^ punctuation.definition.thematic-break
+|                ^ - punctuation
+
+> - * * * * * * *
+>   still a list item
+|   ^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown
+
+> - - * * * * * *
+| ^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered
+| ^ punctuation.definition.list_item.markdown
+|   ^ punctuation.definition.list_item.markdown
+|    ^ - punctuation
+|     ^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+|       ^ punctuation.definition.thematic-break
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break
+|          ^ - punctuation
+|           ^ punctuation.definition.thematic-break
+|            ^ - punctuation
+|             ^ punctuation.definition.thematic-break
+|              ^ - punctuation
+|               ^ punctuation.definition.thematic-break
+|                ^ - punctuation
+
+> - - * * * * * *
+>     still a list item
+| <- markup.quote.markdown markup.list.unnumbered.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.unnumbered.markdown - meta.paragraph
+| ^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown meta.paragraph.list.markdown
+
+> 1. * * * * * * *
+| ^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered
+| ^^ markup.list.numbered.bullet.markdown
+|    ^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.separator.thematic-break.markdown
+|    ^ punctuation.definition.thematic-break
+|     ^ - punctuation
+|      ^ punctuation.definition.thematic-break
+|       ^ - punctuation
+|        ^ punctuation.definition.thematic-break
+|         ^ - punctuation
+|          ^ punctuation.definition.thematic-break
+|           ^ - punctuation
+|            ^ punctuation.definition.thematic-break
+|             ^ - punctuation
+|              ^ punctuation.definition.thematic-break
+|               ^ - punctuation
+|                ^ punctuation.definition.thematic-break
+|                 ^ - punctuation
+
+> 1. * * * * * * *
+>    still a list item
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.numbered.markdown - meta.paragraph
+| ^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.paragraph.list.markdown
+
+## https://custom-tests/block-quotes/list-blocks/unordered-items-with-atx-headings
+
+> * list item
+> # global heading
+  | <- markup.quote.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.list
+  |^^^^^^^^^^^^^^^^ markup.quote.markdown markup.heading.1.markdown - markup.list
+> 
+> * list item
+>  # global heading (matched as list item heading)
+   | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown
+>
+> * list item
+>   # list item heading
+    | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown
+> * list item
+>   ## list item heading
+    | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown
+>   + list item
+>     ### list item heading
+      | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.3.markdown
+>   + list item
+>     ### list item heading
+>     + list item
+>       #### list item heading
+        | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.4.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.4.markdown
+
+> * 
+>   # list item heading
+    | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown  
+>   + 
+>     # list item heading
+      | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown  
+>   + 
+>     # list item heading
+>     - 
+>       # list item heading 1
+        | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown   
+>   + 
+>     # list item heading
+>     - 
+>       # list item heading 1
+>
+>       ## list item heading 2
+        | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown
+
+>       ## not a list item heading
+        | <- markup.quote.markdown markup.raw.block.markdown
+        |^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+> * 
+> 
+>   # list item heading
+    | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown  
+> 
+>   + 
+> 
+>     # list item heading
+      | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown  
+>   + 
+> 
+>     # list item heading
+> 
+>     - 
+> 
+>       # list item heading 1
+        | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.1.markdown  
+>   + 
+> 
+>     # list item heading
+> 
+>     - 
+> 
+>       # list item heading 1
+> 
+>       ## list item heading 2
+        | <- markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown markup.heading.2.markdown
+
+>       ## not a list item heading
+        | <- markup.quote.markdown markup.raw.block.markdown
+        |^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.raw.block.markdown
+
+## https://custom-tests/block-quotes/list-blocks/ordered-items-with-atx-headings
+
+> 
+> 1. list item
+> # global heading
+  | <- markup.quote.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.list
+  |^^^^^^^^^^^^^^^^ markup.quote.markdown markup.heading.1.markdown - markup.list
+> 
+> 2. list item
+>  # global heading (matched as list item heading)
+   | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+>  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+> 
+> 3. list item
+>    # list item heading
+     | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+     |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. list item
+>       # list item heading
+        | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    2. list item
+>       # list item heading
+>       1. list item
+>          # list item heading
+           | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+           |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    3. list item
+>       # list item heading
+        | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+
+> 1. 
+>    # list item heading
+     | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+     |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. 
+>       # list item heading
+        | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. 
+>       # list item heading
+>       1. 
+>          # list item heading
+           | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+           |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. 
+>       # list item heading
+>       1. 
+>          # list item heading
+> 
+>          ## list item heading 2
+           | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+           |^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.2.markdown
+  
+> 1. 
+> 
+>    # list item heading
+     | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+     |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+> 
+>    1. 
+> 
+>       # list item heading
+        | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+        |^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. 
+> 
+>       # list item heading
+> 
+>       1. 
+> 
+>          # list item heading 1
+           | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+           |^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+>    1. 
+> 
+>       # list item heading
+> 
+>       1. 
+> 
+>          # list item heading 1
+>
+>          ## list item heading 2
+           | <- markup.quote.markdown markup.list.numbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+           |^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.2.markdown
+
+## https://custom-tests/block-quotes/list-blocks/items-with-fenced-code-blocks
+
+> 1. item
+>    + item
+>      - item
+>        ```C++
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
+| ^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm
+|        ^^^ punctuation.definition.raw.code-fence.begin.markdown
+|           ^^^ constant.other.language-name.markdown
+
+> 1. item
+>    + item
+>      - item
+>        ```C++
+>        code
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
+| ^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm
+
+> 1. item
+>    + item
+>      - item
+>        ```C++
+>        code
+>        ```
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
+| ^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm
+|        ^^^ punctuation.definition.raw.code-fence.end.markdown
+
+## https://custom-tests/block-quotes/list-blocks/unordered-items-with-reference-definitions
+
+> * list item [ref]
+    |         ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+>
+>   + sub item [ref]
+      |        ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+> 
+>     [ref]: /url
+      | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+      |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+      |^^^ entity.name.reference.link.markdown
+      |   ^ punctuation.definition.reference.end.markdown
+      |    ^ punctuation.separator.key-value.markdown
+      |      ^^^^ markup.underline.link.markdown
+>
+>   + sub item [ref]
+>     - sub item [ref]
+        |        ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+>     
+>       [ref]: /url
+        | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+        |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+        |^^^ entity.name.reference.link.markdown
+        |   ^ punctuation.definition.reference.end.markdown
+        |    ^ punctuation.separator.key-value.markdown
+        |      ^^^^ markup.underline.link.markdown
+>
+>   + sub item [ref]
+>     - sub item [ref]
+>     
+>       [ref]: /url
+>
+>  [ref]: /url
+   | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+   |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+   |^^^ entity.name.reference.link.markdown
+   |   ^ punctuation.definition.reference.end.markdown
+   |    ^ punctuation.separator.key-value.markdown
+   |      ^^^^ markup.underline.link.markdown
+
+## https://custom-tests/block-quotes/list-blocks/ordered-items-with-reference-definitions
+
+> 1. list item [ref]
+     |         ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+>
+>    2. sub item [ref]
+>       |        ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+>
+>       [ref]: /url
+        | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+        |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+        |^^^ entity.name.reference.link.markdown
+        |   ^ punctuation.definition.reference.end.markdown
+        |    ^ punctuation.separator.key-value.markdown
+        |      ^^^^ markup.underline.link.markdown
+>
+>    2. sub item [ref]
+>       3. sub item [ref]
+>          |        ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+>        
+>          [ref]: /url
+           | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+           |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+           |^^^ entity.name.reference.link.markdown
+           |   ^ punctuation.definition.reference.end.markdown
+           |    ^ punctuation.separator.key-value.markdown
+           |      ^^^^ markup.underline.link.markdown
+>
+>    2. sub item [ref]
+>       3. sub item [ref]
+>        
+>          [ref]: /url
+>          
+>    [ref]: /url
+     | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+     |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+     |^^^ entity.name.reference.link.markdown
+     |   ^ punctuation.definition.reference.end.markdown
+     |    ^ punctuation.separator.key-value.markdown
+     |      ^^^^ markup.underline.link.markdown
+
+## https://custom-tests/block-quotes/list-blocks/items-with-reference-definitions
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]: /url "description"
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+|^ markup.quote.markdown markup.list.numbered.markdown - meta.link
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|        ^ punctuation.definition.reference.begin.markdown
+|         ^^^ entity.name.reference.link.markdown
+|            ^ punctuation.definition.reference.end.markdown
+|             ^ punctuation.separator.key-value.markdown
+|               ^^^^ markup.underline.link.markdown
+|                    ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+>        /url "description"
+| <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|        ^^^^ markup.underline.link.markdown
+|             ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+>        /url
+>        "description"
+| <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|        ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+>        </url-with
+>        -continuation>
+| <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                     ^ punctuation.definition.link.end.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+         /url "description"
+|<- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|        ^^^^ markup.underline.link.markdown
+|             ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+         /url
+         "description"
+| <- markup.quote.markdown - meta.string - string - punctuation
+|^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|        ^^^^^^^^^^^^^ meta.string.title.markdown string.quoted.double.markdown
+
+> 1. item
+>    + item
+>      - item [foo]
+>
+>        [foo]:
+         </url-with
+         -continuation>
+| <- markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.markdown
+|^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                     ^ punctuation.definition.link.end.markdown
+
+## https://custom-tests/block-quotes/list-blocks/items-with-footnote-definitions
+
+> 1. list item
+>    + sub item
+>      - sub item [^1]
+>      
+>        [^1]:
+>            This is a foot note
+>            with a second line
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.footnote.markdown-extra
+
+> 1. list item
+>    + sub item
+>      - sub item [^1]
+>      
+>        [^1]:
+>            This is a foot note
+>            with a second line
+>        [^2]:
+|        ^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.link.reference.def.footnote.markdown-extra
+|        ^ punctuation.definition.reference.begin.markdown
+|         ^^ entity.name.reference.link.markdown
+|           ^ punctuation.definition.reference.end.markdown
+|            ^ punctuation.separator.key-value.markdown
+
+> 1. list item
+>    + sub item
+>      - sub item [^1]
+>      
+>        [^1]:
+>            This is a foot note
+>            with a second line
+>        # header
+|^ markup.quote.markdown markup.list.numbered.markdown - markup.heading
+| ^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown
+
+> 1. list item
+>    + sub item
+>      - sub item [^1]
+>      
+>        [^1]:
+>            This is a foot note
+>            with a second line
+>      - sub item
+|^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown
+|      ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+## https://custom-tests/block-quotes#gfm-tasks
+
+> Block quote with GFM tasks
+> * [ ] task
+| ^^^^^^^^^^^ markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|    ^ markup.checkbox.mark.markdown-gfm - punctuation
+|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+> * [x] task
+| ^^^^^^^^^^^ markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|    ^ markup.checkbox.mark.markdown-gfm - punctuation
+|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+> * [X] task
+| ^^^^^^^^^^^ markup.quote.markdown
+| ^ markup.list.unnumbered.bullet.markdown
+|  ^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^ punctuation.definition.list_item.markdown
+|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|    ^ markup.checkbox.mark.markdown-gfm - punctuation
+|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+> * [X] task
+>   - [ ] task
+| ^^^^^^^^^^^^^ markup.quote.markdown
+|   ^ markup.list.unnumbered.bullet.markdown
+|    ^^^^^^^^^^ markup.list.unnumbered.markdown
+|   ^ punctuation.definition.list_item.markdown
+|     ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|      ^ markup.checkbox.mark.markdown-gfm - punctuation
+|       ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+
+## https://custom-tests/block-quotes#emphasis
+
+> Blcok quotes support markup,
+> like *italics*, **bold**, ***bold italic*** and ~~strikethrough~~.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+|      ^^^^^^^^^ markup.italic.markdown
+|                 ^^^^^^^^ markup.bold.markdown
+|                           ^^ markup.bold.markdown punctuation.definition.bold.begin.markdown
+|                             ^ markup.bold.markdown markup.italic.markdown punctuation.definition.italic.begin.markdown
+|                              ^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown - punctuation
+|                                         ^ markup.bold.markdown markup.italic.markdown punctuation.definition.italic.end.markdown
+|                                          ^^ markup.bold.markdown punctuation.definition.bold.end.markdown
+|                                                 ^^^^^^^^^^^^^^^^^ markup.strikethrough.markdown-gfm
+
+
+# TEST: LIST BLOCKS ###########################################################
+
+## https://spec.commonmark.org/0.30/#example-253
+
+A paragraph
+with two lines.
+
+    indented code
+
+> A block quote.
+| <- markup.quote.markdown punctuation.definition.blockquote.markdown - markup.raw
+|^^^^^^^^^^^^^^^^ markup.quote.markdown - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-254
+
+1.  A paragraph
+    with two lines.
+
+        indented code
+
+    > A block quote.
+| <- markup.list.numbered.markdown markup.quote.markdown
+|^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+|   ^ punctuation.definition.blockquote.markdown
+
+## https://spec.commonmark.org/0.30/#example-255
+
+- one
+
+ two
+| <- markup.list.unnumbered.markdown
+|^^^^ markup.list.unnumbered.markdown
+
+> Note: `two` is not a part of the list item, but ST can't handle it!
+
+## https://spec.commonmark.org/0.30/#example-256
+
+- one
+
+  two
+| <- markup.list.unnumbered.markdown
+|^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-257
+
+ -    one
+
+     two
+| <- markup.list.unnumbered.markdown
+|^^^^^^^^ markup.list.unnumbered.markdown
+
+> Note: `two` is not a part of the list item, but ST can't handle it!
+
+## https://spec.commonmark.org/0.30/#example-258
+
+ -    one
+
+      two
+| <- markup.list.unnumbered.markdown
+|^^^^^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-261
+
+Note that at least one space or tab is needed between the list marker
+and any following content, so these are not list items:
+
+-one
+| <- meta.paragraph.markdown - markup.list
+|^^^^ meta.paragraph.markdown - markup.list
+
+2.two
+| <- meta.paragraph.markdown - markup.list
+|^^^^^ meta.paragraph.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-262
+
+A list item may contain blocks that are separated by more than one blank line.
+
+- foo
+
+
+  bar
+  | <- markup.list.unnumbered.markdown
+  |^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-263
+
+1.  foo
+
+    ```
+    | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+    bar
+    | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm - punctuation
+    ```
+    | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+    baz
+    | <- markup.list.numbered.markdown
+
+    > bam
+    | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+    |^^^^^ markup.list.numbered.markdown markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-265
+
+Note that ordered list start numbers must be nine digits or less:
+
+123456789. ok
+| <- markup.list.numbered.bullet.markdown
+|^^^^^^^^^ markup.list.numbered.bullet.markdown
+|         ^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-266
+
+1234567890. not ok
+| <- meta.paragraph.markdown - markup.list
+|^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-267
+
+0. ok
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-268
+
+003. ok
+| <- markup.list.numbered.bullet.markdown
+|^^^ markup.list.numbered.bullet.markdown
+|  ^ punctuation.definition.list_item.markdown
+|   ^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-269
+
+-1. not ok
+| <- meta.paragraph.markdown - markup.list
+|^^^^^^^^^^ meta.paragraph.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-282
+
+- foo
+-   
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^ markup.list.unnumbered.markdown
+
+- foo
+-   
+- bar
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-283
+
+1. foo
+2.
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^ markup.list.numbered.markdown - punctuation
+
+1. foo
+2.
+3. bar
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^ markup.list.numbered.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-284
+
+*
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^ markup.list.unnumbered.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-285
+
+foo
+*
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^ markup.list.unnumbered.markdown - punctuation
+
+foo
+1.
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^ markup.list.numbered.markdown - punctuation 
+
+## https://spec.commonmark.org/0.30/#example-286
+
+ 1.  A paragraph
+     with two lines.
+     |^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+         indented code (but ST can't reliably highlight it!)
+     |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown - markup.raw
+     
+     > A block quote.
+     |^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-287
+
+  1.  A paragraph
+      with two lines.
+      |^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+          indented code (but ST can't reliably highlight it!)
+      |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown - markup.raw
+
+      > A block quote.
+      | ^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-288
+
+   1.  A paragraph
+       with two lines.
+       |^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+            indented code (but ST can't reliably highlight it!)
+       |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown - markup.raw
+
+       > A block quote.
+       |^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-289
+
+    1.  A paragraph
+        with two lines.
+        |^^^^^^^^^^^^^^^ markup.raw.block.markdown - markup.list
+
+            indented code
+        |^^^^^^^^^^^^^^^^^ markup.raw.block.markdown - markup.list
+
+        > A block quote.
+        |^^^^^^^^^^^^^^^^ markup.raw.block.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-290
+
+  1.  A paragraph
+with two lines.
+| <- markup.list.numbered.markdown
+|^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+          indented code (but ST can't reliably highlight it!)
+      |^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown - markup.raw
+
+      > A block quote.
+      | ^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+
+## https://spec.commonmark.org/0.30/#example-291
+
+  1.  A paragraph
+    with two lines.
+    |^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-292
+
+> 1. > Blockquote > text
+|    ^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown
+|    ^ punctuation.definition.blockquote.markdown
+|                 ^ - punctuation
+
+> 1. > Blockquote
+continued here.
+| <- markup.quote.markdown markup.list.numbered.markdown
+|^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-293
+
+> 1. > Blockquote
+> continued here.
+| <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
+|^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-294
+
+So, in this case we need two spaces indent:
+
+- foo
+  - bar
+    - baz
+      - boo
+| <- markup.list.unnumbered.markdown
+|^^^^^ markup.list.unnumbered.markdown
+|     ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|      ^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-295
+
+One is not enough:
+
+- foo
+ - bar
+  - baz
+   - boo
+| <- markup.list.unnumbered.markdown
+|^^ markup.list.unnumbered.markdown
+|  ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|   ^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-296
+
+Here we need four, because the list marker is wider:
+
+10) foo
+    - bar
+| <- markup.list.numbered.markdown
+|^^^ markup.list.numbered.markdown
+|   ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|    ^^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-297
+
+Three is not enough:
+
+10) foo
+   - bar
+| <- markup.list.numbered.markdown
+|^^ markup.list.numbered.markdown
+|  ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|   ^^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-298
+
+A list may be the first block in a list item:
+
+- - foo
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^ markup.list.unnumbered.markdown
+| ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|  ^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-299
+
+A list may be the first block in a list item:
+
+1. - 2. foo 3. bar
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^ markup.list.numbered.markdown
+|  ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|   ^ markup.list.unnumbered.markdown
+|    ^^ markup.list.numbered.bullet.markdown
+|      ^^^^^^^^^^^^^ markup.list.numbered.markdown - punctuation
+
+## https://spec.commonmark.org/0.30/#example-300
+
+A list item can contain a heading:
+
+- # Foo
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^^^ markup.list.unnumbered.markdown
+| ^^^^^^ markup.heading.1.markdown
+| ^ punctuation.definition.heading.begin.markdown
+|   ^^^ entity.name.section.markdown
+
+
+- Should be a setext heading!
+  ---
+| ^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown
+
+- Bar
+  ---
+  baz
+| <- markup.list.unnumbered.markdown
+|^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-301
+
+Changing the bullet or ordered list delimiter starts a new list:
+
+- foo
+- bar
++ baz
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-302
+
+Changing the bullet or ordered list delimiter starts a new list:
+
+1. foo
+2. bar
+3) baz
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-303
+
+In CommonMark, a list can interrupt a paragraph. 
+That is, no blank line is needed to separate a paragraph from a following list:
+
+Foo
+- bar
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+Foo
+- bar
+- baz
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+## https://spec.commonmark.org/0.30/#example-304
+
+In order to solve of unwanted lists in paragraphs with hard-wrapped numerals, 
+we allow only lists starting with 1 to interrupt paragraphs.
+
+The number of windows in my house is
+14.  The number of doors is 6.
+| <- meta.paragraph.markdown - markup.list
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-305
+
+We may still get an unintended result in cases like
+
+The number of windows in my house is
+1.  The number of doors is 6.
+| <- markup.list.numbered.bullet.markdown
+|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-306
+
+There can be any number of blank lines between items:
+
+- foo
+
+- bar
+  |^^^ markup.list.unnumbered.markdown
+
+
+- baz
+  |^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-307
+
+- foo
+  - bar
+    - baz
+
+
+      bim
+      |^^^ markup.list.unnumbered.markdown - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-308
+
+To separate consecutive lists of the same type,
+you can insert a blank HTML comment:
+
+- foo
+- bar
+
+<!-- -->
+| <- meta.disable-markdown comment.block.html
+|^^^^^^^ meta.disable-markdown comment.block.html
+
+- baz
+- bim
+
+## https://spec.commonmark.org/0.30/#example-309
+
+To separate a list from an indented code block that would otherwise 
+be parsed as a subparagraph of the final list item,
+you can insert a blank HTML comment:
+
+-   foo
+
+    notcode
+    |^^^^^^^ markup.list.unnumbered.markdown - markup.raw
+
+-   foo
+
+<!-- -->
+
+    code
+    |^^^^ markup.raw.block.markdown - markup.list
+
+## https://spec.commonmark.org/0.30/#example-311
+
+List items need not be indented to the same level.
+
+1. a
+   | <- markup.list.numbered.markdown - markup.raw
+
+ 2. b
+    | <- markup.list.numbered.markdown - markup.raw
+
+  3. c
+     | <- markup.list.numbered.markdown - markup.raw
+
+1) a
+   | <- markup.list.numbered.markdown - markup.raw
+
+ 2) b
+    | <- markup.list.numbered.markdown - markup.raw
+
+  3) c
+     | <- markup.list.numbered.markdown - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-313
+
+And here, `3. c` should be treated as in indented code block, 
+because it is indented four spaces and preceded by a blank line.
+
+1. a
+   | <- markup.list.numbered.markdown - markup.raw
+
+  2. b
+     | <- markup.list.numbered.markdown - markup.raw
+
+    3. c
+       | <- markup.list.numbered.markdown - markup.raw
+
+1) a
+   | <- markup.list.numbered.markdown - markup.raw
+
+  2) b
+     | <- markup.list.numbered.markdown - markup.raw
+
+    3) c
+       | <- markup.list.numbered.markdown - markup.raw
+
+> Note: ST's syntax engine and the implementation of this syntax don't support that.
+
+## https://spec.commonmark.org/0.30/#example-314
+
+This is a loose list, because there is a blank line between two of the list items:
+
+- a
+- b
+
+- c
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-315
+
+So is this, with a empty second item:
+
+* a
+*
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^ markup.list.unnumbered.markdown
+* c
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^ markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-317
+
+- a
+- b [ref]
+  | ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+
+  [ref]: /url
+  | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+  |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+  |^^^ entity.name.reference.link.markdown
+  |   ^ punctuation.definition.reference.end.markdown
+  |    ^ punctuation.separator.key-value.markdown
+  |      ^^^^ markup.underline.link.markdown
+- d
+  | <- markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-318
+
+- a
+- ```
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  b
+  | <- markup.list.unnumbered.markdown markup.raw.code-fence.markdown-gfm
+
+
+  ```
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+- a
+- ```
+  b
+
+
+  ```
+- c
+  | <- markup.list.unnumbered.markdown - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-319
+
+- a
+  - b
+
+    c
+    | <- markup.list.unnumbered.markdown
+- d
+  | <- markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-320
+
+* a
+  > b
+  >
+  | <- markup.list.unnumbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+  |^ markup.list.unnumbered.markdown markup.quote.markdown - punctuation
+
+* a
+  > b
+  >
+* c
+  | <- markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-321
+
+- a
+  > b
+  ```
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  c
+  ```
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+- a
+  > b
+  ```
+  c
+  ```
+- d
+  | <- markup.list.unnumbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-324
+
+1. ```
+   | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   foo
+   | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm
+   ```
+   | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+   bar
+   | <- markup.list.numbered.markdown
+
+## https://spec.commonmark.org/0.30/#example-325
+
+* foo
+  * bar
+
+  baz
+  | <- markup.list.unnumbered.markdown
+  |^^^ markup.list.unnumbered.markdown
+
+## https://custom-tests/list-blocks/gfm-tasks
+
+* [ ] Unticked GitHub-flavored-markdown checkbox
+| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|  ^ markup.checkbox.mark.markdown-gfm - punctuation
+|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+
+* [x] Ticked GFM checkbox
+| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|  ^ markup.checkbox.mark.markdown-gfm - punctuation
+|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+
+* [X] Another ticked checkbox
+| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|  ^ markup.checkbox.mark.markdown-gfm - punctuation
+|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+
+* [X] Another ticked checkbox
+    + [ ] Sub-item with checkbox
+|     ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|      ^ markup.checkbox.mark.markdown-gfm - punctuation
+|       ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+
+* [] Not a checkbox
+| ^^ - markup.checkbox
+
+* [/] Not a checkbox
+| ^^^ - markup.checkbox
+
+* Not [ ] a [x] checkbox [X]
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.checkbox
+
+* [ ] [Checkbox][] with next word linked
+| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
+|  ^ markup.checkbox.mark.markdown-gfm - punctuation
+|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
+|     ^^^^^^^^^^^^ meta.link
+
+## https://custom-tests/list-blocks/items-with-thematic-breaks
+
+- * * * * * * *
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown
+| ^ punctuation.definition.thematic-break
+|  ^ - punctuation
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+|       ^ punctuation.definition.thematic-break
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break
+|          ^ - punctuation
+|           ^ punctuation.definition.thematic-break
+|            ^ - punctuation
+|             ^ punctuation.definition.thematic-break
+|              ^ - punctuation
+
+- * * * * * * *
+  still a list item
+| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
+
+- - * * * * * *
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|  ^ - punctuation
+|   ^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.separator.thematic-break.markdown
+|   ^ punctuation.definition.thematic-break
+|    ^ - punctuation
+|     ^ punctuation.definition.thematic-break
+|      ^ - punctuation
+|       ^ punctuation.definition.thematic-break
+|        ^ - punctuation
+|         ^ punctuation.definition.thematic-break
+|          ^ - punctuation
+|           ^ punctuation.definition.thematic-break
+|            ^ - punctuation
+|             ^ punctuation.definition.thematic-break
+|              ^ - punctuation
+
+- - * * * * * *
+    still a list item
+|   ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
+
+1. * * * * * * *
+| <- markup.list.numbered.bullet.markdown
+|  ^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.separator.thematic-break.markdown
+|  ^ punctuation.definition.thematic-break
+|   ^ - punctuation
+|    ^ punctuation.definition.thematic-break
+|     ^ - punctuation
+|      ^ punctuation.definition.thematic-break
+|       ^ - punctuation
+|        ^ punctuation.definition.thematic-break
+|         ^ - punctuation
+|          ^ punctuation.definition.thematic-break
+|           ^ - punctuation
+|            ^ punctuation.definition.thematic-break
+|             ^ - punctuation
+|              ^ punctuation.definition.thematic-break
+|               ^ - punctuation
+
+1. * * * * * * *
+   still a list item
+|  ^^^^^^^^^^^^^^^^^^ markup.list.numbered
+
+## https://custom-tests/list-blocks/items-with-atx-headings
+
+* list item
+# global heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.list
+|^^^^^^^^^^^^^^^^ markup.heading.1.markdown - markup.list
+
+* list item
+ # global heading (matched as list item heading)
+ | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+ |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown
+
+* list item
+  # list item heading
+  | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+  |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown
+* list item
+  ## list item heading
+  | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+  |^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.2.markdown
+  + list item
+    ### list item heading
+    | <- markup.list.unnumbered.markdown markup.heading.3.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.3.markdown
+    + list item
+      #### list item heading
+      | <- markup.list.unnumbered.markdown markup.heading.4.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.4.markdown
+
+* 
+  # list item heading
+  | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+  |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+  + 
+    # list item heading
+    | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+    - 
+      # list item heading 1
+      | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+
+      ## list item heading 2
+      | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.2.markdown
+
+* 
+
+  # list item heading
+  | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+  |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+
+  + 
+
+    # list item heading
+    | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+    |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+
+    - 
+
+      # list item heading 1
+      | <- markup.list.unnumbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.1.markdown  
+
+      ## list item heading 2
+      | <- markup.list.unnumbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown markup.heading.2.markdown
+
+1. list item
+# global heading
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown - markup.list
+|^^^^^^^^^^^^^^^^ markup.heading.1.markdown - markup.list
+
+2. list item
+ # global heading (matched as list item heading)
+ | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+ |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+3. list item
+   # list item heading
+   | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+   |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+   1. list item
+      # list item heading
+      | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+      1. list item
+         # list item heading
+         | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+   2. list item
+      # list item heading
+      | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+      1. list item
+         # list item heading
+         | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+1. 
+   # list item heading
+   | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+   |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+   1. 
+      # list item heading
+      | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+      1. 
+         # list item heading
+         | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+         ## list item heading 2
+         | <- markup.list.numbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.2.markdown
+
+1. 
+
+   # list item heading
+   | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+   |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+   1. 
+
+      # list item heading
+      | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+      |^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+      1. 
+
+         # list item heading 1
+         | <- markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+         ## list item heading 2
+         | <- markup.list.numbered.markdown markup.heading.2.markdown punctuation.definition.heading.begin.markdown
+         |^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.2.markdown
+
+## https://custom-tests/list-blocks/items-with-fenced-code-blocks-indented-by-tabs
+
+  * foo
+	```xml
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm constant.other.language-name.markdown
+	<tag>
+|^^^^^ markup.list.unnumbered.markdown markup.raw.code-fence.xml.markdown-gfm text.xml meta.tag.xml
+	```
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+
+## https://custom-tests/list-blocks/items-with-html-blocks
+
+* list item
+  
+  <p>*no-markdown*</p>
+  |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown - meta.paragraph
+  |               ^^^^ meta.tag
+
+  + sub item
+
+    <p>*no-markdown*</p>
+    |^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown - meta.paragraph
+    |               ^^^^ meta.tag
+
+    <style>
+        h1 {
+            font-family: Helvetica;
+        |^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown source.css.embedded.html meta.property-list.css
+        }
+
+        p {
+            font-family: "Ubuntu Sans";
+        |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown source.css.embedded.html meta.property-list.css
+        }
+    </style>
+    | <- markup.list.unnumbered.markdown meta.disable-markdown meta.tag.style.end.html punctuation.definition.tag.begin.html
+    |^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown meta.tag.style.end.html
+    |       ^ markup.list.unnumbered.markdown meta.disable-markdown - mata.tag
+
+    Further sub item text.
+    | <- markup.list.unnumbered.markdown
+    |^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown
+
+  + sub item
+    <p>
+    | <- markup.list.unnumbered.markdown meta.disable-markdown meta.tag
+    |^^ markup.list.unnumbered.markdown meta.disable-markdown meta.tag
+      *no-markodwn*
+    |^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown - markup.italic
+    </p>
+    - not a list item
+    | <- markup.list.unnumbered.markdown meta.disable-markdown - punctuation
+    |^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown - punctuation
+
+## https://custom-tests/list-blocks/items-with-reference-definitions
+
+* list item [ref]
+  |         ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+
+  + sub item [ref]
+    |        ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+  
+    [ref]: /url
+    | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+    |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+    |^^^ entity.name.reference.link.markdown
+    |   ^ punctuation.definition.reference.end.markdown
+    |    ^ punctuation.separator.key-value.markdown
+    |      ^^^^ markup.underline.link.markdown
+
+    - sub item [ref]
+      |        ^^^^^ markup.list.unnumbered.markdown meta.link.reference.description.markdown
+    
+      [ref]: /url
+      | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+      |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+      |^^^ entity.name.reference.link.markdown
+      |   ^ punctuation.definition.reference.end.markdown
+      |    ^ punctuation.separator.key-value.markdown
+      |      ^^^^ markup.underline.link.markdown
+ 
+      [ref]:
+      /url
+      | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+      |^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+
+      [ref]: /url
+      "title"
+      | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+      |^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+
+      [ref]: /url
+      no title
+      | <- markup.list.unnumbered.markdown meta.paragraph.list.markdown - meta.link
+      |^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown - meta.link
+
+  [ref]: /url
+  | <- markup.list.unnumbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+  |^^^^^^^^^^^ markup.list.unnumbered.markdown meta.link.reference.def.markdown
+  |^^^ entity.name.reference.link.markdown
+  |   ^ punctuation.definition.reference.end.markdown
+  |    ^ punctuation.separator.key-value.markdown
+  |      ^^^^ markup.underline.link.markdown
+
+1. list item [ref]
+   |         ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+
+   2. sub item [ref]
+      |        ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+    
+      [ref]: /url
+      | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+      |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+      |^^^ entity.name.reference.link.markdown
+      |   ^ punctuation.definition.reference.end.markdown
+      |    ^ punctuation.separator.key-value.markdown
+      |      ^^^^ markup.underline.link.markdown
+
+      3. sub item [ref]
+         |        ^^^^^ markup.list.numbered.markdown meta.link.reference.description.markdown
+       
+         [ref]: /url
+         | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+         |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+         |^^^ entity.name.reference.link.markdown
+         |   ^ punctuation.definition.reference.end.markdown
+         |    ^ punctuation.separator.key-value.markdown
+         |      ^^^^ markup.underline.link.markdown
+
+         [ref]:
+         /url
+         | <- markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+         |^^^ markup.list.numbered.markdown meta.link.reference.def.markdown markup.underline.link.markdown
+
+         [ref]: /url
+         "title"
+         | <- markup.list.numbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+         |^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown meta.string.title.markdown string.quoted.double.markdown
+
+         [ref]: /url
+         no title
+         | <- markup.list.numbered.markdown meta.paragraph.list.markdown - meta.link
+         |^^^^^^^^ markup.list.numbered.markdown meta.paragraph.list.markdown - meta.link
+
+   [ref]: /url
+   | <- markup.list.numbered.markdown meta.link.reference.def.markdown punctuation.definition.reference.begin.markdown
+   |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.markdown
+   |^^^ entity.name.reference.link.markdown
+   |   ^ punctuation.definition.reference.end.markdown
+   |    ^ punctuation.separator.key-value.markdown
+   |      ^^^^ markup.underline.link.markdown
+
+## https://custom-tests/list-blocks/items-with-footnote-definitions
+
+1. list item
+   + sub item
+     - sub item [^1]
+     
+       [^1]:
+           This is a foot note
+           with a second line
+| <- markup.list.numbered.markdown meta.link.reference.def.footnote.markdown-extra
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.link.reference.def.footnote.markdown-extra
+
+1. list item
+   + sub item
+     - sub item [^1]
+     
+       [^1]:
+           This is a foot note
+           with a second line
+       [^2]:
+       ^^^^^^ markup.list.numbered.markdown meta.link.reference.def.footnote.markdown-extra
+       ^ punctuation.definition.reference.begin.markdown
+        ^^ entity.name.reference.link.markdown
+          ^ punctuation.definition.reference.end.markdown
+           ^ punctuation.separator.key-value.markdown
+
+1. list item
+   + sub item
+     - sub item [^1]
+     
+       [^1]:
+           This is a foot note
+           with a second line
+       # header
+|^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.heading.1.markdown
+
+1. list item
+   + sub item
+     - sub item [^1]
+     
+       [^1]:
+           This is a foot note
+           with a second line
+     - sub item
+|^^^^^^^^^^^^^^ markup.list.numbered.markdown
+|    ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+## https://custom-tests/list-blocks/items-with-line-continuation
+
+* list item
+second line
+| <- markup.list.unnumbered.markdown
+  + subitem
+second line
+| <- markup.list.unnumbered.markdown
+    - subitem
+second line
+| <- markup.list.unnumbered.markdown
+      - subitem
+second line
+| <- markup.list.unnumbered.markdown
+
+paragraph
+| <- meta.paragraph.markdown
+
+1. list item
+second line
+| <- markup.list.numbered.markdown
+   2. subitem
+second line
+| <- markup.list.numbered.markdown
+      3. subitem
+second line
+| <- markup.list.numbered.markdown
+         4. subitem
+second line
+| <- markup.list.numbered.markdown
+
+paragraph
+| <- meta.paragraph.markdown
+
+1. list item
+second line
+| <- markup.list.numbered.markdown
+   + subitem
+second line
+| <- markup.list.numbered.markdown
+     - subitem
+second line
+| <- markup.list.numbered.markdown
+       - subitem
+second line
+| <- markup.list.numbered.markdown
+
+paragraph
+| <- meta.paragraph.markdown
+
+## https://custom-tests/list-blocks/items-with-block-quotes/basics
+
+* list item
+
+   > This is a blockquote.
+   | <- markup.list.unnumbered markup.quote punctuation.definition.blockquote
+
+  + subitem
+
+    > This is a blockquote.
+    | <- markup.list.unnumbered markup.quote punctuation.definition.blockquote
+
+    - subitem
+  
+      > This is a blockquote.
+      | <- markup.list.unnumbered markup.quote punctuation.definition.blockquote
+
+      - subitem
+    
+        > This is a blockquote.
+        | <- markup.list.unnumbered markup.quote punctuation.definition.blockquote
+
+  This is a paragraph still part of the 
+  list item
+ |^^^^^^^^^^ markup.list.unnumbered.markdown - meta.paragraph meta.paragraph
+
+1. list item
+
+   > This is a blockquote.
+   | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+
+   2. subitem
+
+      > This is a blockquote.
+      | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+    
+      3. subitem
+    
+         > This is a blockquote.
+         | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+
+   This is a paragraph still part of the 
+   list item
+   |^^^^^^^^^ markup.list.numbered.markdown - meta.paragraph meta.paragraph
+
+## https://custom-tests/list-blocks/items-with-block-quotes/block-quote-terminations
+
+1. item
+   + item
+     - item
+       > Block quote followed by heading
+       # heading
+       | <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+       |^^^^^^^^^ markup.heading.1.markdown - meta.quote
+       | ^^^^^^^ entity.name.section.markdown
+
+       > Block quote followed by unordered list
+       * list item
+       | <- markup.list.numbered.markdown markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+       |^^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+       > Block quote followed by unordered list
+       + list item
+       | <- markup.list.numbered.markdown markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+       |^^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+       > Block quote followed by unordered list
+       - list item
+       | <- markup.list.numbered.markdown markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+       |^^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+       > Block quote followed by ordered list
+       1. list item
+       | <- markup.list.numbered.markdown markup.list.numbered.bullet.markdown
+       |^ markup.list.numbered.markdown markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+       | ^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+       > Block quote followed by ordered list
+       2. list item
+       | <- markup.list.numbered.bullet.markdown - punctuation
+       |^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
+       | ^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
+
+       > Block quote followed by invalid list
+       1234567890. no list item
+       | <- markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+       |^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+
+       > Block quote followed by html block
+       <p>*no-markdown</p>
+       | <- meta.disable-markdown meta.tag.block
+       |^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
+
+## https://custom-tests/list-blocks/items-with-block-quotes/headings-and-paragraphs
+
+1. item
+   + item
+     - item
+       > # Foo
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^ markup.quote.markdown - markup.heading
+       | ^^^^^^ markup.quote.markdown markup.heading.1.markdown
+       | ^ punctuation.definition.heading.begin.markdown
+       |   ^^^ entity.name.section.markdown
+       
+       > # Foo
+       bar
+       | <- meta.paragraph.list.markdown - markup.quote
+       |^^ meta.paragraph.list.markdown - markup.quote
+       
+       > # Foo
+       > bar
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^ markup.quote.markdown
+       
+       > # Foo
+       > bar
+       > baz
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^ markup.quote.markdown
+
+       ># Foo
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^^ markup.quote.markdown markup.heading.1.markdown
+       |^ punctuation.definition.heading.begin.markdown
+       |  ^^^ entity.name.section.markdown
+       
+       ># Foo
+       >bar
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^ markup.quote.markdown
+       
+       ># Foo
+       >bar
+       > baz
+       | <- markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^ markup.quote.markdown
+
+## https://custom-tests/list-blocks/items-with-block-quotes/paragraphs-vs-codeblocks
+
+1. item
+   + item
+     - item
+       >foo 1
+       >foo 2
+       |^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+       
+       > foo 1
+       > foo 2
+       | ^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+       
+       >  foo 1
+       >  foo 2
+       | ^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+       
+       >   foo 1
+       >   foo 2
+       | ^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.paragraph.markdown
+
+       >       foo 1
+       >       foo 2
+       | ^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.raw.block.markdown
+
+## https://custom-tests/list-blocks/items-with-nested-block-quotes
+
+1. item
+   + item
+     - item
+       > > Nested block quote
+       | <- markup.quote punctuation.definition.blockquote
+       | ^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+       |^ - punctuation
+       | ^ punctuation.definition.blockquote
+       |  ^ - punctuation
+       
+       > > Nested quote
+       > Followed by more quoted text that is not nested
+       | <- markup.quote punctuation.definition.blockquote - markup.quote markup.quote
+       
+       >    > this is a nested quote but no code in a block quote
+       | <- punctuation.definition.blockquote
+       |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown
+       
+       >    > this is a nested quote but no code in a block quote
+       >     > with a second line of content
+       | <- punctuation.definition.blockquote
+       |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.paragraph.markdown
+       |     ^ - punctuation
+       
+       >     > this is code in a block quote, not a nested quote
+       | <- punctuation.definition.blockquote
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block - markup.quote markup.quote
+
+## https://custom-tests/list-blocks/items-with-block-quotes/list-blocks
+
+1. item
+   + item
+     - item
+       > Block
+       > 1. item
+       | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown
+       | ^^ markup.list.numbered.bullet.markdown
+
+       > Block
+       > 1. item
+       >    + item
+       | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.list.numbered.markdown
+       |    ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+       > Block
+       > 1. item
+       >    + item
+       >      - item
+       | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.list.numbered.markdown
+       |      ^ markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+
+       > Block
+       > 1. item
+       >    + item
+       >      - item
+       >        > quote
+       >        > quote
+       | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.list.numbered.markdown meta.paragraph.list.markdown
+       |        ^ punctuation.definition.blockquote.markdown
+
+       > Block
+       > 1. item
+       >    + item
+       >      - item
+       >      # heading
+              | <- markup.list.numbered.markdown markup.quote.markdown markup.list.numbered.markdown markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+       > # heading
+       | <- markup.list.numbered.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
+       |^ markup.list.numbered.markdown markup.quote.markdown - markup.heading
+       | ^^^^^^^^^^ markup.list.numbered.markdown markup.quote.markdown markup.heading.1.markdown
+       | ^ punctuation.definition.heading.begin.markdown
+       |   ^^^^^^^ entity.name.section.markdown
+
+## https://custom-tests/list-blocks/items-with-code-spans
+
+- `<foo>` | `<bar>` (foo/bar.baz)
+- `<foo>` | `<my-bar>` | (foo/bar-baz.foo)
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown - markup.table
+
+1. Open `Command Palette` using menu item `Tools → Command Palette...`
+   |    ^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.raw.inline.markdown
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.raw.inline.markdown
+2. Choose `Package Control: Install Package`
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown markup.raw.inline.markdown
+
+## https://custom-tests/list-blocks/items-with-emphasis
+
+- test *testing
+blah*
+|   ^ markup.list.unnumbered markup.italic punctuation.definition.italic.end
+- fgh
+- *ghgh
+| ^ markup.list.unnumbered markup.italic punctuation.definition.italic.begin
+- fgfg
+| <- markup.list.unnumbered.bullet punctuation.definition.list_item
+- _test
+
+| <- markup.list.unnumbered markup.italic invalid.illegal.non-terminated.bold-italic
+  still a list item
+| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
+
+## https://custom-tests/list-blocks/items-with-inline-html-tags
+
+- `code` - <a name="demo"></a>
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown
+| ^^^^^^ markup.raw.inline.markdown
+| ^ punctuation.definition.raw.begin.markdown
+|      ^ punctuation.definition.raw.end.markdown
+|        ^ - punctuation
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html 
+
+- list item
+
+  <span>*no-markdown*</span>
+  |^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
+  |                  ^^^^^^^ meta.tag
+
+  - list item
+  
+    <span>*no-markdown*</span>
+    |^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
+    |                  ^^^^^^^ meta.tag
+
+    - list item
+      
+      <span>*no-markdown*</span>
+      |^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
+      |                  ^^^^^^^ meta.tag
+
+## https://custom-tests/list-blocks/items-with-links-and-references
+
+ 1. [see `demo`](#demo "demo")
+    | <- markup.list.numbered.markdown meta.link.inline.description.markdown punctuation.definition.link.begin.markdown
+    |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.description.markdown
+    |           ^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.metadata.markdown
+    |           ^ punctuation.definition.metadata.begin.markdown
+    |                  ^ punctuation.definition.string.begin.markdown
+    |                       ^ punctuation.definition.string.end.markdown
+    |                        ^ punctuation.definition.metadata.end.markdown
+
+    [see `demo`](#demo (demo))
+    | <- markup.list.numbered.markdown meta.link.inline.description.markdown punctuation.definition.link.begin.markdown
+    |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.description.markdown
+    |           ^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.metadata.markdown
+    |           ^ punctuation.definition.metadata.begin.markdown
+    |                  ^ punctuation.definition.string.begin.markdown
+    |                       ^ punctuation.definition.string.end.markdown
+    |                        ^ punctuation.definition.metadata.end.markdown
+
+    [see `demo`](#demo 'demo')
+    | <- markup.list.numbered.markdown meta.link.inline.description.markdown punctuation.definition.link.begin.markdown
+    |^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.description.markdown
+    |           ^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.link.inline.metadata.markdown
+    |           ^ punctuation.definition.metadata.begin.markdown
+    |                  ^ punctuation.definition.string.begin.markdown
+    |                       ^ punctuation.definition.string.end.markdown
+    |                        ^ punctuation.definition.metadata.end.markdown
+
+    Here is a ![example image](https://test.com/sublime.png "A demonstration").
+    |         ^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.description.markdown
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.metadata.markdown
+    |                                                                         ^^ markup.list.numbered.markdown - meta.image
+    |         ^^ punctuation.definition.image.begin.markdown
+    |                        ^ punctuation.definition.image.end.markdown
+    |                         ^ punctuation.definition.metadata.begin.markdown
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
+    |                                                       ^^^^^^^^^^^^^^^^^ string.quoted.double.markdown
+    |                                                       ^ punctuation.definition.string.begin.markdown
+    |                                                                       ^ punctuation.definition.string.end.markdown
+    |                                                                        ^ punctuation.definition.metadata.end.markdown
+
+    Here is a ![example image](https://test.com/sublime.png 'A demonstration').
+    |         ^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.description.markdown
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.metadata.markdown
+    |                                                                         ^^ markup.list.numbered.markdown - meta.image
+    |         ^^ punctuation.definition.image.begin.markdown
+    |                        ^ punctuation.definition.image.end.markdown
+    |                         ^ punctuation.definition.metadata.begin.markdown
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
+    |                                                       ^^^^^^^^^^^^^^^^^ string.quoted.single.markdown
+    |                                                       ^ punctuation.definition.string.begin.markdown
+    |                                                                       ^ punctuation.definition.string.end.markdown
+    |                                                                        ^ punctuation.definition.metadata.end.markdown
+
+    Here is a ![example image](https://test.com/sublime.png (A demonstration)).
+    |         ^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.description.markdown
+    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered.markdown meta.image.inline.metadata.markdown
+    |                                                                         ^^ markup.list.numbered.markdown - meta.image
+    |         ^^ punctuation.definition.image.begin.markdown
+    |                        ^ punctuation.definition.image.end.markdown
+    |                         ^ punctuation.definition.metadata.begin.markdown
+    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
+    |                                                       ^^^^^^^^^^^^^^^^^ string.quoted.other.markdown
+    |                                                       ^ punctuation.definition.string.begin.markdown
+    |                                                                       ^ punctuation.definition.string.end.markdown
+    |                                                                        ^ punctuation.definition.metadata.end.markdown
+
+
+# TEST: CODE SPANS ############################################################
+
+```testing``123```
+| <- punctuation.definition.raw.begin
+|         ^^ - punctuation
+|              ^^^ punctuation.definition.raw.end
+
+```testing``123````
+| <- punctuation.definition.raw.begin
+|        ^ - punctuation
+|            ^^^^ - punctuation
+```
+| <- punctuation.definition.raw.end
+
+``testing`123````
+| <- punctuation.definition.raw.begin
+|        ^ - punctuation
+|            ^^^^ - punctuation
+more text``
+|        ^^ punctuation.definition.raw.end
+
+``text
+
+| <- invalid.illegal.non-terminated.raw
+text
+| <- - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-327
+
+`hi`lo`
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^ markup.raw.inline.markdown
+|  ^ punctuation.definition.raw.end.markdown
+|   ^^ - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-328
+
+`foo`
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^ meta.paragraph.markdown markup.raw.inline.markdown
+|   ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-329
+
+`` foo ` bar  ``
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^^^^^^^^^^ markup.raw.inline.markdown
+|^ punctuation.definition.raw.begin.markdown
+|      ^ - punctuation
+|             ^^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-330
+
+` `` `
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^ markup.raw.inline.markdown
+| ^^ - punctuation
+|    ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-331
+
+`  ``  `
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^^ markup.raw.inline.markdown
+|  ^^ - punctuation
+|      ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-332
+
+` a`
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^ markup.raw.inline.markdown
+|  ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-333
+
+` b `
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^ markup.raw.inline.markdown
+|   ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-334
+
+` `
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^ markup.raw.inline.markdown
+| ^ punctuation.definition.raw.end.markdown
+|  ^ - markup 
+
+`  `
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^ markup.raw.inline.markdown
+|  ^ punctuation.definition.raw.end.markdown
+|   ^ - markup 
+
+## https://spec.commonmark.org/0.30/#example-335
+
+``
+foo
+bar  
+baz
+``
+| <- markup.raw.inline.markdown punctuation.definition.raw.end.markdown
+|^ markup.raw.inline.markdown punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-336
+
+``
+foo 
+``
+| <- markup.raw.inline.markdown punctuation.definition.raw.end.markdown
+|^ markup.raw.inline.markdown punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-337
+
+`foo   bar
+  baz`
+|^^^^^ markup.raw.inline.markdown
+|    ^ punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-338
+
+`foo\`bar`
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^ markup.raw.inline.markdown
+|     ^^^ - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-339
+
+``foo`bar``
+| <- meta.paragraph.markdown markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^^^^^ meta.paragraph.markdown markup.raw.inline.markdown
+|^ punctuation.definition.raw.begin.markdown
+| ^^^^^^^ - punctuation
+|        ^^ punctuation.definition.raw.end.markdown
+
+````bar```` baz
+|^^^^^^^^^^ markup.raw.inline.markdown
+|          ^^^^^ - markup.raw
+
+## https://spec.commonmark.org/0.30/#example-340
+
+`foo `` bar`
+| <- markup.raw.inline.markdown punctuation.definition.raw.begin.markdown
+|^^^^^^^^^^ markup.raw.inline.markdown - punctuation
+|          ^ markup.raw.inline.markdown punctuation.definition.raw.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-341
+
+*foo`*`
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|   ^^^ markup.italic.markdown markup.raw.inline.markdown
+
+| <- invalid.illegal.non-terminated.bold-italic
+
+## https://spec.commonmark.org/0.30/#example-342
+
+[not a `link](/foo`)
+|^^^^^^^^^^^^^^^^^^^ - meta.link
+|      ^^^^^^^^^^^^ markup.raw.inline.markdown
+
+## https://spec.commonmark.org/0.30/#example-343
+
+`<a href="`">`
+|^^^^^^^^^^ markup.raw.inline.markdown
+|          ^^ - markup.raw
+
+| <- invalid.illegal.non-terminated.raw
+
+## https://spec.commonmark.org/0.30/#example-344
+
+<a href="`">`
+| ^^^^^^^^^ meta.tag.inline.a
+|           ^ punctuation.definition.raw.begin
+
+| <- invalid.illegal.non-terminated.raw
+
+## https://spec.commonmark.org/0.30/#example-345
+
+`<http://foo.bar.`baz>`
+|^^^^^^^^^^^^^^^^^ markup.raw.inline
+|                     ^ punctuation.definition.raw.begin
+
+| <- invalid.illegal.non-terminated.raw
+
+## https://spec.commonmark.org/0.30/#example-346
+
+<http://foo.bar.`baz>`
+|^^^^^^^^^^^^^^^^^^^ markup.underline.link
+|                    ^ punctuation.definition.raw.begin
+
+| <- invalid.illegal.non-terminated.raw
+
+
+# TEST: EMPHASIS ##############################################################
+
+## https://spec.commonmark.org/0.30/#example-350
+
+*foo bar*
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^ markup.italic.markdown
+|       ^ punctuation.definition.italic.end
+
+## https://spec.commonmark.org/0.30/#example-351
+
+This is not emphasis, because the opening `*` is followed by whitespace, and hence not part of a left-flanking delimiter run:
+
+a * foo bar*
+| ^^^^^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-352
+
+a*"foo"*
+| <- - markup.italic - punctuation
+|^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-353
+
+* a *
+| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown - markup.italic
+|^^^^^ markup.list.unnumbered.markdown - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-354
+
+Intraword emphasis with `*` is permitted:
+
+foo*bar*
+| <- - markup.italic
+|^^ - markup.italic
+|  ^^^^^ markup.italic.markdown
+|  ^ punctuation.definition.italic.begin.markdown
+|      ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-355
+
+5*6*78
+| <- - markup.italic
+|^^^ markup.italic.markdown
+|^ punctuation.definition.italic.begin.markdown
+|  ^ punctuation.definition.italic.end.markdown
+|   ^^ - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-356
+
+_foo bar_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^ meta.paragraph.markdown markup.italic.markdown
+|       ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-357
+
+This is not emphasis, because the opening `_` is followed by whitespace:
+
+_ foo bar_
+| <- - markup.italic - punctuation
+|^^^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-358
+
+This is not emphasis, because the opening `_` is preceded by an alphanumeric and followed by punctuation:
+
+a_"foo"_
+| <- - markup.italic - punctuation
+|^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-359
+
+Emphasis with `_` is not allowed inside words:
+
+foo_bar_
+| <- - markup.italic - punctuation
+|^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-360
+
+5_6_78
+| <- - markup.italic - punctuation
+|^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-361
+
+пристаням_стремятся_
+| <- - markup.italic - punctuation
+|^^^^^^^^^^^^^^^^^^^ - markup.italic - punctuation
+
+## https://spec.commonmark.org/0.30/#example-362
+
+Here `_` does not generate emphasis, because the first delimiter run is right-flanking
+and the second left-flanking:
+
+aa_"bb"_cc
+| <- - markup.italic - punctuation
+|^^^^^^ - markup.italic - punctuation
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-363
+
+This is emphasis, even though the opening delimiter is both left- and right-flanking,
+because it is preceded by punctuation:
+
+foo-_(bar)_
+| <- - markup.italic - punctuation
+|^^^ - markup.italic - punctuation
+|   ^^^^^^^ markup.italic.markdown
+|   ^ punctuation.definition.italic.begin.markdown
+|         ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-365
+
+This is not emphasis, because the closing `*` is preceded by whitespace:
+
+*foo bar *
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^ markup.italic.markdown
+
+| <- markup.italic.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-366
+
+A line ending also counts as whitespace:
+
+*foo bar *
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^ markup.italic.markdown
+|        ^ - punctuation
+*
+| <- markup.italic.markdown - punctuation
+abc*
+| <- markup.italic.markdown
+|^^^ meta.paragraph.markdown markup.italic.markdown
+|  ^ punctuation.definition.italic.end.markdown
+|   ^ - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-367
+
+This is not emphasis, because the second `*` is preceded by punctuation and followed
+by an alphanumeric (hence it is not part of a right-flanking delimiter run):
+
+*(*foo)
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-368
+
+The point of this restriction is more easily appreciated with this example:
+
+*(*foo*)*
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-369
+
+Intraword emphasis with `*` is allowed:
+
+*foo*bar
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^ markup.italic.markdown
+|   ^ punctuation.definition.italic.end.markdown
+|    ^^^^ - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-370
+
+This is not emphasis, because the closing `_` is preceded by whitespace:
+
+_foo bar _
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^ markup.italic.markdown
+|        ^ - punctuation
+
+| <- markup.italic.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+_foo bar _
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^ markup.italic.markdown
+|        ^ - punctuation
+_
+| <- markup.italic.markdown - punctuation
+abc_
+| <- markup.italic.markdown
+|^^^ markup.italic.markdown
+|  ^ punctuation.definition.italic.end
+|   ^ - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-371
+
+This is not emphasis, because the second `_` is preceded by punctuation and followed
+by an alphanumeric (hence it is not part of a right-flanking delimiter run):
+
+_(_foo)
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-371
+
+The point of this restriction is more easily appreciated with this example:
+
+_(_foo_)_
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-373
+
+Intraword emphasis is disallowed for `_`:
+
+_foo_bar
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^ markup.italic.markdown
+|   ^ - punctuation
+abc_
+| <- markup.italic.markdown
+|^^^ markup.italic.markdown
+|  ^ punctuation.definition.italic.end.markdown
+|   ^ - markup.italic
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-374
+
+Intraword emphasis is disallowed for `_`:
+
+_пристаням_стремятся
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^ markup.italic.markdown
+
+| <- markup.italic.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-375
+
+_foo_bar_baz_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^ markup.italic.markdown
+|   ^^^^^ - punctuation
+|           ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-376
+
+This is emphasis, even though the closing delimiter is both left- and right-flanking,
+because it is followed by punctuation:
+
+_(bar)_.
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^ markup.italic.markdown
+|     ^ punctuation.definition.italic.end.markdown
+|      ^^ - markup.italic
+
+## https://spec.commonmark.org/0.30/#example-377
+
+**foo bar**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown
+|        ^^ punctuation.definition.bold.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-378
+
+** foo bar**
+| <- - markup - punctuation
+|^^^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-379
+
+This is not strong emphasis, because the opening `**` is preceded by an alphanumeric
+and followed by punctuation, and hence not part of a left-flanking delimiter run:
+
+a**"foo"**
+| <- - markup - punctuation
+|^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-380
+
+Intraword strong emphasis with `**` is permitted:
+
+foo**bar**
+| <- - markup
+|^^ - markup
+|  ^^^^^^^ meta.paragraph.markdown markup.bold.markdown
+|  ^^ punctuation.definition.bold.begin.markdown
+|       ^^ punctuation.definition.bold.end.markdown
+|         ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-381
+
+__foo bar__
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown
+|        ^^ punctuation.definition.bold.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-382
+
+This is not strong emphasis, because the opening delimiter is followed by whitespace:
+__ foo bar__
+| <- - markup - punctuation
+|^^^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-383
+
+__
+| <- - punctuation
+|^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-384
+
+a__"foo"__
+| <- - markup - punctuation
+|^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-385
+
+Intraword strong emphasis is forbidden with `__`:
+foo__bar__
+| <- - markup - punctuation
+|^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-386
+
+5__6__78
+| <- - markup - punctuation
+|^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-387
+
+пристаням__стремятся__
+| <- - markup - punctuation
+|^^^^^^^^^^^^^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-389
+
+foo-__(bar)__
+| <- - markup
+|^^^ - markup
+|   ^^^^^^^^^ markup.bold.markdown
+|   ^^ punctuation.definition.bold.begin.markdown
+|          ^^ punctuation.definition.bold.end.markdown
+|            ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-390
+
+**foo bar **
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|         ^^ - punctuation
+
+| <- markup.bold.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-394
+
+**foo "*bar*" foo**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^ markup.bold.markdown - markup.italic
+|^ punctuation.definition.bold.begin.markdown
+|      ^^^^^ markup.bold.markdown markup.italic.markdown
+|      ^ punctuation.definition.italic.begin.markdown
+|          ^ punctuation.definition.italic.end.markdown
+|           ^^^^^^^ markup.bold.markdown - markup.italic
+|                ^^ punctuation.definition.bold.end.markdown
+|                  ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-395
+
+Intraword emphasis:
+ 
+**foo**bar
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^ markup.bold.markdown
+|    ^^ punctuation.definition.bold.end.markdown
+|      ^^^^ - markup
+
+## https://spec.commonmark.org/0.30/#example-396
+
+__foo bar __
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|         ^^ - punctuation
+
+| <- markup.bold.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-397
+
+This is not strong emphasis, because the second `__` 
+is preceded by punctuation and followed by an alphanumeric:
+
+__(__foo)
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-398
+
+_(__foo__)_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+| ^^^^^^^ markup.italic.markdown markup.bold.markdown
+| ^^ punctuation.definition.bold.begin.markdown
+|      ^^ punctuation.definition.bold.end.markdown
+|         ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-399
+
+Intraword strong emphasis is forbidden with `__`:
+__foo__bar
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|    ^^ - punctuation
+
+| <- markup.bold.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-400
+
+__пристаням__стремятся
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|          ^^ - punctuation
+
+| <- markup.bold.markdown invalid.illegal.non-terminated.bold-italic.markdown
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-401
+
+__foo__bar__baz__
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|    ^^^^^^^ - punctuation
+|              ^^ punctuation.definition.bold.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-402
+
+This is strong emphasis, even though the closing delimiter is both left- and right-flanking,
+because it is followed by punctuation:
+
+__(bar)__.
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown 
+|      ^^ punctuation.definition.bold.end.markdown
+|        ^^ - markup
+
+## https://spec.commonmark.org/0.30/#example-403
+
+Any nonempty sequence of inline elements can be the contents of an emphasized span.
+
+*foo [bar](/url)*
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^ markup.italic.markdown
+|    ^^^^^^^^^^^ meta.link.inline
+|               ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-404
+
+*foo
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^ markup.italic.markdown
+bar*
+| <- markup.italic.markdown
+|^^^ markup.italic.markdown
+|  ^ punctuation.definition.italic.end
+|   ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-405
+
+_foo __bar__ baz_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^ markup.italic.markdown - markup markup
+|    ^^ punctuation.definition.bold.begin.markdown
+|    ^^^^^^^ markup.italic.markdown markup.bold.markdown
+|         ^^ punctuation.definition.bold.end.markdown
+|           ^^^^^ markup.italic.markdown - markup markup
+|               ^ punctuation.definition.italic.end.markdown
+|                ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-418
+
+*foo [*bar*](/url)*
+| <-  markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^ markup.italic.markdown - markup.italic markup.italic
+|    ^^^^^^^^^^^^^ meta.link.inline
+|     ^^^^^ markup.italic.markdown markup.italic.markdown
+|          ^^^^^^^ markup.italic.markdown - markup.italic markup.italic
+
+*foo [_bar_](/url)*
+| <-  markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^ markup.italic.markdown - markup.italic markup.italic
+|    ^^^^^^^^^^^^^ meta.link.inline
+|     ^^^^^ markup.italic.markdown markup.italic.markdown
+|          ^^^^^^^ markup.italic.markdown - markup.italic markup.italic
+
+_foo [_bar_](/url)_
+| <-  markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^ markup.italic.markdown - markup.italic markup.italic
+|    ^^^^^^^^^^^^^ meta.link.inline
+|     ^^^^^ markup.italic.markdown markup.italic.markdown
+|          ^^^^^^^ markup.italic.markdown - markup.italic markup.italic
+
+_foo [**bar**](/url)_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^ markup.italic.markdown - markup.italic markup.bold
+|    ^^^^^^^^^^^^^^^ meta.link.inline
+|     ^^ punctuation.definition.bold.begin.markdown
+|     ^^^^^^^ markup.italic.markdown markup.bold.markdown
+|          ^^ punctuation.definition.bold.end.markdown
+|            ^^^^^^^^ markup.italic.markdown - markup.italic markup.bold
+|                   ^ punctuation.definition.italic.end.markdown
+
+_foo [__bar__](/url)_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^ markup.italic.markdown - markup.italic markup.bold
+|    ^^^^^^^^^^^^^^^ meta.link.inline
+|     ^^ punctuation.definition.bold.begin.markdown
+|     ^^^^^^^ markup.italic.markdown markup.bold.markdown
+|          ^^ punctuation.definition.bold.end.markdown
+|            ^^^^^^^^ markup.italic.markdown - markup.italic markup.bold
+|                   ^ punctuation.definition.italic.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-419
+
+** is not an empty emphasis
+| <- - punctuation
+|^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-420
+
+**** is not an empty strong emphasis
+| <- - punctuation
+|^^^ - punctuation
+
+## https://spec.commonmark.org/0.30/#example-421
+
+**foo [bar](/url)**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown
+|     ^^^^^^^^^^^ meta.link.inline
+|                ^^ punctuation.definition.bold.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-422
+
+**foo
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown
+bar**
+| <- markup.bold.markdown
+|^^^^ markup.bold.markdown
+|  ^^ punctuation.definition.bold.end
+|    ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-423
+
+__foo _bar_ baz__
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^ markup.bold.markdown - markup markup
+|^ punctuation.definition.bold.begin.markdown
+|     ^ punctuation.definition.italic.begin.markdown
+|     ^^^^^ markup.bold.markdown markup.italic.markdown
+|         ^ punctuation.definition.italic.end.markdown
+|          ^^^^^^ markup.bold.markdown - markup markup
+|               ^ punctuation.definition.bold.end.markdown
+|                ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-432
+
+**foo [*bar*](/url)**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^ markup.bold.markdown - markup.bold markup.italic
+|     ^^^^^^^^^^^^^ meta.link.inline
+|^ punctuation.definition.bold.begin.markdown
+|      ^ punctuation.definition.italic.begin.markdown
+|      ^^^^^ markup.bold.markdown markup.italic.markdown
+|          ^ punctuation.definition.italic.end.markdown
+|           ^^^^^^^^^ markup.bold.markdown - markup.bold markup.italic
+|                  ^^ punctuation.definition.bold.end.markdown
+
+**foo [_bar_](/url)**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^ markup.bold.markdown - markup.bold markup.italic
+|     ^^^^^^^^^^^^^ meta.link.inline
+|^ punctuation.definition.bold.begin.markdown
+|      ^ punctuation.definition.italic.begin.markdown
+|      ^^^^^ markup.bold.markdown markup.italic.markdown
+|          ^ punctuation.definition.italic.end.markdown
+|           ^^^^^^^^^ markup.bold.markdown - markup.bold markup.italic
+|                  ^^ punctuation.definition.bold.end.markdown
+
+## https://spec.commonmark.org/0.30/#example-433
+
+__ is not an empty emphasis
+| <- - markup - punctuation
+|^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-434
+
+____ is not an empty strong emphasis
+| <- - markup - punctuation
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-435
+
+foo ***
+|   ^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-436
+
+foo *\**
+|^^^ - markup
+|   ^^^^ markup.italic.markdown
+|   ^ punctuation.definition.italic.begin.markdown
+|    ^^ constant.character.escape.markdown
+|      ^ punctuation.definition.italic.end.markdown
+|       ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-437
+
+foo *_*
+|^^^ - markup
+|   ^^^ markup.italic.markdown
+|   ^punctuation.definition.italic.begin.markdown
+|     ^ punctuation.definition.italic.end.markdown
+|      ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-439
+
+foo **\***
+|^^^ - markup
+|   ^^^^^^ markup.bold.markdown
+|   ^^ punctuation.definition.bold.begin.markdown
+|     ^^ constant.character.escape.markdown
+|       ^^ punctuation.definition.bold.end.markdown
+|         ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-440
+
+foo **_**
+|^^^ - markup
+|   ^^^^^ markup.bold.markdown
+|   ^^punctuation.definition.bold.begin.markdown
+|      ^^ punctuation.definition.bold.end.markdown
+|        ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-441
+
+**foo*
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-442
+
+*foo**
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-443
+
+***foo**
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-444
+
+****foo*
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-445
+
+**foo***
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^^^^^^ markup.bold.markdown
+|^ punctuation.definition.bold.begin.markdown
+|    ^^ punctuation.definition.bold.end.markdown
+|      ^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-446
+
+*foo****
+
+> Note: Needs ST4's branching to get it right!
+
+## https://spec.commonmark.org/0.30/#example-447
+
+foo ___
+|   ^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-448
+
+foo _\__
+|^^^ - markup
+|   ^^^^ markup.italic.markdown
+|   ^ punctuation.definition.italic.begin.markdown
+|    ^^ constant.character.escape.markdown
+|      ^ punctuation.definition.italic.end.markdown
+|       ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-449
+
+foo _*_
+|^^^ - markup
+|   ^^^ markup.italic.markdown
+|   ^punctuation.definition.italic.begin.markdown
+|     ^ punctuation.definition.italic.end.markdown
+|      ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-450
+
+foo _____
+|   ^^^^^ - markup - punctuation
+
+## https://spec.commonmark.org/0.30/#example-451
+
+foo __\___
+|^^^ - markup
+|   ^^^^^^ markup.bold.markdown
+|   ^^ punctuation.definition.bold.begin.markdown
+|     ^^ constant.character.escape.markdown
+|       ^^ punctuation.definition.bold.end.markdown
+|         ^ - markup
+
+## https://spec.commonmark.org/0.30/#example-452
+
+foo __*__
+|^^^ - markup
+|   ^^^^^ markup.bold.markdown
+|   ^^punctuation.definition.bold.begin.markdown
+|      ^^ punctuation.definition.bold.end.markdown
+|        ^ - markup
+
+## https://custom-tests/emphasis
+
+This text is _italic_, but this__text__is neither bold_nor_italic
+|            ^ punctuation.definition.italic
+|             ^^^^^^ markup.italic
+|                   ^ punctuation.definition.italic
+|                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.bold - markup.italic
+
+the following is italic *and doesn't end here * but does end here*
+|                       ^ punctuation.definition.italic.begin
+|                                             ^ - punctuation.definition.italic
+|                                                                ^ punctuation.definition.italic.end
+
+the following is bold **and doesn't end here ** but does end here**
+|                     ^^ punctuation.definition.bold.begin
+|                                            ^^ - punctuation.definition.bold
+|                                                                ^^ punctuation.definition.bold.end
+
+the following is not bold ** test ****
+|                         ^^ - punctuation.definition.bold.begin
+|                                 ^^^^ - punctuation.definition.bold
+
+the following is not italic _ test ____
+|                           ^ - punctuation.definition.italic.begin
+|                                  ^^^^ - punctuation.definition.italic
+
+more **tests *** ** here**
+|    ^^ punctuation.definition.bold.begin
+|            ^^^^^^ - punctuation.definition
+|                       ^^ punctuation.definition.bold.end
+
+more __tests *** ** example __ here__
+|    ^^ punctuation.definition.bold.begin
+|            ^^^^^^^^^^^^^^^^^^^^^^ - punctuation.definition
+|                                  ^^ punctuation.definition.bold.end
+
+more _tests <span class="test_">here</span>_
+|    ^ punctuation.definition.italic.begin
+|                            ^ - punctuation.definition
+|                                          ^ punctuation.definition.italic.end
+
+more _tests <span class="test_">_here</span>_
+|    ^ punctuation.definition.italic.begin
+|                            ^ - punctuation.definition
+|                               ^ - punctuation
+|                                           ^ punctuation.definition.italic.end
+
+_more `tests_` here_
+| <- punctuation.definition.italic.begin
+|     ^^^^^^^^ markup.raw.inline
+|                  ^ punctuation.definition.italic.end
+
+__more `tests__` here__
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+
+**more `tests__` here**
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+
+**more `tests**` here**
+| <- punctuation.definition.bold.begin
+|      ^^^^^^^^^ markup.raw.inline
+|                    ^^ punctuation.definition.bold.end
+
+*more `tests__` here**
+| <- punctuation.definition.italic.begin
+|                   ^^ - punctuation
+abc*
+|  ^ punctuation.definition.italic.end
+
+This is ***bold italic***
+|       ^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^ punctuation.definition.bold.end
+
+This is ***bold italic* and just bold**
+|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^^^^^^^^^^^^^^^ - markup.italic
+|                                    ^^ punctuation.definition.bold.end
+
+The next scope overlap funny because we have to pick one order
+to scope three indicators in a row
+This is ***bold italic** and just italic*
+|       ^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.italic
+|         ^ punctuation.definition.italic.begin
+|                     ^^ punctuation.definition.bold.end
+|                       ^^^^^^^^^^^^^^^^^ - markup.bold
+|                                       ^ punctuation.definition.italic.end
+
+This is **_bold italic_**
+|       ^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^ punctuation.definition.bold.end
+
+This is __*bold italic*__
+|       ^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^ punctuation.definition.bold.end
+
+This is ___bold italic___
+|       ^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^ punctuation.definition.bold.end
+
+This is ___bold italic_ and just bold__
+|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^ punctuation.definition.italic.begin
+|         ^^^^^^^^^^^^^ markup.italic
+|                     ^ punctuation.definition.italic.end
+|                      ^^^^^^^^^^^^^^^^ - markup.italic
+|                                    ^^ punctuation.definition.bold.end
+
+The next scope overlap funny because we have to pick one order
+to scope three indicators in a row
+This is ___bold italic__ and just italic_
+|       ^^^^^^^^^^^^^^^ markup.bold
+|       ^^ punctuation.definition.bold.begin
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.italic
+|         ^ punctuation.definition.italic.begin
+|                     ^^ punctuation.definition.bold.end
+|                       ^^^^^^^^^^^^^^^^^ - markup.bold
+|                                       ^ punctuation.definition.italic.end
+
+This is _**italic bold**_
+|       ^^^^^^^^^^^^^^^^^ markup.italic
+|       ^ punctuation.definition.italic.begin
+|        ^^^^^^^^^^^^^^^ markup.bold
+|        ^^ punctuation.definition.bold.begin
+|                     ^^ punctuation.definition.bold.end
+|                       ^ punctuation.definition.italic.end
+
+This is *__italic bold__*
+|       ^^^^^^^^^^^^^^^^^ markup.italic
+|       ^ punctuation.definition.italic.begin
+|        ^^^^^^^^^^^^^^^ markup.bold
+|        ^^ punctuation.definition.bold.begin
+|                     ^^ punctuation.definition.bold.end
+|                       ^ punctuation.definition.italic.end
+
+**test!_test** Issue 1163
+|^^^^^^^^^^^^^ markup.bold
+|      ^ - punctuation.definition.italic
+|           ^^ punctuation.definition.bold.end
+
+__test!*test__ Issue 1163
+|^^^^^^^^^^^^^ markup.bold
+|      ^ - punctuation.definition.italic
+|           ^^ punctuation.definition.bold.end
+
+*test
+
+| <- invalid.illegal.non-terminated.bold-italic
+abc*
+|  ^ - punctuation
+
+_test
+
+| <- invalid.illegal.non-terminated.bold-italic
+abc_
+|  ^ - punctuation
+
+**test
+
+| <- invalid.illegal.non-terminated.bold-italic
+abc**
+|  ^^ - punctuation
+
+__test
+
+| <- invalid.illegal.non-terminated.bold-italic
+abc__
+|  ^^ - punctuation
+
+__test\
+|     ^ meta.hard-line-break constant.character.escape
+testing__
+
+*italic text <span>HTML element</span> end of italic text*
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+_italic text <SPAN>HTML element</SPAN> end of italic text_
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+**bold text <span>HTML element</span> end of bold text**
+| <- punctuation.definition.bold
+|                                                     ^^ punctuation.definition.bold
+|           ^^^^^^ meta.tag.inline.any.html
+|                             ^^^^^^^ meta.tag.inline.any.html
+
+__bold text <span>HTML element</span> end of bold text__
+| <- punctuation.definition.bold
+|                                                     ^^ punctuation.definition.bold
+|           ^^^^^^ meta.tag.inline.any.html
+|                             ^^^^^^^ meta.tag.inline.any.html
+
+*italic text <span>HTML element</span> end of italic text*
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+_italic text <span>HTML element</span> end of italic text_
+| <- punctuation.definition.italic
+|                                                        ^ punctuation.definition.italic
+|            ^^^^^^ meta.tag.inline.any.html
+|                              ^^^^^^^ meta.tag.inline.any.html
+
+_test <span>text_ foobar</span>
+| <- punctuation
+|               ^ punctuation.definition.italic.end
+
+__test <span>text__ not formatted</span>
+| <- punctuation
+|                ^^ punctuation.definition.bold.end
+
+*test <span>text* not formatted</span>
+| <- punctuation
+|               ^ punctuation.definition.italic.end
+
+**test <span>text** not formatted</span>
+| <- punctuation
+|                ^^ punctuation.definition.bold.end
+
+_test <span>text **formatted**</span>_
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+
+*test <span>text __formatted__</span>*
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+
+*test <span>text __formatted__</span>* **more** _text_
+| <- punctuation
+|                ^^ punctuation
+|                           ^^ punctuation
+|                                    ^ punctuation
+|                                      ^^ punctuation
+|                                            ^^ punctuation
+|                                               ^ punctuation
+|                                                    ^ punctuation
+
+*test <span>text* __formatted</span>__
+| <- punctuation
+|               ^ punctuation
+|                 ^^ punctuation
+|                                   ^^ punctuation
+
+__test <span>text__ *formatted</span>*
+| <- punctuation
+|                ^^ punctuation
+|                   ^ punctuation
+|                                    ^ punctuation
+
+# TEST: STRIKETHROUGH #########################################################
+
+__~~bold striked~~__
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.strikethrough
+| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
+|                 ^^ markup.bold.markdown - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^^ punctuation.definition.strikethrough.begin.markdown
+|               ^^ punctuation.definition.strikethrough.end.markdown 
+|                 ^^ punctuation.definition.bold.end.markdown
+
+**~~bold striked~~**
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.strikethrough
+| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
+|                 ^^ markup.bold.markdown - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^^ punctuation.definition.strikethrough.begin.markdown
+|               ^^ punctuation.definition.strikethrough.end.markdown 
+|                 ^^ punctuation.definition.bold.end.markdown
+
+_~~italic striked~~_
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
+|                  ^ markup.italic.markdown - markup.strikethrough
+|^^ punctuation.definition.strikethrough.begin.markdown
+|                ^^ punctuation.definition.strikethrough.end.markdown 
+|                  ^ punctuation.definition.italic.end.markdown
+
+*~~italic striked~~*
+| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
+|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
+|                  ^ markup.italic.markdown - markup.strikethrough
+|^^ punctuation.definition.strikethrough.begin.markdown
+|                ^^ punctuation.definition.strikethrough.end.markdown 
+|                  ^ punctuation.definition.italic.end.markdown
+
+___~~bold italic striked~~___
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.italic - markup.strikethrough
+| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
+|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^ punctuation.definition.italic.begin.markdown
+|  ^^ punctuation.definition.strikethrough.begin.markdown
+|                       ^^ punctuation.definition.strikethrough.end.markdown 
+|                         ^ punctuation.definition.italic.end.markdown
+|                          ^^ punctuation.definition.bold.end.markdown
+
+***~~bold italic striked~~***
+| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
+|^ markup.bold.markdown - markup.italic - markup.strikethrough
+| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
+|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
+|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
+|^ punctuation.definition.bold.begin.markdown
+| ^ punctuation.definition.italic.begin.markdown
+|  ^^ punctuation.definition.strikethrough.begin.markdown
+|                       ^^ punctuation.definition.strikethrough.end.markdown 
+|                         ^ punctuation.definition.italic.end.markdown
+|                          ^^ punctuation.definition.bold.end.markdown
+
+~Hi~ Hello, world!
+| <- - punctuation.definition.strikethrough
+|^^^^^^^^^^^^^^^^^ meta.paragraph - markup
+|  ^ - punctuation.definition.strikethrough
+
+This ~text~~~~ is ~~~~curious~.
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - markup
+|    ^ - punctuation.definition.strikethrough
+|         ^^^^ - punctuation.definition.strikethrough
+|                 ^^^^ - punctuation.definition.strikethrough
+|                            ^ - punctuation.definition.strikethrough
+
+This ~~text~~~~ is ~~~~curious~~.
+|^^^^ meta.paragraph - markup
+|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph markup.strikethrough
+|                               ^^ meta.paragraph - markup
+|    ^^ punctuation.definition.strikethrough.begin
+|          ^^^^ - punctuation.definition.strikethrough
+|                  ^^^^ - punctuation.definition.strikethrough
+|                             ^^ punctuation.definition.strikethrough.end
+
+This ~~has a
+|    ^^^^^^^^ meta.paragraph markup.strikethrough
+
+| <- meta.paragraph markup.strikethrough invalid.illegal.non-terminated.bold-italic
+new paragraph~~.
+|            ^^ meta.paragraph markup.strikethrough punctuation.definition.strikethrough.begin
+
+| <- invalid.illegal.non-terminated.bold-italic
+
+A ~~[striked](https://link-url)~~
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown markup.strikethrough.markdown-gfm
+
+A ~~![striked](https://image-url)~~
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown markup.strikethrough.markdown-gfm
+
+A ~~[![striked](image-url)](link-url)~~
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown markup.strikethrough.markdown-gfm
+
+
+# TEST: LINKS #################################################################
+
 A [link](https://example.com){ :_attr = value }, *italic text* and **bold**.
 | ^^^^^^ meta.link.inline.description.markdown
 | ^ punctuation.definition.link.begin
@@ -424,11 +7040,6 @@ A [link](https://example.com){ :_attr = value }, *italic text* and **bold**.
 |                                                                  ^^ punctuation.definition.bold
 |                                                                  ^^^^^^^^ markup.bold
 |                                                                        ^^ punctuation.definition.bold
-
-Inline `code sample`.
-|      ^^^^^^^^^^^^^ markup.raw.inline
-|      ^ punctuation.definition.raw
-|                  ^ punctuation.definition.raw
 
 Here is a [](https://example.com).
 |         ^^ meta.link.inline
@@ -543,19 +7154,147 @@ Here is a [blank reference link][]{}.
 |                                 ^ punctuation.definition.attributes.begin.markdown
 |                                  ^ punctuation.definition.attributes.end.markdown
 
-Here is a footnote[^1][link][] or long[^longnote][link][].
-|                 ^^^^ meta.link.reference.footnote.markdown-extra
-|                     ^^^^^^ meta.link.reference.literal.description.markdown
-|                           ^^ meta.link.reference.literal.metadata.markdown
-|                                     ^^^^^^^^^^^ meta.link.reference.footnote.markdown-extra
-|                                                ^^^^^^^^ meta.link.reference.literal
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca/documentations/about/cool ) for more information about...
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline markup.underline.link
+|                                                 ^ - invalid
+|                                                  ^ meta.link.inline punctuation.definition.metadata.end
 
-Here is a footnote [^footnote](not_link_dest).
-|                  ^^^^^^^^^^^ meta.paragraph.markdown meta.link.reference.footnote.markdown-extra
-|                  ^ punctuation.definition.link.begin.markdown
-|                   ^^^^^^^^^ meta.link.reference.literal.footnote-id.markdown
-|                            ^ punctuation.definition.link.end.markdown
-|                             ^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.link
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca /documentations/about/cool ) for more information about...
+| ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inline markup.underline.link
+|                       ^ meta.paragraph meta.link.inline - markup.underline.link
+|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.link.inline
+
+now you can access the [The Ever Cool Site: Documentation about Sites](
+  www.thecoolsite.com.ca/documentations/about/cool
+  (title)) for more information about...
+| ^^^^^^^^ meta.paragraph meta.link.inline
+|        ^ punctuation.definition.metadata.end
+| ^^^^^^^ string.quoted.other.markdown
+
+link with a single underscore inside the text : [@_test](http://example.com)
+|                                                ^^^^^^ meta.paragraph meta.link.inline.description - punctuation.definition
+|                                                      ^ meta.paragraph meta.link.inline punctuation.definition.link.end
+
+[foo]
+|<- meta.link.reference punctuation.definition.link.begin
+|^^^ meta.paragraph meta.link.reference
+|   ^ meta.link.reference punctuation.definition.link.end
+
+This is literal [Foo*bar\]] but [ref][Foo*bar\]]
+|               ^^^^^^^^^^^ meta.link.reference.description.markdown
+|               ^ punctuation.definition.link.begin.markdown
+|                ^^^^^^^ - constant
+|                       ^^ constant.character.escape.markdown
+|                         ^ punctuation.definition.link.end.markdown
+|                               ^^^^^ meta.link.reference.description.markdown
+|                                    ^^^^^^^^^^^ meta.link.reference.metadata.markdown
+
+[**Read more &#8594;**][details]
+|^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                      ^^^^^^^^^ meta.link.reference.metadata.markdown
+|^^ punctuation.definition.bold.begin.markdown
+|            ^^^^^^^ constant.character.entity.decimal.html
+|                   ^^ punctuation.definition.bold.end.markdown
+|                       ^^^^^^^ markup.underline.link.markdown
+
+[Read more &#8594;][details]
+|^^^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                  ^^^^^^^^^ meta.link.reference.metadata.markdown
+|          ^^^^^^^ constant.character.entity.decimal.html
+|                   ^^^^^^^ markup.underline.link
+
+[Read more <span style="font-weight: bold;">&#8594;</span>][details]
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                                                          ^^^^^^^^^ meta.link.reference.metadata.markdown
+|          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+|                       ^^^^^^^^^^^^^^^^^^ source.css
+|                                           ^^^^^^^ constant.character.entity.decimal.html - meta.tag
+|                                                  ^^^^^^^ meta.tag
+|                                                           ^^^^^^^ markup.underline.link
+
+[![Cool ★ Image - Click to Enlarge][img-example]][img-example]
+| <- meta.link.reference.description.markdown punctuation.definition.link.begin.markdown
+|^^ meta.link.reference.description.markdown meta.image.reference.description.markdown
+|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.description.markdown meta.image.reference.description.markdown
+|                                  ^^^^^^^^^^^^^^ meta.link.reference.description.markdown
+|                                                ^^^^^^^^^^^^^ meta.link.reference.metadata.markdown
+|^^ punctuation.definition.image.begin.markdown
+|                                 ^ punctuation.definition.image.end.markdown
+|                                  ^ punctuation.definition.metadata.begin.markdown
+|                                   ^^^^^^^^^^^ markup.underline.link
+|                                              ^ punctuation.definition.metadata.end.markdown
+|                                               ^ punctuation.definition.link.end.markdown
+|                                                ^ punctuation.definition.metadata.begin.markdown
+|                                                 ^^^^^^^^^^^ markup.underline.link
+|                                                            ^ punctuation.definition.metadata.end.markdown
+
+[![Cool ★ Image - Click to Enlarge](http://www.sublimetext.com/anim/rename2_packed.png)](http://www.sublimetext.com/anim/rename2_packed.png)
+| <- meta.paragraph.markdown meta.link.inline.description.markdown punctuation.definition.link.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inline.description.markdown meta.image.inline.description.markdown
+|                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inline.description.markdown meta.image.inline.metadata.markdown
+|                                                                                      ^ meta.paragraph.markdown meta.link.inline.description.markdown
+|                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inline.metadata.markdown
+|^^ punctuation.definition.image.begin.markdown
+|                                 ^ punctuation.definition.image.end.markdown
+|                                  ^ punctuation.definition.metadata.begin.markdown
+|                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
+|                                                                                     ^ punctuation.definition.metadata.end.markdown
+|                                                                                      ^ punctuation.definition.link.end.markdown
+|                                                                                       ^ punctuation.definition.metadata.begin.markdown
+|                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.markdown
+|                                                                                                                                          ^ punctuation.definition.metadata.end.markdown
+
+[link [containing] [square] brackets](#backticks)
+|<- punctuation.definition.link.begin
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
+|                                   ^ punctuation.definition.link.end
+
+[link `containing square] brackets] in backticks`[]](#wow)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
+|     ^ punctuation.definition.raw.begin
+|                                               ^ punctuation.definition.raw.end
+|                                                  ^ punctuation.definition.link.end
+
+[link ``containing square]` brackets[[][] in backticks``](#wow)
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
+|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline
+|     ^^ punctuation.definition.raw.begin
+|                                                     ^^ punctuation.definition.raw.end
+|                                                       ^ punctuation.definition.link.end
+
+This is a [reference] ()
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^ - meta.link
+
+This is a [reference] (followed by parens)
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a [reference] []
+|         ^^^^^^^^^^^ meta.link.reference
+|                    ^ - meta.link
+|                     ^^ meta.link.reference
+
+This is a ![reference] ()
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^ - meta.link
+
+This is a ![reference] (followed by parens)
+|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^^^^^^^^^^^^^^^^^^^^^ - meta.link
+
+This is a ![reference] []
+|         ^^^^^^^^^^^^^^^ - meta.image
+|          ^^^^^^^^^^^ meta.link.reference
+|                     ^ - meta.link
+|                      ^^ meta.link.reference
+
+
+# TEST: IMAGES ################################################################
 
 Here is a ![](https://example.com/cat.gif).
 |         ^^^ meta.image.inline.description.markdown
@@ -659,373 +7398,33 @@ Here is a ![Image Ref Alt][1].
 |                          ^ markup.underline.link.markdown
 |                           ^ punctuation.definition.metadata.end.markdown
 
-now you can access the [The Ever Cool Site: Documentation about Sites](
-  www.thecoolsite.com.ca/documentations/about/cool ) for more information about...
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline markup.underline.link
-|                                                 ^ - invalid
-|                                                  ^ meta.link.inline punctuation.definition.metadata.end
 
-now you can access the [The Ever Cool Site: Documentation about Sites](
-  www.thecoolsite.com.ca /documentations/about/cool ) for more information about...
-| ^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph meta.link.inline markup.underline.link
-|                       ^ meta.paragraph meta.link.inline - markup.underline.link
-|                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.link.inline
+# TEST: FOOTNOTES #############################################################
 
-now you can access the [The Ever Cool Site: Documentation about Sites](
-  www.thecoolsite.com.ca/documentations/about/cool
-  (title)) for more information about...
-| ^^^^^^^^ meta.paragraph meta.link.inline
-|        ^ punctuation.definition.metadata.end
-| ^^^^^^^ string.quoted.other.markdown
+## https://michelf.ca/projects/php-markdown/extra/#footnotes
 
-  1. Ordered list item
-| ^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered
-| ^^ markup.list.numbered.bullet - markup.list.numbered markup.list.numbered
-|  ^ punctuation.definition.list_item
-  2. Ordered list item #2
-| ^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered - markup.list.numbered markup.list.numbered
-| ^^ markup.list.numbered.bullet
-|  ^ punctuation.definition.list_item
-     1. Subitem
-     2. Another subitem
-|^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered
-|    ^^ markup.list.numbered.bullet
-|     ^ punctuation.definition.list_item
-|       ^^^^^^^^^^^^^^^^ meta.paragraph.list - meta.paragraph.list meta.paragraph.list
+That's some text with a footnote.[^1]
+|                                ^^^^ meta.paragraph meta.link.reference.footnote.markdown-extra
+|                                ^ punctuation.definition.link.begin
+|                                 ^^ meta.link.reference.literal.footnote-id
+|                                   ^ punctuation.definition.link.end
 
-Paragraph break.
+Here is a footnote[^1][link][] or long[^longnote][link][].
+|                 ^^^^ meta.link.reference.footnote.markdown-extra
+|                     ^^^^^^ meta.link.reference.literal.description.markdown
+|                           ^^ meta.link.reference.literal.metadata.markdown
+|                                     ^^^^^^^^^^^ meta.link.reference.footnote.markdown-extra
+|                                                ^^^^^^^^ meta.link.reference.literal
 
-  - Unordered list item
-| ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered - markup.list.unnumbered markup.list.unnumbered
-| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-  - Unordered list item #2
-| ^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered - markup.list.unnumbered markup.list.unnumbered
-| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
+Here is a footnote [^footnote](not_link_dest).
+|                  ^^^^^^^^^^^ meta.paragraph.markdown meta.link.reference.footnote.markdown-extra
+|                  ^ punctuation.definition.link.begin.markdown
+|                   ^^^^^^^^^ meta.link.reference.literal.footnote-id.markdown
+|                            ^ punctuation.definition.link.end.markdown
+|                             ^^^^^^^^^^^^^^^ meta.paragraph.markdown - meta.link
 
-Paragraph break.
 
-- `<Logo>` | `<logo>` (components/Logo.vue)
-- `<MyComponent>` | `<my-component>` | (components/my-component.vue)
-| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown
-
-Paragraph break.
-
-  * Unordered list item
-| ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered - markup.list.unnumbered markup.list.unnumbered
-| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-  + Unordered list item #2
-| ^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered - markup.list.unnumbered markup.list.unnumbered
-| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-    + Subitem 1
-|   ^ punctuation.definition.list_item
-  + Item
-    + Subitem
-    + Another subitem
-|   ^ markup.list.unnumbered.bullet punctuation.definition.list_item - meta.paragraph.list
-|     ^^^^^^^^^^^^^^^ meta.paragraph.list
-      + Nested Subitem
-|     ^ markup.list.unnumbered.bullet punctuation.definition.list_item - markup.list.unnumbered markup.list.unnumbered
-        + Nested + Subitem
-|       ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-|                ^ - punctuation.definition.list_item
-
-  * Unsorted list item
-	```xml
-|^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown meta.code-fence.definition.begin.xml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|    ^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown meta.code-fence.definition.begin.xml.markdown-gfm constant.other.language-name.markdown
-	<tag>
-|^^^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown markup.raw.code-fence.xml.markdown-gfm text.xml meta.tag.xml
-	```
-|^^^ markup.list.unnumbered.markdown meta.paragraph.list.markdown meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-
-Paragraph break.
-
-> This is a block quote. It contains markup.
-> Including things like *italics*
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote
-|                       ^^^^^^^^^ markup.italic
-
-Paragraph break.
-
----
-|^^^ meta.separator.thematic-break
-|^^ punctuation.definition.thematic-break
-
-Paragraph break.
-
---------
-|^^^^^^^^ meta.separator.thematic-break
-|^^^^^^^ punctuation.definition.thematic-break
-
-[1]: https://google.com
-| <- meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|^ entity.name.reference.link
-|  ^ punctuation.separator.key-value
-|    ^^^^^^^^^^^^^^^^^^ markup.underline.link
-
-<div>this is HTML until <span>there are two</span> blank lines</div>
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-disabled markdown
-| <- meta.disable-markdown
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-<div>this is HTML until there are two blank lines
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-still <span>HTML</span>
-|      ^^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
-</div>
-| ^^^^ meta.disable-markdown
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-<pre>nested tags don't count <pre>test</pre>
-|                                     ^^^^^^ meta.disable-markdown meta.tag.block.any.html
-non-disabled markdown
-| <- - meta.disable-markdown
-
-<div>nested tags don't count <div>test
-|                                 ^^^^^ meta.disable-markdown
-</div>
-| ^^^ meta.disable-markdown entity.name.tag.block.any.html
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-<div>two blank lines needed</div> to stop disabled markdown
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-disabled markdown
-| <- meta.disable-markdown
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-<div>another</div> <span>disable</span> test
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-|                  ^^^^^^ meta.tag.inline.any.html
-disabled markdown
-| <- meta.disable-markdown
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-*a*
-| ^ markup.italic
-<p>*a*</p>
-| ^^^^^^^^^ meta.disable-markdown - markup.italic
-*a*
-| ^^ meta.disable-markdown
-
-non-disabled markdown
-| <- - meta.disable-markdown
-
-
-# Block Quote Tests ###########################################################
-
->=
-| <- punctuation.definition.blockquote.markdown 
-
->==
-| <- punctuation.definition.blockquote.markdown
-
-  >=
-| ^ punctuation.definition.blockquote.markdown
-    >=
-|   ^^ - punctuation.definition.blockquote.markdown
-
-    >=
-|   ^^ - punctuation.definition.blockquote.markdown
-
-> Block quote
-| <- markup.quote punctuation.definition.blockquote
-| ^^^^^^^^^^^ markup.quote
-
-> Block quote followed by an empty block quote line
->
-| <- markup.quote punctuation.definition.blockquote
-
-> Block quote followed by an empty block quote line
->
-> Followed by more quoted text
-| <- markup.quote punctuation.definition.blockquote
-
-> > Nested block quote
-| <- markup.quote punctuation.definition.blockquote
-| ^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.quote.markdown
-|^ - punctuation
-| ^ punctuation.definition.blockquote
-|  ^ - punctuation
-
-> > Nested quote
-> Followed by more quoted text that is not nested
-| <- markup.quote punctuation.definition.blockquote - markup.quote markup.quote
-
-> Here is a block quote
-This quote continues on. Line breaking is OK in markdown
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote
-> Here it is again
-| <- punctuation.definition.blockquote
-
-paragraph
-| <- meta.paragraph
-
->    > this is a nested quote but no code in a block quote
-| <- punctuation.definition.blockquote
-|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown markup.quote.markdown
-
->     > this is code in a block quote, not a nested quote
-| <- punctuation.definition.blockquote
-|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block - markup.quote markup.quote
-
-> CommonMark expects following line to be indented code block (see: example 326)
-    > but all common parsers handle it as continued text.
-|   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.quote.markdown - markup.raw
-|   ^ - punctuation
-
-> Quoted fenced code block begin
-> ```
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
-| ^^^ punctuation.definition.raw.code-fence.begin.markdown
-
-> Quoted fenced code block language identifier
-> ```C++
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
-|    ^^^ constant.other.language-name.markdown
-
-> Quoted fenced code block language identifier
-> ```C++ info string
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
-|    ^^^ constant.other.language-name.markdown
-|       ^^^^^^^^^^^^^ - constant
-
-> Quoted fenced code block content
-> ```
-> code block
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^^^^^ markup.quote.markdown markup.raw.code-fence.markdown-gfm
-
-> Quoted fenced code block end
-> ```
-> ```
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
-| ^^^ punctuation.definition.raw.code-fence.end.markdown
-
-> > 2nd level quoted fenced code block
-> > ```
-> > code block ```
-> > ```
-| <- markup.quote.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
-|^^^ markup.quote.markdown markup.quote.markdown - meta.code-fence
-|   ^^^^ markup.quote.markdown markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
-
-> Block quote followed by fenced code block
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
-
-> Quoted fenced code block is terminated by missing > at bol
-> ```
-no code block
-| <- meta.paragraph.markdown - meta.quote - meta.code-fence
-|^^^^^^^^^^^^^ meta.paragraph.markdown - meta.quote - meta.code-fence
-
-> Quoted fenced code block is terminated by missing > at bol
-> ```
-> content
-no code block
-| <- meta.paragraph.markdown - meta.quote - meta.code-fence
-|^^^^^^^^^^^^^ meta.paragraph.markdown - meta.quote - meta.code-fence
-
-> Unterminated quoted fenced code block followed by unquoted fenced code block
-> ```
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm - markup.quote
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm - markup.quote
-
-> Block quote followed by heading
-# heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
-|^^^^^^^^^ markup.heading.1.markdown - meta.quote
-| ^^^^^^^ entity.name.section.markdown
-
-> Block quote followed by list
-* list item
-| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
-|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
-
-> Block quote followed by list
-+ list item
-| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
-|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
-
-> Block quote followed by list
-- list item
-| <- markup.list.unnumbered.bullet.markdown punctuation.definition.list_item.markdown
-|^^^^^^^^^^^ markup.list.unnumbered.markdown - meta.quote
-
-> Block quote followed by list
-1. list item
-| <- markup.list.numbered.bullet.markdown - punctuation
-|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
-| ^^^^^^^^^^ markup.list.numbered.markdown - meta.quote
-
-> Block quote followed by thematic break
-***
-| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - meta.quote
-
-> Block quote followed by thematic break
-- - -
-| <- meta.separator.thematic-break.markdown punctuation.definition.thematic-break.markdown - meta.quote
-
-Code block below:
-
-    this is code!
-| ^^^^^^^^^^^^^^^^ markup.raw.block
-
-    more code
-    spanning multiple lines
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.block
-
-paragraph
-| <- meta.paragraph
-
-- - - -
-| ^^^^^^ meta.separator
-| ^ punctuation.definition.thematic-break
-|   ^ punctuation.definition.thematic-break
-|     ^ punctuation.definition.thematic-break
-|  ^ - punctuation
-* * * * *
-| ^^^^^^^^ meta.separator
-
-_ _ _ _ _ _ _
-| ^^^^^^^^^^^^ meta.separator
-| ^ punctuation.definition.thematic-break
-|   ^ punctuation.definition.thematic-break
-|  ^ - punctuation
-
--  -  -  - 
-| <- meta.separator.thematic-break punctuation.definition.thematic-break
-|^^ - punctuation
-|  ^ punctuation
-|        ^ punctuation
-
-###[ COMMONMARK AUTOLINKS ]###################################################
+# TEST: COMMONMARK AUTOLINKS ##################################################
 
 <mailto:test+test@test.com>
 | <- meta.link.email.markdown punctuation.definition.link.begin.markdown - markup.underline
@@ -1114,7 +7513,8 @@ _ _ _ _ _ _ _
 |    ^^^ punctuation.separator.path.markdown
 |                  ^ punctuation.separator.path.markdown
 
-###[ GFM AUTOLINKS ]##########################################################
+
+# TEST: GFM AUTOLINKS #########################################################
 
 Visit ftp://intra%20net
 |     ^^^^^^^^^^^^^^^^^ meta.link.inet.markdown markup.underline.link
@@ -1268,1178 +7668,8 @@ a.b-c_d@a.b.
 | <- - meta.link - markup.underline
 |^^^^^^^^^^^^^ - meta.link - markup.underline.link
 
-###[ LIGATURES ]##############################################################
 
-this is a raw ampersand & does not require HTML escaping
-|                       ^ - entity - illegal
-
-this is a raw bracket < > does not require HTML escaping
-|                     ^^^ - meta.tag - punctuation
-
-these are raw ligatures << <<< <<<< <<<<< >>>>> >>>> >>> >>
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures <- <-- <--- <---- <-< <--< <---< <----<
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures -> --> ---> ----> >-> >--> >---> >---->
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures >- >-- >--- >---- ----< ---< --< -<
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures >< >-< >--< >---< <---> <--> <-> <>
-|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures <= <== <=== <==== <=< <==< <===< <====<
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures => ==> ===> ====> >=> >==> >===> >====>
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures >= >== >=== >==== ====< ===< ==< =<
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures >< >=< >==< >===< <===> <==> <=> <>
-|                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-these are raw ligatures - -- --- ---- ----- ===== ==== === == =
-|                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.other.valid-bracket - meta.tag
-
-[2]: https://github.com/sublimehq/Packages "Packages Repo"
-| <- meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|^ entity.name.reference.link
-|  ^ punctuation.separator.key-value
-|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                                          ^^^^^^^^^^^^^^^ string.quoted.double
-|                                          ^ punctuation.definition.string.begin
-|                                                        ^ punctuation.definition.string.end
-
-[3]: https://github.com/sublimehq/Packages/issues/ 'Issues on Packages Repo'
-| <- meta.link.reference.def.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|^ entity.name.reference.link
-|  ^ punctuation.separator.key-value
-|    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
-|                                                  ^ punctuation.definition.string.begin
-|                                                                          ^ punctuation.definition.string.end
-
-Paragraph followed immediately by a list, no blank line in between
-- list item 1
-| <- markup.list.unnumbered punctuation.definition.list_item
-
-Paragraph followed immediately by a numbered list, no blank line in between
- 1. list item 1
-|^^^^^^^^^^^^^^^ markup.list.numbered
-|^^ markup.list.numbered.bullet
-| ^ punctuation.definition.list_item
-|   ^^^^^^^^^^^^ meta.paragraph.list
-  more text - this punctuation should be ignored 2.
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list
-|           ^ - punctuation.definition.list_item
-|                                                 ^ - punctuation.definition.list_item
-
-Paragraph not followed immediately by a numbered list,
-because it doesn't begin with the number one:
- 2. text
-| ^ - markup.list.numbered - punctuation.definition.list_item
-
-
-> Block quote with list items
-> - list item 1
-| ^ markup.quote punctuation.definition.list_item
-> - list item 2
-| ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-| ^^^^^^^^^^^^^^ markup.quote markup.list.unnumbered
-|   ^^^^^^^^^^^^ meta.paragraph.list
->   1. sub list item
-| <- markup.quote punctuation.definition.blockquote
-|^^^^^^^^^^^^^^^^^^^^ markup.quote
-|    ^ punctuation.definition.list_item
-|   ^^ markup.list.numbered.bullet
-| ^^^^^^^^^^^^^^^^^^^ markup.list.numbered
-|      ^^^^^^^^^^^^^^ meta.paragraph.list
-> - list item 3
-  continued
-| ^^^^^^^^^^ markup.quote.markdown markup.list.unnumbered.markdown meta.paragraph.list.markdown
-
-* this is a list
-
-   > This is a blockquote.
-|  ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
-
-  - this is a list
-    > This is a blockquote.
-|   ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
-
- This is a paragraph still part of the 
- list item
-| ^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - meta.paragraph.list meta.paragraph.list
-
-* Lorem ipsum
-
-        This is a code block
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered markup.raw.block
-* list continues
-| <- markup.list.unnumbered punctuation.definition.list_item - markup.raw.block
-* list continues
-* [ ] Unticked GitHub-flavored-markdown checkbox
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered
-| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|  ^ markup.checkbox.mark.markdown-gfm - punctuation
-|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-* [x] Ticked GFM checkbox
-| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|  ^ markup.checkbox.mark.markdown-gfm - punctuation
-|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-* [X] Another ticked checkbox
-| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|  ^ markup.checkbox.mark.markdown-gfm - punctuation
-|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-    + [ ] Sub-item with checkbox
-|     ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|      ^ markup.checkbox.mark.markdown-gfm - punctuation
-|       ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-* [] Not a checkbox
-| ^^^^^^^^^^^^^^^^^ - storage - constant
-* [/] Not a checkbox
-| ^^^^^^^^^^^^^^^^^^ - storage
-* Not [ ] a [x] checkbox [X]
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ - storage - constant
-* [ ] [Checkbox][] with next word linked
-| ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|  ^ markup.checkbox.mark.markdown-gfm - punctuation
-|   ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-|     ^^^^^^^^^^^^ meta.link
-* list has `unclosed code
-* list continues
-| ^^^^^^^^^^^^^^^ - markup.raw
-
-> * [ ] task
-| ^^^^^^^^^^^ markup.quote.markdown
-| ^ markup.list.unnumbered.bullet.markdown
-|  ^^^^^^^^^^ markup.list.unnumbered.markdown
-| ^ punctuation.definition.list_item.markdown
-|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|    ^ markup.checkbox.mark.markdown-gfm - punctuation
-|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-> * [x] task
-| ^^^^^^^^^^^ markup.quote.markdown
-| ^ markup.list.unnumbered.bullet.markdown
-|  ^^^^^^^^^^ markup.list.unnumbered.markdown
-| ^ punctuation.definition.list_item.markdown
-|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|    ^ markup.checkbox.mark.markdown-gfm - punctuation
-|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-> * [X] task
-| ^^^^^^^^^^^ markup.quote.markdown
-| ^ markup.list.unnumbered.bullet.markdown
-|  ^^^^^^^^^^ markup.list.unnumbered.markdown
-| ^ punctuation.definition.list_item.markdown
-|   ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|    ^ markup.checkbox.mark.markdown-gfm - punctuation
-|     ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-> * [X] task
->   - [ ] task
-| ^^^^^^^^^^^^^ markup.quote.markdown
-|   ^ markup.list.unnumbered.bullet.markdown
-|    ^^^^^^^^^^ markup.list.unnumbered.markdown
-|   ^ punctuation.definition.list_item.markdown
-|     ^ markup.checkbox.begin.markdown-gfm punctuation.definition.checkbox.begin.markdown-gfm
-|      ^ markup.checkbox.mark.markdown-gfm - punctuation
-|       ^ markup.checkbox.end.markdown-gfm punctuation.definition.checkbox.end.markdown-gfm
-
-* list item
-  
-  <p>*no-markdown*</p>
-| ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown
-|                 ^^^^ meta.tag
-  - list item
-
-    <p>*no-markdown*</p>
-|   ^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered.markdown meta.disable-markdown
-|                   ^^^^ meta.tag
-
-- `code` - <a name="demo"></a>
-| ^ markup.list.unnumbered meta.paragraph.list markup.raw.inline punctuation.definition.raw
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html
- 3. [see `demo`](#demo "demo")
-| ^ punctuation.definition.list_item
-|   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
-|    ^^^^^^^^^^ meta.link.inline.description
-|               ^ punctuation.definition.metadata.begin
-|                      ^ punctuation.definition.string.begin
-|                           ^ punctuation.definition.string.end
-|                            ^ punctuation.definition.metadata.end
-    [see `demo`](#demo (demo))
-|   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
-|    ^^^^^^^^^^ meta.link.inline.description
-|               ^ punctuation.definition.metadata.begin
-|                      ^ punctuation.definition.string.begin
-|                           ^ punctuation.definition.string.end
-|                            ^ punctuation.definition.metadata.end
-    [see `demo`](#demo 'demo')
-|   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline
-|    ^^^^^^^^^^ meta.link.inline.description
-|               ^ punctuation.definition.metadata.begin
-|                      ^ punctuation.definition.string.begin
-|                           ^ punctuation.definition.string.end
-|                            ^ punctuation.definition.metadata.end
-    Here is a ![example image](https://test.com/sublime.png "A demonstration").
-|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
-|             ^^ punctuation.definition.image.begin
-|               ^^^^^^^^^^^^^ meta.image.inline.description
-|                            ^ punctuation.definition.image.end
-|                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
-|                                                           ^^^^^^^^^^^^^^^^^ string.quoted.double
-|                                                           ^ punctuation.definition.string.begin
-|                                                                           ^ punctuation.definition.string.end
-|                                                                            ^ punctuation.definition.metadata
-    Here is a ![example image](https://test.com/sublime.png 'A demonstration').
-|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
-|             ^^ punctuation.definition.image.begin
-|               ^^^^^^^^^^^^^ meta.image.inline.description
-|                            ^ punctuation.definition.image.end
-|                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
-|                                                           ^^^^^^^^^^^^^^^^^ string.quoted.single
-|                                                           ^ punctuation.definition.string.begin
-|                                                                           ^ punctuation.definition.string.end
-|                                                                            ^ punctuation.definition.metadata
-    Here is a ![example image](https://test.com/sublime.png (A demonstration)).
-|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.image.inline
-|             ^^ punctuation.definition.image.begin
-|               ^^^^^^^^^^^^^ meta.image.inline.description
-|                            ^ punctuation.definition.image.end
-|                             ^ punctuation.definition.metadata
-|                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
-|                                                           ^^^^^^^^^^^^^^^^^ string.quoted.other
-|                                                           ^ punctuation.definition.string.begin
-|                                                                           ^ punctuation.definition.string.end
-|                                                                            ^ punctuation.definition.metadata
-
-1) numberd item
-| <- markup.list.numbered.bullet.markdown
-|^ markup.list.numbered.bullet.markdown punctuation.definition.list_item.markdown
-| ^^^^^^^^^^^^^^ markup.list.numbered.markdown
-
- 2) numberd item
-| <- markup.list.numbered.markdown
-|^^ markup.list.numbered.bullet.markdown
-|  ^^^^^^^^^^^^^^ markup.list.numbered.markdown
-
-  3) numberd item
-| <- markup.list.numbered.markdown
-|^ markup.list.numbered.markdown
-| ^^ markup.list.numbered.bullet.markdown
-|   ^^^^^^^^^^^^^^ markup.list.numbered.markdown
-
-   4) numberd item
-| <- markup.list.numbered.markdown
-|^^ markup.list.numbered.markdown
-|  ^^ markup.list.numbered.bullet.markdown
-|    ^^^^^^^^^^^^^^ markup.list.numbered.markdown
-
-  <!-- HTML comment -->
-| ^^^^^^^^^^^^^^^^^^^^^ comment.block.html
-
-*italic text <span>HTML element</span> end of italic text*
-| <- punctuation.definition.italic
-|                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
-
-_italic text <SPAN>HTML element</SPAN> end of italic text_
-| <- punctuation.definition.italic
-|                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
-
-**bold text <span>HTML element</span> end of bold text**
-| <- punctuation.definition.bold
-|                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
-
-__bold text <span>HTML element</span> end of bold text__
-| <- punctuation.definition.bold
-|                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
-
-*italic text <span>HTML element</span> end of italic text*
-| <- punctuation.definition.italic
-|                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
-
-_italic text <span>HTML element</span> end of italic text_
-| <- punctuation.definition.italic
-|                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
-
-[link [containing] [square] brackets](#backticks)
-|<- punctuation.definition.link.begin
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
-|                                   ^ punctuation.definition.link.end
-[link `containing square] brackets] in backticks`[]](#wow)
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
-|     ^ punctuation.definition.raw.begin
-|                                               ^ punctuation.definition.raw.end
-|                                                  ^ punctuation.definition.link.end
-[link ``containing square]` brackets[[][] in backticks``](#wow)
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.inline.description
-|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw.inline
-|     ^^ punctuation.definition.raw.begin
-|                                                     ^^ punctuation.definition.raw.end
-|                                                       ^ punctuation.definition.link.end
-`inline markup <span></span>`
-|              ^^^^^^^^^^^^^ markup.raw.inline - meta.tag.inline.any.html
-escaped backtick \`this is not code\`
-|                ^^ constant.character.escape
-|                                  ^^ constant.character.escape
-|                  ^^^^^^^^^^^^^^^^ - markup.raw.inline
-
-This is a [reference] ()
-|         ^^^^^^^^^^^ meta.link.reference
-|                    ^^^^ - meta.link
-
-This is a [reference] (followed by parens)
-|         ^^^^^^^^^^^ meta.link.reference
-|                    ^^^^^^^^^^^^^^^^^^^^^ - meta.link
-
-This is a [reference] []
-|         ^^^^^^^^^^^ meta.link.reference
-|                    ^ - meta.link
-|                     ^^ meta.link.reference
-
-This is a ![reference] ()
-|         ^^^^^^^^^^^^^^^ - meta.image
-|          ^^^^^^^^^^^ meta.link.reference
-|                     ^^^^ - meta.link
-
-This is a ![reference] (followed by parens)
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.image
-|          ^^^^^^^^^^^ meta.link.reference
-|                     ^^^^^^^^^^^^^^^^^^^^^ - meta.link
-
-This is a ![reference] []
-|         ^^^^^^^^^^^^^^^ - meta.image
-|          ^^^^^^^^^^^ meta.link.reference
-|                     ^ - meta.link
-|                      ^^ meta.link.reference
-
-http://spec.commonmark.org/0.28/#example-322
-*foo`*`
-|^^^^^^^ markup.italic
-|   ^^^ markup.raw.inline
-
-| <- invalid.illegal.non-terminated.bold-italic
-
-http://spec.commonmark.org/0.28/#example-323
-[not a `link](/foo`)
-|^^^^^^^^^^^^^^^^^^^ - meta.link
-|      ^^^^^^^^^^^^ markup.raw.inline
-
-http://spec.commonmark.org/0.28/#example-324
-`<a href="`">`
-|^^^^^^^^^^ markup.raw.inline
-|          ^^ - markup.raw
-
-| <- invalid.illegal.non-terminated.raw
-
-http://spec.commonmark.org/0.28/#example-325
-<a href="`">`
-| ^^^^^^^^^ meta.tag.inline.a
-|           ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
-
-http://spec.commonmark.org/0.28/#example-326
-`<http://foo.bar.`baz>`
-|^^^^^^^^^^^^^^^^^ markup.raw.inline
-|                     ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
-
-http://spec.commonmark.org/0.28/#example-327
-<http://foo.bar.`baz>`
-|^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                    ^ punctuation.definition.raw.begin
-
-| <- invalid.illegal.non-terminated.raw
-
-http://spec.commonmark.org/0.27/#example-328
-*foo bar*
-| <- punctuation.definition.italic.begin
-|       ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-329
-This is not emphasis, because the opening `*` is followed by whitespace, and hence not part of a left-flanking delimiter run:
-a * foo bar*
-| ^^^^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-332
-Intraword emphasis with `*` is permitted:
-foo*bar*
-|  ^ punctuation.definition.italic.begin
-|      ^ punctuation.definition.italic.end
-http://spec.commonmark.org/0.27/#example-333
-5*6*78
-|^ punctuation.definition.italic.begin
-|  ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-334
-_foo bar_
-| <- punctuation.definition.italic.begin
-|       ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-335
-This is not emphasis, because the opening `_` is followed by whitespace:
-_ foo bar_
-| <- - punctuation
-| ^^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-336
-This is not emphasis, because the opening `_` is preceded by an alphanumeric and followed by punctuation:
-a_"foo"_
-|^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-337
-Emphasis with `_` is not allowed inside words:
-foo_bar_
-|  ^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-338
-5_6_78
-|^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-339
-пристаням_стремятся_
-|        ^^^^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-341
-foo-_(bar)_
-|   ^ punctuation.definition.italic.begin
-|         ^ punctuation.definition.italic.end
-
-*foo bar *
-| <- punctuation.definition.italic.begin
-|        ^ - punctuation
-*
-| <- - punctuation
-abc*
-|  ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-347
-*foo*bar
-| <- punctuation.definition.italic.begin
-|   ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-348
-_foo bar _
-| <- punctuation.definition.italic.begin
-|        ^ - punctuation
-_
-| <- - punctuation
-abc_
-|  ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-351
-Intraword emphasis is disallowed for `_`:
-_foo_bar
-| <- punctuation.definition.italic.begin
-|   ^ - punctuation
-abc_
-|  ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-353
-_foo_bar_baz_
-| <- punctuation.definition.italic.begin
-|   ^^^^^ - punctuation
-|           ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-354
-_(bar)_.
-| <-  punctuation.definition.italic.begin
-|     ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-355
- **foo bar**
-|^^ punctuation.definition.bold.begin
-|         ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-356
-** foo bar**
-| <- - punctuation
-|         ^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-358
-foo**bar**
-|  ^^ punctuation.definition.bold.begin
-|       ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-359
- __foo bar__
-|^^ punctuation.definition.bold.begin
-|         ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-360
-This is not strong emphasis, because the opening delimiter is followed by whitespace:
-__ foo bar__
-| <- - punctuation
-|         ^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-361
-__
-| <- - punctuation
-
-http://spec.commonmark.org/0.27/#example-362
-a__"foo"__
-|^^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-363
-Intraword strong emphasis is forbidden with `__`:
-foo__bar__
-|  ^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-364
-5__6__78
-|^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-367
-foo-__(bar)__
-|   ^^ punctuation.definition.bold.begin
-|          ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-368
-**foo bar **
-| <- punctuation.definition.bold.begin
-|         ^^ - punctuation
-abc**
-|  ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-373
-Intraword emphasis:
- **foo**bar
-|^^ punctuation.definition.bold.begin
-|     ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-374
- __foo bar __
-|^^ punctuation.definition.bold.begin
-|          ^^ - punctuation
-abc__
-|  ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-376
-_(__foo__)_
-| <- punctuation.definition.italic.begin
-| ^^ punctuation.definition.bold.begin
-|      ^^ punctuation.definition.bold.end
-|         ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-377
-Intraword strong emphasis is forbidden with `__`:
-__foo__bar
-| <- punctuation.definition.bold.begin
-|    ^^ - punctuation
-abc__
-|  ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-379
-__foo__bar__baz__
-| <- punctuation.definition.bold.begin
-|              ^^ punctuation.definition.bold.end
-|    ^^^^^^^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-380
-This is strong emphasis, even though the closing delimiter is both left- and right-flanking, because it is followed by punctuation:
-__(bar)__.
-| <- punctuation.definition.bold.begin
-|      ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-381
-*foo [bar](/url)*
-| <- punctuation.definition.italic.begin
-|               ^ punctuation.definition.italic.end
-|    ^^^^^^^^^^^ meta.link.inline
-
-http://spec.commonmark.org/0.27/#example-382
-*foo
-| <- punctuation.definition.italic.begin
-bar*
-|  ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-383
-_foo __bar__ baz_
-| <- punctuation.definition.italic.begin
-|    ^^ punctuation.definition.bold.begin
-|         ^^ punctuation.definition.bold.end
-|               ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-394
-** is not an empty emphasis
-| <- - punctuation
-|^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-395
-**** is not an empty strong emphasis
-| <- - punctuation
-|^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-396
-**foo [bar](/url)**
-| <- punctuation.definition.bold.begin
-|     ^^^^^^^^^^^ meta.link.inline
-|                ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-397
-**foo
-| <- punctuation.definition.bold.begin
-bar**
-|  ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-398
-__foo _bar_ baz__
-| <- punctuation.definition.bold.begin
-|     ^ punctuation.definition.italic.begin
-|         ^ punctuation.definition.italic.end
-|              ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-408
-__ is not an empty emphasis
-| <- - punctuation
-|^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-409
-____ is not an empty strong emphasis
-| <- - punctuation
-|^^^ - punctuation
-
-
-http://spec.commonmark.org/0.27/#example-410
-foo ***
-|   ^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-411
-foo *\**
-|   ^ punctuation.definition.italic.begin
-|    ^^ constant.character.escape
-|      ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-412
-foo *_*
-|   ^ punctuation.definition.italic.begin
-|    ^ - punctuation
-|     ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-414
-foo **\***
-|   ^^ punctuation.definition.bold.begin
-|     ^^ constant.character.escape
-|       ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-415
-foo **_**
-|   ^^ punctuation.definition.bold.begin
-|     ^ - punctuation
-|      ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-422
-foo ___
-|   ^^^^ - punctuation
-
-http://spec.commonmark.org/0.27/#example-423
-foo _\__
-|   ^ punctuation.definition.italic.begin
-|    ^^ constant.character.escape
-|      ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-424
-foo _*_
-|   ^ punctuation.definition.italic.begin
-|    ^ - punctuation
-|     ^ punctuation.definition.italic.end
-
-http://spec.commonmark.org/0.27/#example-426
-foo __\___
-|   ^^ punctuation.definition.bold.begin
-|     ^^ constant.character.escape
-|       ^^ punctuation.definition.bold.end
-
-http://spec.commonmark.org/0.27/#example-427
-foo __*__
-|   ^^ punctuation.definition.bold.begin
-|     ^ - punctuation
-|      ^^ punctuation.definition.bold.end
-
-This text is _bold_, but this__text__is neither bold_nor_italic
-|            ^ punctuation.definition.italic
-|             ^^^^ markup.italic
-|                 ^ punctuation.definition.italic
-|                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - markup.bold - markup.italic
-
-the following is italic *and doesn't end here * but does end here*
-|                       ^ punctuation.definition.italic.begin
-|                                             ^ - punctuation.definition.italic
-|                                                                ^ punctuation.definition.italic.end
-the following is bold **and doesn't end here ** but does end here**
-|                     ^^ punctuation.definition.bold.begin
-|                                            ^^ - punctuation.definition.bold
-|                                                                ^^ punctuation.definition.bold.end
-the following is not bold ** test ****
-|                         ^^ - punctuation.definition.bold.begin
-|                                 ^^^^ - punctuation.definition.bold
-the following is not italic _ test ____
-|                           ^ - punctuation.definition.italic.begin
-|                                  ^^^^ - punctuation.definition.italic
-
-more **tests *** ** here**
-|    ^^ punctuation.definition.bold.begin
-|            ^^^^^^ - punctuation.definition
-|                       ^^ punctuation.definition.bold.end
-more __tests *** ** example __ here__
-|    ^^ punctuation.definition.bold.begin
-|            ^^^^^^^^^^^^^^^^^^^^^^ - punctuation.definition
-|                                  ^^ punctuation.definition.bold.end
-more _tests <span class="test_">here</span>_
-|    ^ punctuation.definition.italic.begin
-|                            ^ - punctuation.definition
-|                                          ^ punctuation.definition.italic.end
-more _tests <span class="test_">_here</span>_
-|    ^ punctuation.definition.italic.begin
-|                            ^ - punctuation.definition
-|                               ^ - punctuation
-|                                           ^ punctuation.definition.italic.end
-_more `tests_` here_
-| <- punctuation.definition.italic.begin
-|     ^^^^^^^^ markup.raw.inline
-|                  ^ punctuation.definition.italic.end
-__more `tests__` here__
-| <- punctuation.definition.bold.begin
-|      ^^^^^^^^^ markup.raw.inline
-|                    ^^ punctuation.definition.bold.end
-**more `tests__` here**
-| <- punctuation.definition.bold.begin
-|      ^^^^^^^^^ markup.raw.inline
-|                    ^^ punctuation.definition.bold.end
-**more `tests**` here**
-| <- punctuation.definition.bold.begin
-|      ^^^^^^^^^ markup.raw.inline
-|                    ^^ punctuation.definition.bold.end
-*more `tests__` here**
-| <- punctuation.definition.italic.begin
-|                   ^^ - punctuation
-abc*
-|  ^ punctuation.definition.italic.end
-
-_test <span>text_ foobar</span>
-| <- punctuation
-|               ^ punctuation.definition.italic.end
-__test <span>text__ not formatted</span>
-| <- punctuation
-|                ^^ punctuation.definition.bold.end
-*test <span>text* not formatted</span>
-| <- punctuation
-|               ^ punctuation.definition.italic.end
-**test <span>text** not formatted</span>
-| <- punctuation
-|                ^^ punctuation.definition.bold.end
-_test <span>text **formatted**</span>_
-| <- punctuation
-|                ^^ punctuation
-|                           ^^ punctuation
-|                                    ^ punctuation
-*test <span>text __formatted__</span>*
-| <- punctuation
-|                ^^ punctuation
-|                           ^^ punctuation
-|                                    ^ punctuation
-*test <span>text __formatted__</span>* **more** _text_
-| <- punctuation
-|                ^^ punctuation
-|                           ^^ punctuation
-|                                    ^ punctuation
-|                                      ^^ punctuation
-|                                            ^^ punctuation
-|                                               ^ punctuation
-|                                                    ^ punctuation
-*test <span>text* __formatted</span>__
-| <- punctuation
-|               ^ punctuation
-|                 ^^ punctuation
-|                                   ^^ punctuation
-
-__test <span>text__ *formatted</span>*
-| <- punctuation
-|                ^^ punctuation
-|                   ^ punctuation
-|                                    ^ punctuation
-
-This is ***bold italic***
-|       ^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^ punctuation.definition.bold.end
-
-This is ***bold italic* and just bold**
-|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^^^^^^^^^^^^^^^ - markup.italic
-|                                    ^^ punctuation.definition.bold.end
-
-The next scope overlap funny because we have to pick one order
-to scope three indicators in a row
-This is ***bold italic** and just italic*
-|       ^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.italic
-|         ^ punctuation.definition.italic.begin
-|                     ^^ punctuation.definition.bold.end
-|                       ^^^^^^^^^^^^^^^^^ - markup.bold
-|                                       ^ punctuation.definition.italic.end
-
-This is **_bold italic_**
-|       ^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^ punctuation.definition.bold.end
-
-This is __*bold italic*__
-|       ^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^ punctuation.definition.bold.end
-
-This is ___bold italic___
-|       ^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^ punctuation.definition.bold.end
-
-This is ___bold italic_ and just bold__
-|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^ punctuation.definition.italic.begin
-|         ^^^^^^^^^^^^^ markup.italic
-|                     ^ punctuation.definition.italic.end
-|                      ^^^^^^^^^^^^^^^^ - markup.italic
-|                                    ^^ punctuation.definition.bold.end
-
-The next scope overlap funny because we have to pick one order
-to scope three indicators in a row
-This is ___bold italic__ and just italic_
-|       ^^^^^^^^^^^^^^^ markup.bold
-|       ^^ punctuation.definition.bold.begin
-|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.italic
-|         ^ punctuation.definition.italic.begin
-|                     ^^ punctuation.definition.bold.end
-|                       ^^^^^^^^^^^^^^^^^ - markup.bold
-|                                       ^ punctuation.definition.italic.end
-
-This is _**italic bold**_
-|       ^^^^^^^^^^^^^^^^^ markup.italic
-|       ^ punctuation.definition.italic.begin
-|        ^^^^^^^^^^^^^^^ markup.bold
-|        ^^ punctuation.definition.bold.begin
-|                     ^^ punctuation.definition.bold.end
-|                       ^ punctuation.definition.italic.end
-
-This is *__italic bold__*
-|       ^^^^^^^^^^^^^^^^^ markup.italic
-|       ^ punctuation.definition.italic.begin
-|        ^^^^^^^^^^^^^^^ markup.bold
-|        ^^ punctuation.definition.bold.begin
-|                     ^^ punctuation.definition.bold.end
-|                       ^ punctuation.definition.italic.end
-
-**test!_test** Issue 1163
-|^^^^^^^^^^^^^ markup.bold
-|      ^ - punctuation.definition.italic
-|           ^^ punctuation.definition.bold.end
-
-__test!*test__ Issue 1163
-|^^^^^^^^^^^^^ markup.bold
-|      ^ - punctuation.definition.italic
-|           ^^ punctuation.definition.bold.end
-
-# Strikethrough Tests
-
-__~~bold striked~~__
-| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
-|^ markup.bold.markdown - markup.strikethrough
-| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
-|                 ^^ markup.bold.markdown - markup.strikethrough
-|^ punctuation.definition.bold.begin.markdown
-| ^^ punctuation.definition.strikethrough.begin.markdown
-|               ^^ punctuation.definition.strikethrough.end.markdown 
-|                 ^^ punctuation.definition.bold.end.markdown
-
-**~~bold striked~~**
-| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
-|^ markup.bold.markdown - markup.strikethrough
-| ^^^^^^^^^^^^^^^^ markup.bold.markdown markup.strikethrough.markdown-gfm
-|                 ^^ markup.bold.markdown - markup.strikethrough
-|^ punctuation.definition.bold.begin.markdown
-| ^^ punctuation.definition.strikethrough.begin.markdown
-|               ^^ punctuation.definition.strikethrough.end.markdown 
-|                 ^^ punctuation.definition.bold.end.markdown
-
-_~~italic striked~~_
-| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
-|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
-|                  ^ markup.italic.markdown - markup.strikethrough
-|^^ punctuation.definition.strikethrough.begin.markdown
-|                ^^ punctuation.definition.strikethrough.end.markdown 
-|                  ^ punctuation.definition.italic.end.markdown
-
-*~~italic striked~~*
-| <- markup.italic.markdown punctuation.definition.italic.begin.markdown
-|^^^^^^^^^^^^^^^^^^ markup.italic.markdown markup.strikethrough.markdown-gfm
-|                  ^ markup.italic.markdown - markup.strikethrough
-|^^ punctuation.definition.strikethrough.begin.markdown
-|                ^^ punctuation.definition.strikethrough.end.markdown 
-|                  ^ punctuation.definition.italic.end.markdown
-
-___~~bold italic striked~~___
-| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
-|^ markup.bold.markdown - markup.italic - markup.strikethrough
-| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
-|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
-|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
-|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
-|^ punctuation.definition.bold.begin.markdown
-| ^ punctuation.definition.italic.begin.markdown
-|  ^^ punctuation.definition.strikethrough.begin.markdown
-|                       ^^ punctuation.definition.strikethrough.end.markdown 
-|                         ^ punctuation.definition.italic.end.markdown
-|                          ^^ punctuation.definition.bold.end.markdown
-
-***~~bold italic striked~~***
-| <- markup.bold.markdown punctuation.definition.bold.begin.markdown
-|^ markup.bold.markdown - markup.italic - markup.strikethrough
-| ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
-|  ^^^^^^^^^^^^^^^^^^^^^^^ markup.bold.markdown markup.italic.markdown markup.strikethrough.markdown-gfm
-|                         ^ markup.bold.markdown markup.italic.markdown - markup.strikethrough
-|                          ^^ markup.bold.markdown - markup.italic - markup.strikethrough
-|^ punctuation.definition.bold.begin.markdown
-| ^ punctuation.definition.italic.begin.markdown
-|  ^^ punctuation.definition.strikethrough.begin.markdown
-|                       ^^ punctuation.definition.strikethrough.end.markdown 
-|                         ^ punctuation.definition.italic.end.markdown
-|                          ^^ punctuation.definition.bold.end.markdown
-
-~Hi~ Hello, world!
-| <- punctuation.definition.strikethrough.begin
-|^^^ meta.paragraph markup.strikethrough
-|  ^ punctuation.definition.strikethrough.end
-|   ^^^^^^^^^^^^^^^ meta.paragraph - markup
-
-This ~text~~~~ is ~~~~curious~.
-|    ^^^^^^^^^ meta.paragraph markup.strikethrough
-|                 ^^^^^^^^^^^^ meta.paragraph markup.strikethrough
-|                             ^^ meta.paragraph - markup
-|    ^ punctuation.definition.strikethrough.begin
-|         ^^^^ punctuation.definition.strikethrough.end
-|                 ^^^^ punctuation.definition.strikethrough.begin
-|                            ^ punctuation.definition.strikethrough.end
-
-This ~~has a
-|    ^^^^^^^^ meta.paragraph markup.strikethrough
-
-| <- meta.paragraph markup.strikethrough invalid.illegal.non-terminated.bold-italic
-new paragraph~~.
-|            ^^ meta.paragraph markup.strikethrough punctuation.definition.strikethrough.begin
-
-| <- invalid.illegal.non-terminated.bold-italic
-
-
-# Fenced Code Block Tests
-
-Paragraph is terminated by fenced code blocks.
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-
-Code blocks terminate **bold text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be bold**
-| <- - meta.bold
-|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
-
-Code blocks terminate __bold text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be bold__
-| <- - meta.bold
-|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
-
-Code blocks terminate *italic text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be italic*
-| <- - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
-
-Code blocks terminate _italic text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be italic_
-| <- - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
-
-Code blocks terminate ***bold italic text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be bold italic***
-| <- - meta.bold - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
-
-Code blocks terminate ___bold italic text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be bold italic___
-| <- - meta.bold - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
-
-Code blocks terminate **_bold italic text
-```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-this must not be bold italic_**
-| <- - meta.bold - meta.italic
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
-
-```js
-| <- punctuation.definition.raw.code-fence.begin
-|  ^^ constant.other.language-name
-for (var i = 0; i < 10; i++) {
-| ^ source.js keyword.control.loop
-    console.log(i);
-}
-```
-| <- punctuation.definition.raw.code-fence.end
-
-```ts
-|  ^^ constant.other.language-name
-declare type foo = 'bar'
-```
-
-```R%&?! weired language name
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
-|  ^^^^^ constant.other.language-name.markdown
-|        ^^^^^^^^^^^^^^^^^^^^^ - constant
-```
-
-```{key: value}
-|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
-|  ^^^^^^^^^^^^ - constant
-```
-
-``` {key: value}
-|^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
-|   ^^^^^^^^^^^^ - constant
-```
-
-```testing``123```
-| <- punctuation.definition.raw.begin
-|         ^^ - punctuation
-|              ^^^ punctuation.definition.raw.end
-```testing``123````
-| <- punctuation.definition.raw.begin
-|        ^ - punctuation
-|            ^^^^ - punctuation
-```
-| <- punctuation.definition.raw.end
-``testing`123````
-| <- punctuation.definition.raw.begin
-|        ^ - punctuation
-|            ^^^^ - punctuation
-more text``
-|        ^^ punctuation.definition.raw.end
-``text
-
-| <- invalid.illegal.non-terminated.raw
-text
-| <- - markup.raw
-
-http://spec.commonmark.org/0.28/#example-315
-`` foo ` bar  ``
-|^ punctuation.definition.raw.begin
-|^^^^^^^^^^^^^^^ markup.raw.inline
-|      ^ - punctuation
-|             ^^ punctuation.definition.raw.end
-
-http://spec.commonmark.org/0.28/#example-316
-` `` `
-|<- punctuation.definition.raw.begin
-|^^^^^ markup.raw.inline
-| ^^ - punctuation
-|    ^ punctuation.definition.raw.end
-
-http://spec.commonmark.org/0.28/#example-318
-`foo   bar
-  baz`
-|^^^^^ markup.raw.inline
-|    ^ punctuation.definition.raw.end
-
-~~~~ 
-| <- punctuation.definition.raw.code-fence.begin
- ~~~~
-| ^^^ punctuation.definition.raw.code-fence.end
-
-~~~~~test~
-| ^^^^^^^^^ meta.paragraph - constant - markup.raw
-
-~~~~~~test
-| ^^^^ punctuation.definition.raw.code-fence.begin
-|     ^^^^ constant.other.language-name
-~~~~~~
-| ^^^^ punctuation.definition.raw.code-fence.end
-
-```test
-|  ^^^^ constant.other.language-name
-  ```
-| ^^^ punctuation.definition.raw.code-fence.end
-
-hello world ````test````
-|           ^^^^^^^^^^^^ markup.raw.inline
-|                       ^ - markup.raw
-
-`foo `` bar`
-|    ^^^^^^ markup.raw.inline - punctuation
-|          ^ punctuation.definition.raw.end
+# TEST: HARD LINE BREAKS ######################################################
 
 hard line break  
 |              ^^ meta.hard-line-break punctuation.definition.hard-line-break
@@ -2461,914 +7691,8 @@ soft line break
 |                                ^^^ - meta.hard-line-break
 not a hard line break`
 
-*test
 
-| <- invalid.illegal.non-terminated.bold-italic
-abc*
-|  ^ - punctuation
-
-_test
-
-| <- invalid.illegal.non-terminated.bold-italic
-abc_
-|  ^ - punctuation
-
-**test
-
-| <- invalid.illegal.non-terminated.bold-italic
-abc**
-|  ^^ - punctuation
-
-__test
-
-| <- invalid.illegal.non-terminated.bold-italic
-abc__
-|  ^^ - punctuation
-
-__test\
-|     ^ meta.hard-line-break constant.character.escape
-testing__
-
-- test *testing
-blah*
-|   ^ markup.list.unnumbered meta.paragraph.list markup.italic punctuation.definition.italic.end - meta.paragraph.list meta.paragraph.list
-- fgh
-- *ghgh
-| ^ markup.list.unnumbered meta.paragraph.list markup.italic punctuation.definition.italic.begin - meta.paragraph.list meta.paragraph.list
-- fgfg
-| <- markup.list.unnumbered.bullet punctuation.definition.list_item
-- _test
-
-| <- markup.list.unnumbered meta.paragraph.list markup.italic invalid.illegal.non-terminated.bold-italic
-  still a list item
-| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list
-- * * * * * * *
-| <- punctuation.definition.list_item
-| ^^^^^^^^ markup.list.unnumbered meta.paragraph.list meta.separator.thematic-break - meta.paragraph.list meta.paragraph.list
-| ^ punctuation.definition.thematic-break
-|   ^ punctuation.definition.thematic-break
-|     ^ punctuation.definition.thematic-break
-|       ^ punctuation.definition.thematic-break
-|         ^ punctuation.definition.thematic-break
-|           ^ punctuation.definition.thematic-break
-|             ^ punctuation.definition.thematic-break
-|  ^ - punctuation.definition.thematic-break
-|    ^ - punctuation.definition.thematic-break
-|      ^ - punctuation.definition.thematic-break
-|        ^ - punctuation.definition.thematic-break
-|          ^ - punctuation.definition.thematic-break
-|            ^ - punctuation.definition.thematic-break
-  still a list item
-| ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - meta.paragraph.list meta.paragraph.list
-
-http://spec.commonmark.org/0.27/#example-407
-**foo [*bar*](/url)**
-| <- punctuation.definition.bold.begin
-|     ^^^^^^^^^^^^^ markup.bold meta.link.inline
-|                  ^^ punctuation.definition.bold.end
-|      ^ punctuation.definition.italic.begin
-|          ^ punctuation.definition.italic.end
-**foo [_bar_](/url)**
-| <- punctuation.definition.bold.begin
-|     ^^^^^^^^^^^^^ markup.bold meta.link.inline
-|                  ^^ punctuation.definition.bold.end
-|      ^ punctuation.definition.italic.begin
-|          ^ punctuation.definition.italic.end
-_foo [**bar**](/url)_
-| <- punctuation.definition.italic.begin
-|    ^^^^^^^^^^^^^^^ markup.italic meta.link.inline
-|                   ^ punctuation.definition.italic.end
-|     ^^ punctuation.definition.bold.begin
-|          ^^ punctuation.definition.bold.end
-
-
-1. Open `Command Palette` using menu item `Tools → Command Palette...`
-|^ markup.list.numbered punctuation.definition.list_item
-|                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list markup.raw.inline
-2. Choose `Package Control: Install Package`
-
-[**Read more &#8594;**][details]
-|^^ punctuation.definition.bold.begin
-|            ^^^^^^^ constant.character.entity.decimal.html
-|                   ^^ punctuation.definition.bold.end
-|                       ^^^^^^^ markup.underline.link
-
-[Read more &#8594;][details]
-|          ^^^^^^^ constant.character.entity.decimal.html
-|                   ^^^^^^^ markup.underline.link
-
-[Read more <span style="font-weight: bold;">&#8594;</span>][details]
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.description
-|                       ^^^^^^^^^^^^^^^^^^ source.css
-|                                           ^^^^^^^ constant.character.entity.decimal.html
-|                                                           ^^^^^^^ markup.underline.link
-
-[![Cool ★ Image - Click to Enlarge][img-example]][img-example]
-|^ punctuation.definition.image.begin
-|                                   ^^^^^^^^^^^ markup.underline.link
-|                                               ^ punctuation.definition.link.end
-|                                                 ^^^^^^^^^^^ markup.underline.link
-
-[![Cool ★ Image - Click to Enlarge](http://www.sublimetext.com/anim/rename2_packed.png)](http://www.sublimetext.com/anim/rename2_packed.png)
-|^ punctuation.definition.image.begin
-|                                  ^ punctuation.definition.metadata.begin
-|                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.image.markdown
-|                                                                                     ^ punctuation.definition.metadata.end
-|                                                                                       ^ punctuation.definition.metadata.begin
-|                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                                                                                                                                          ^ punctuation.definition.metadata.end
-
-[img-example]: http://www.sublimetext.com/anim/rename2_packed.png
-|^^^^^^^^^^^ meta.link.reference.def.markdown entity.name.reference.link
-|            ^ punctuation.separator.key-value
-|              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link
-|                                                                ^ - meta.link - markup
-
-[//]: # (This is a comment without a line-break.)
-|     ^ meta.link.reference.def.markdown markup.underline.link
-|       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.other
-|                                                ^ - meta.link
-
-[//]: # (This is a comment with a
-|     ^ meta.link.reference.def.markdown markup.underline.link
-|       ^ punctuation.definition.string.begin
-        line-break.)
-|                  ^ punctuation.definition.string.end
-|                   ^ - meta.link
-
-[//]: # (testing)blah
-|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|       ^ punctuation.definition.string.begin
-|               ^ punctuation.definition.string.end
-|                ^^^^ invalid.illegal.expected-eol
-|                    ^ - meta.link - invalid
-
-[//]: # (testing
-blah
-| <- meta.link.reference.def.markdown string.quoted.other
-
-| <- invalid.illegal.non-terminated.link-title
-text
-| <- meta.paragraph - meta.link.reference.def.markdown
-
-[foo]: <bar> "test" 
-|^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|                   ^ - meta.link
-|      ^ punctuation.definition.link.begin
-|       ^^^ markup.underline.link
-|          ^ punctuation.definition.link.end
-|            ^^^^^^ string.quoted.double
-|                  ^ - invalid.illegal.expected-eol
-
-[foo]: <bar>> "test" 
-|^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|                    ^ - meta.link
-|      ^ punctuation.definition.link.begin
-|       ^^^ markup.underline.link
-|          ^ punctuation.definition.link.end
-|           ^^^^^^^^ invalid.illegal.expected-eol
-|                   ^ - invalid.illegal.expected-eol
-
-https://michelf.ca/projects/php-markdown/extra/#footnotes
-That's some text with a footnote.[^1]
-|                                ^^^^ meta.paragraph meta.link.reference.footnote.markdown-extra
-|                                ^ punctuation.definition.link.begin
-|                                 ^^ meta.link.reference.literal.footnote-id
-|                                   ^ punctuation.definition.link.end
-
- [^1]: And that's the footnote.
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra
-|^ punctuation.definition.reference.begin.markdown
-| ^^ entity.name.reference.link.markdown
-|   ^ punctuation.definition.reference.end.markdown
-|    ^ punctuation.separator.key-value.markdown
-
-[^1]:
-    And that's the footnote.
-
-    That's the *second* paragraph.
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.footnote.markdown-extra - markup.raw
-|              ^^^^^^^^ markup.italic
-
-- a
-  - b
-    - c
-      - d
-|     ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-        text here
-|       ^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - markup.raw.block - meta.paragraph.list meta.paragraph.list
-
-            code here
-            | ^^^^^^^^ markup.raw.block
-
-      - e
-|     ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-
-            code here
-
-            >     block quote code here
-|           ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
-|                 ^^^^^^^^^^^^^^^^^^^^^^ markup.list.unnumbered markup.quote markup.raw.block
-
-            > > test
-|           ^ markup.list.unnumbered markup.quote punctuation.definition.blockquote
-|             ^ markup.list.unnumbered markup.quote markup.quote punctuation.definition.blockquote - markup.raw.block
-
-      - f
-|     ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-        1. test
-|       ^^ markup.list.numbered.bullet
-|        ^ punctuation.definition.list_item
-
-abc
-| <- meta.paragraph - markup.list
-
-| foo | bar |
-|^^^^^^^^^^^^^ meta.table.header
-| <- punctuation.separator.table-cell
-|     ^ punctuation.separator.table-cell
-|           ^ punctuation.separator.table-cell
-| ^^^^ - punctuation.separator.table-cell
-
-| foo | bar |
-| --- | --- |
-| baz | bim <kbd>Ctrl+C</kbd> |
-| <- meta.table punctuation.separator.table-cell
-|           ^^^^^ meta.tag.inline.any
-|                             ^ punctuation.separator.table-cell
-
-| <- - meta.table
-
-| abc | defghi |
-:-: | -----------:
-|^^^^^^^^^^^^^^^^^ meta.table.header-separator
-| <- punctuation.definition.table-cell-alignment
-|^ punctuation.section.table-header
-|   ^ punctuation.separator.table-cell
-|     ^^^^^^^^^^^ punctuation.section.table-header
-|                ^ punctuation.definition.table-cell-alignment - punctuation.section.table-header
-bar | baz
-|   ^ meta.table punctuation.separator.table-cell
-
-| f\|oo  |
-| <- meta.table punctuation.separator.table-cell
-|  ^^ meta.table constant.character.escape - punctuation.separator.table-cell
-|        ^ meta.table punctuation.separator.table-cell
-
-| f\|oo  |
-| ------ |
-| b `|` az |
-|   ^^^ meta.table markup.raw.inline - meta.table.header-separator
-|          ^ meta.table punctuation.separator.table-cell
-| b **|** im |
-| <- meta.table punctuation.separator.table-cell
-|   ^^^^^ meta.table markup.bold - punctuation.separator.table-cell
-|            ^ meta.table punctuation.separator.table-cell
-
-| abc | def |
-| --- | --- |
-| bar | baz |
-|^^^^^^^^^^^^^ meta.table
-test
-|^^^^ meta.table
-> bar
-| <- markup.quote punctuation.definition.blockquote - meta.table
-
-`|` this `|` example `|` is not a table `|`
-| ^ punctuation.definition.raw.end - meta.table
-| nor is this | because it is not at block level, it immediately follows a paragraph |
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - meta.table
-
-| First Header  | Second Header | Third Header         |
-| :------------ | :-----------: | -------------------: |
-| First row     | Data          | Very long data entry |
-| Second row    | **Cell**      | *Cell*               |
-| Third row     | Cell that spans across two columns  ||
-| ^^^^^^^^^^^^^^ meta.table
-|                                                     ^^ punctuation.separator.table-cell
-
- | table that doesn't start at column 0 |
-  | ---- |
-  | blah |
-| ^^^^^^^^ meta.table
-| ^ punctuation.separator.table-cell
-
-not a table | 
-| ^^^^^^^^^^^^^ - meta.table
-
- abc | def
- --- | ---
- --- | ---
-| ^^^^ meta.table - meta.table.header
-
- a | b
- - | -
-|^^^^^^ meta.table.header-separator.markdown-gfm
-|^ punctuation.section.table-header.markdown
-|  ^ punctuation.separator.table-cell.markdown
-|    ^ punctuation.section.table-header.markdown
- - | -
-|^^^^^^ meta.table.markdown-gfm
-
- a | b
- -:| -
-|^^^^^^ meta.table.header-separator.markdown-gfm
-|^ punctuation.section.table-header.markdown
-| ^ punctuation.definition.table-cell-alignment.markdown
-|  ^ punctuation.separator.table-cell.markdown
-|    ^ punctuation.section.table-header.markdown
- - | -
-|^^^^^^ meta.table.markdown-gfm
-
-| test | me |
-|------|----|
-|^^^^^^ punctuation.section.table-header
-|*test | me |
-|^^^^^^ - markup.bold
-|      ^ punctuation.separator.table-cell
-|           ^ punctuation.separator.table-cell
-|`test | me |
-|^ invalid.deprecated.unescaped-backticks
-|      ^ punctuation.separator.table-cell
-
-| table | followed by
-paragraph
-| <- meta.paragraph.markdown
-|^^^^^^^^^ meta.paragraph.markdown
-
-| table | followed by
-https://foo.bar/baz
-| <- meta.paragraph.markdown meta.link.inet.markdown markup.underline.link.markdown-gfm
-|^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown meta.link.inet.markdown markup.underline.link.markdown-gfm
-
-| table | followed by
-# heading
-| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
-|^^^^^^^^^ markup.heading.1.markdown
-
-| table | followed by
-> quote
-| <- markup.quote.markdown punctuation.definition.blockquote.markdown
-|^^^^^^^ markup.quote.markdown
-
-| table | followed by
-    quote
-| <- markup.raw.block.markdown
-|^^^^^^^^^ markup.raw.block.markdown
-
-| table | followed by
-```fenced
-| <- meta.code-fence.definition.begin.text.markdown-gfm
-|^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
-code block
-```
-| <- meta.code-fence.definition.end.text.markdown-gfm
-|^^ meta.code-fence.definition.end.text.markdown-gfm
-
-A line without bolded |
-|                     ^ - punctuation.separator.table-cell
-
-A line with bolded **|**
-|                    ^ - punctuation.separator.table-cell
-
-1. test
-|  ^^^^^ markup.list.numbered meta.paragraph.list
-   - test
-|^^^^^^^^^ markup.list.unnumbered
-|  ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-|    ^^^^^ meta.paragraph.list
-   - test
-|^^^^^^^^^ markup.list.unnumbered
-|  ^ markup.list.unnumbered.bullet punctuation.definition.list_item
-|    ^^^^^ meta.paragraph.list
-   test
-|^^^^^^^ markup.list.numbered meta.paragraph.list
- ****test****
-|^^^^^^^^^^^^^ markup.list.numbered meta.paragraph.list - punctuation
-
- - - test
-|^ punctuation.definition.list_item
-|  ^^^^^^^ markup.list.unnumbered meta.paragraph.list - punctuation
-- - - - test
-| <- punctuation.definition.list_item
-| ^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - punctuation
-
-paragraph
-
-  * List Item 1
-    Text under Item 1
-  * List Item 2
-    Text under Item 2
-
-  * List Item 3
-    Text under Item 3
-|   ^^^^^^^^^^^^^^^^^^ markup.list.unnumbered meta.paragraph.list - markup.raw
-
- 1. fenced code block inside a list item
-| ^ punctuation.definition.list_item
-    ```language
-|^^^^^^^^^^^^^^^ meta.paragraph.list
-|   ^^^ punctuation.definition.raw.code-fence.begin
-|      ^^^^^^^^ constant.other.language-name
-|   ^^^^^^^^^^^ meta.code-fence
-    
-|^^^^ meta.paragraph.list markup.raw.code-fence
-    ```
-|   ^^^ punctuation.definition.raw.code-fence.end
-    test
-|   ^^^^^ meta.paragraph.list - markup.raw.code-fence
-
- 2. test
-| ^ punctuation.definition.list_item
-
-Normal paragraph
-| <- meta.paragraph - markup
-
-1. List
-    1. Nested list
-    2. Second item
-
-    This line is still list item 1
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered - markup.raw.block
-
-Test
-| <- meta.paragraph - markup.list
-
-http://spec.commonmark.org/0.28/#example-116
-
-<table><tr><td>
-<pre>
-**Hello**,
-| ^^^^^^^^^ meta.disable-markdown
-
-_world_.
-| ^^^^ markup.italic - meta.disable-markdown
-</pre>
-</td></tr></table>
-
-http://spec.commonmark.org/0.28/#example-120
-
-<DIV CLASS="foo">
-| ^^^^^^^^^^^^^^^^ meta.disable-markdown
-
-*Markdown*
-| ^^^^^^^ meta.paragraph markup.italic - meta.disable-markdown
-
-</DIV>
-| ^^^ meta.disable-markdown meta.tag.block.any.html
-
-http://spec.commonmark.org/0.28/#example-127
-
-<div><a href="bar">*foo*</a></div>
-|                  ^^^^^ meta.disable-markdown - markup.italic
-
-http://spec.commonmark.org/0.28/#example-129
-
-<div></div>
-``` c
-int x = 33;
-```
-| ^^ meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-130
-
-<a href="foo">
-*bar*
-|^^^^^ meta.disable-markdown
-</a>
-
-http://spec.commonmark.org/0.28/#example-131
-
-<Warning>
-*bar*
-|^^^^^ meta.disable-markdown
-</Warning>
-| ^^^^^^^ meta.disable-markdown meta.tag.other.html entity.name.tag.other.html
-
-http://spec.commonmark.org/0.28/#example-135
-
-<del>
-| ^^ meta.disable-markdown meta.tag.inline.any.html entity.name.tag.inline.any.html
-
-*foo*
-| ^^ meta.paragraph markup.italic
-
-</del>
-| ^^^ meta.disable-markdown meta.tag.inline.any.html entity.name.tag.inline.any.html
-
-<del>
-*foo*
-|^^^^^ meta.disable-markdown
-</del>
-
-http://spec.commonmark.org/0.28/#example-136
-
-<del>*foo*</del>
-| ^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
-|    ^^^^^ markup.italic
-|           ^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
-|^^^^^^^^^^^^^^^ meta.paragraph - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-137
-
-<pre language="haskell"><code>
-| ^^ meta.disable-markdown meta.tag.block.any.html entity.name.tag.block.any.html
-import Text.HTML.TagSoup
-
-main :: IO ()
-| ^^^^^^^^^^^^ meta.disable-markdown
-main = print $ parseTags tags
-</code></pre>
-| ^^^^^^^^^^^ meta.disable-markdown
-|        ^^^ meta.tag.block.any.html entity.name.tag.block.any.html
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-138
-
-<script type="text/javascript">
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.script.begin.html
-// JavaScript example
-| ^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown source.js.embedded.html comment.line.double-slash.js
-
-document.getElementById("demo").innerHTML = "Hello JavaScript!";
-| ^^^^^^ meta.disable-markdown source.js.embedded.html support.type.object.dom.js
-</script>
-| ^^^^^^ meta.disable-markdown meta.tag.script.end.html entity.name.tag.script.html
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-139
-
-<style
-  type="text/css">
-| ^^^^^^^^^^^^^^^ meta.disable-markdown meta.tag.style.begin.html meta.attribute-with-value.html
-h1 {color:red;}
-|   ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
-
-p {color:blue;}
-|  ^^^^^ meta.disable-markdown source.css.embedded.html meta.property-list.css meta.property-name.css support.type.property-name.css
-</style>
-| ^^^^^ meta.disable-markdown meta.tag.style.end.html entity.name.tag.style.html
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-143
-
-<style>p{color:red;}</style>
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-*foo*
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-144
-
-<!-- foo -->*bar*
-| ^^^^^^^^^^ comment.block.html
-|           ^^^^^ meta.disable-markdown
-*baz*
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-145
-
-<script>
-foo
-</script>1. *bar*
-| ^^^^^^^^^^^^^^^^ meta.disable-markdown
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-146
-
-<!-- Foo
-| ^^ meta.disable-markdown comment.block.html punctuation.definition.comment
-
-bar
-   baz -->
-| ^^^^^^^^ meta.disable-markdown comment.block.html
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-147
-
-<?php
-| ^^^^ meta.disable-markdown
-
-  echo '>';
-
-?>
-|^^ meta.disable-markdown
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-148
-
-<!DOCTYPE html>
-| ^^^^^^^ meta.disable-markdown meta.tag.sgml.doctype.html
-okay
-| <- - meta.disable-markdown
-
-<!ENTITY html>
-| ^^^^^^^^^^^^^ meta.disable-markdown
-okay
-| <- - meta.disable-markdown
-
-http://spec.commonmark.org/0.28/#example-149
-
-<![CDATA[
-| ^^^^^^^^ meta.disable-markdown meta.tag.sgml
-function matchwo(a,b)
-{
-  if (a < b && a < 0) then {
-    return 1;
-
-  } else {
-
-    return 0;
-  }
-}
-]]>
-|^ meta.disable-markdown meta.tag.sgml
-okay
-| <- - meta.disable-markdown
-
-1. Test
-
-   ```python
-|  ^^^ markup.list.numbered meta.code-fence punctuation.definition.raw.code-fence.begin
-       Test
-
-| <- - invalid
-       Test
-   ```
-|  ^^^ punctuation.definition.raw.code-fence.end
-
-1. Test 2
-|^ markup.list.numbered.bullet punctuation.definition.list_item
-
-```clojure
-|^^^^^^^^^ meta.code-fence.definition.begin.clojure
-|  ^^^^^^^ constant.other.language-name
- (/ 10 3.0)
-|<- source.clojure
-|^^^^^^^^^^ source.clojure
-```
-|^^ meta.code-fence.definition.end.clojure punctuation.definition.raw.code-fence.end
-
-```cmd
-
-| <- markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
-```
-
-```css
-
-| <- markup.raw.code-fence.css.markdown-gfm source.css
-```
-
-```diff
-+ inserted
-| <- source.diff markup.inserted.diff punctuation.definition.inserted.diff
-- deleted
-| <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
-```
-
-```haskell
-
-| <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
-```
-
-```html
-  <html>
-| <- markup.raw.code-fence.html.markdown-gfm text.html
-| ^^^^^^ text.html meta.tag
-```
-
-```jsx
-
-| <- markup.raw.code-fence.jsx.markdown-gfm
-```
-
-```lisp
-
-| <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
-```
-
-```lua
-
-| <- markup.raw.code-fence.lua.markdown-gfm source.lua
-```
-
-```matlab
-
-| <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
-```
-
-```ocaml
-
-| <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
-```
-
-```scala
-
-| <- markup.raw.code-fence.scala.markdown-gfm source.scala
-```
-
-```sh
-
-| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
-```
-
-```shell
-
-| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
-```
-
-```shell-script
-
-| <- markup.raw.code-fence.shell-script.markdown-gfm source.shell.bash
-```
-
-```tsx
-
-| <- markup.raw.code-fence.tsx.markdown-gfm
-```
-
-```xml
-|^^^^^ meta.code-fence.definition.begin.xml
-|  ^^^ constant.other.language-name
-<?xml version="1.0" ?>
-|^^^^^^^^^^^^^^^^^^^^^^ markup.raw.code-fence.xml
-|     ^^^^^^^ meta.tag.preprocessor.xml entity.other.attribute-name.localname.xml
-<example>
-    <foobar />
-</example>
-```
-|^^ punctuation.definition.raw.code-fence.end
-
-```sql
-|^^^^^ meta.code-fence.definition.begin.sql
-|  ^^^ constant.other.language-name
-SELECT TOP 10 *
-|^^^^^^^^^^^^^^^ markup.raw.code-fence.sql source.sql
-FROM TableName
-```
-|^^ meta.code-fence.definition.end.sql punctuation.definition.raw.code-fence.end - markup
-
-```python
-|^^ punctuation.definition.raw.code-fence.begin
-|^^^^^^^^^ meta.code-fence.definition.begin.python - markup
-|  ^^^^^^ constant.other.language-name
-def function():
-    pass
-|   ^^^^ keyword.control.flow
-unclosed_paren = (
-|                ^ meta.group.python punctuation.section.group.begin.python
-```
-|^^ meta.code-fence.definition.end.python punctuation.definition.raw.code-fence.end
-
-```Graphviz
-graph n {}
-| ^^^ storage.type.dot
-```
-
-| <- - markup.raw
-
-```php
-var_dump(expression);
-| ^^^^^^ support.function.var.php
-```
-
-```html+php
-<div></div>
-|^^^ entity.name.tag.block.any.html
-<?php
-|^^^^ punctuation.section.embedded.begin.php
-var_dump(expression);
-| ^^^^^^ support.function.var.php
-```
-|^^ punctuation.definition.raw.code-fence.end.markdown
-
-```regex
-(?x)
-\s+
-```
-|^^^ meta.code-fence.definition.end.regexp - markup
-|^^ punctuation.definition.raw.code-fence.end
-
-```bash
-# test
-| ^^^^^ source.shell comment.line.number-sign
-echo hello, \
-|           ^^ punctuation.separator.continuation.line
-echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
-|                       ^^ constant.character.escape
-```
-| <- meta.code-fence.definition.end.shell-script punctuation.definition.raw.code-fence.end
-
-```     bash
-| <- punctuation.definition.raw.code-fence.begin
-|  ^^^^^ meta.code-fence.definition.begin.shell-script.markdown-gfm
-|       ^^^^ constant.other.language-name
-# test
-| ^^^^^ source.shell comment.line.number-sign
-```
-| <- meta.code-fence.definition.end.shell-script punctuation.definition.raw.code-fence.end
-
-~~~~    ruby startline=3 $%@#$
-| <- punctuation.definition.raw.code-fence.begin
-|   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm
-|       ^^^^ constant.other.language-name
-|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm
-def foo(x)
-  return 3
-end
-~~~~~~~
-| <- meta.code-fence.definition.end.ruby punctuation.definition.raw.code-fence.end
-
-\~/.bashrc
-|^ constant.character.escape
-
-  -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  - constant - keyword - variable
-
-    -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
-|   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.raw - constant - keyword - variable - punctuation
-
->  -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant - keyword - variable
-
-> > -= += /= %= -- ++ ** !~ =~ ~~ <= >= => <=> // && == !=
-| ^ markup.quote.markdown markup.quote.markdown punctuation.definition.blockquote.markdown
-|  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant - keyword - variable
-
-\<div>
-|<- constant.character.escape
-|^ constant.character.escape
-|^^^^^^ - meta.tag
-
-\<div\>
-|^ constant.character.escape
-|^^^^^^ - meta.tag
-|    ^^ constant.character.escape
-
-link with a single underscore inside the text : [@_test](http://example.com)
-|                                                ^^^^^^ meta.paragraph meta.link.inline.description - punctuation.definition
-|                                                      ^ meta.paragraph meta.link.inline punctuation.definition.link.end
-
-# h1
-- list
-## h2
-|^ punctuation.definition.heading.begin
-1. list
-### h3
-|^^ punctuation.definition.heading.begin
-
-1. list [001]blah
-|       ^^^^^ meta.link.reference
-|       ^ punctuation.definition.link.begin
-|           ^ punctuation.definition.link.end
-|            ^^^^^ - meta.link
-
-  [001]: https://en.wikipedia.org/wiki/Root-mean-square_deviation "Wikipedia - RMSE"
-| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.list.numbered meta.link.reference.def.markdown
-1. another list item
-
-[foo]: /url "title"
-|^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|    ^ punctuation.separator.key-value
-|      ^^^^ markup.underline.link
-|           ^^^^^^^ string.quoted.double
-
-[foo]
-|<- meta.link.reference punctuation.definition.link.begin
-|^^^ meta.paragraph meta.link.reference
-|   ^ meta.link.reference punctuation.definition.link.end
-
-This is literal [Foo*bar\]] but [ref][Foo*bar\]]
-|               ^^^^^^^^^^^ meta.link.reference.description.markdown
-|               ^ punctuation.definition.link.begin.markdown
-|                ^^^^^^^ - constant
-|                       ^^ constant.character.escape.markdown
-|                         ^ punctuation.definition.link.end.markdown
-|                               ^^^^^ meta.link.reference.description.markdown
-|                                    ^^^^^^^^^^^ meta.link.reference.metadata.markdown
-
- [Foo*bar\]]:my_(url) 'title (with parens)'
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.reference.def.markdown
-|^ punctuation.definition.reference.begin.markdown
-| ^^^^^^^^^ entity.name.reference.link.markdown - punctuation
-|          ^ punctuation.definition.reference.end.markdown
-|           ^ punctuation.separator.key-value.markdown
-|            ^^^^^^^^ markup.underline.link
-|                    ^ - markup - string
-|                     ^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
-
- [foo]: <>
-|^^^^^^^^^ meta.link.reference.def.markdown
-|     ^ punctuation.separator.key-value
-|       ^ punctuation.definition.link.begin
-|        ^ punctuation.definition.link.end
-
-# CriticMarkup ################################################################
+# TEST: CRITIC MARKUP #########################################################
 
 This is an {++additional++} word in {++**bold**++}.
 |          ^^^^^^^^^^^^^^^^ markup.critic.addition.markdown
@@ -3431,6 +7755,48 @@ This is a {-- deletion --} and {~~substitute~>with~~striked~~text~~} or {~~~~old
 |                                                                                        ^^ punctuation.definition.strikethrough.end.markdown
 |                                                                                          ^^^ punctuation.definition.critic.end.markdown
 
+No striked {~~~>~~} critics.
+|          ^^^^^^^^ markup.critic.substitution.markdown
+|          ^^^ punctuation.definition.critic.begin.markdown
+|             ^^ punctuation.separator.critic.markdown
+|               ^^^ punctuation.definition.critic.end.markdown
+|                  ^^^^^^^^^^ - markup.critic
+
+No striked {~~~~>~~~} critics.
+|          ^^^^^^^^^^ markup.critic.substitution.markdown
+|          ^^^ punctuation.definition.critic.begin.markdown
+|             ^ - punctuation
+|              ^^ punctuation.separator.critic.markdown
+|                ^ - punctuation
+|                 ^^^ punctuation.definition.critic.end.markdown
+|                    ^^^^^^^^^^ - markup.critic
+
+No striked {~~~~~>~~~~} critics.
+|          ^^^^^^^^^^^^ markup.critic.substitution.markdown
+|          ^^^ punctuation.definition.critic.begin.markdown
+|             ^^ - punctuation
+|               ^^ punctuation.separator.critic.markdown
+|                 ^^ - punctuation
+|                   ^^^ punctuation.definition.critic.end.markdown
+|                      ^^^^^^^^^^ - markup.critic
+
+No striked {~~~~~~>~~~~~} critics.
+|          ^^^^^^^^^^^^^^ markup.critic.substitution.markdown
+|          ^^^ punctuation.definition.critic.begin.markdown
+|             ^^^ - punctuation
+|                ^^ punctuation.separator.critic.markdown
+|                  ^^^ - punctuation
+|                     ^^^ punctuation.definition.critic.end.markdown
+|                        ^^^^^^^^^^ - markup.critic
+
+No striked {~~~~~~~>~~~~~~} critics.
+|          ^^^^^^^^^^^^^^^^ markup.critic.substitution.markdown
+|          ^^^ punctuation.definition.critic.begin.markdown
+|             ^^^^ - punctuation
+|                 ^^ punctuation.separator.critic.markdown
+|                   ^^^^ - punctuation
+|                       ^^^ punctuation.definition.critic.end.markdown
+|                          ^^^^^^^^^^ - markup.critic
 
 This is a {>> comment <<}.
 |         ^^^^^^^^^^^^^^^ markup.critic.comment.markdown

--- a/tests/test_convert_inline_link_to_reference.py
+++ b/tests/test_convert_inline_link_to_reference.py
@@ -1,0 +1,446 @@
+from MarkdownEditing.tests import DereferrablePanelTestCase
+
+
+class TestConvertInlineLinkToReference(DereferrablePanelTestCase):
+    def setUp(self):
+        self.setBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+            """
+        )
+
+    def test_convert_link1_with_caret_in_description(self):
+        self.setCaretTo(2, 10)
+        self._test_convert_link1()
+
+    def test_convert_link1_with_caret_in_url(self):
+        self.setCaretTo(2, 25)
+        self._test_convert_link1()
+
+    def _test_convert_link1(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub][] inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
+            [GitHub]: https://github.com
+            """
+        )
+
+    def test_convert_link2_with_caret_in_description(self):
+        self.setCaretTo(3, 2)
+        self._test_convert_link2()
+
+    def test_convert_link2_with_caret_in_url(self):
+        self.setCaretTo(3, 9)
+        self._test_convert_link2()
+
+    def _test_convert_link2(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues][] go here.
+            [GitHub](https://github.com)
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
+            [Issues]: https://github.com/user/repo/issues
+            """
+        )
+
+    def test_convert_link3_with_caret_in_description(self):
+        self.setCaretTo(4, 7)
+        self._test_convert_link3()
+
+    def test_convert_link3_with_caret_in_url(self):
+        self.setCaretTo(4, 27)
+        self._test_convert_link3()
+
+    def _test_convert_link3(self):
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub](https://github.com) inline link.
+            [Issues](https://github.com/user/repo/issues) go here.
+            [GitHub][]
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
+            [GitHub]: https://github.com
+            """
+        )
+
+    def test_convert_link1_to_3(self):
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.setCaretTo(3, 2)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.setCaretTo(4, 7)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        # try to convert image
+        self.setCaretTo(5, 50)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self._test_convert_all()
+
+    def test_convert_all(self):
+        self.view.run_command("mde_convert_inline_links_to_references")
+        self._test_convert_all()
+
+    def _test_convert_all(self):
+        self.assertEqualBlockText(
+            """
+            # Test 1
+            First [GitHub][] inline link.
+            [Issues][] go here.
+            [GitHub][]
+            Just another paragraph with ![screenshot](assets/img/screenshot.png).
+
+            [GitHub]: https://github.com
+            [Issues]: https://github.com/user/repo/issues
+            """
+        )
+
+
+class TestConvertInlineLinkToReferenceReuseExistingDefinitions(DereferrablePanelTestCase):
+    def test_reuse_indented_definition(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+               [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+               [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_with_multiple_spaces(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:       https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:       https://github.com
+            """
+        )
+
+    def test_reuse_multiline_definition(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+            """
+        )
+
+    def test_reuse_definition_with_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: https://github.com "the page description"
+            """
+        )
+
+    def test_reuse_multiline_definition_with_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+                "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+                "the page description"
+            """
+        )
+
+    def test_reuse_definition_with_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: https://github.com (the page description)
+            """
+        )
+
+    def test_reuse_multiline_definition_with_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+                https://github.com
+                (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+                https://github.com
+                (the page description)
+            """
+        )
+
+    def test_reuse_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com>
+            """
+        )
+
+    def test_reuse_indended_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+               [GitHub]:    <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+               [GitHub]:    <https://github.com>
+            """
+        )
+
+    def test_reuse_multiline_definition_with_angled_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]:
+            <https://github.com>
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]:
+            <https://github.com>
+            """
+        )
+
+    def test_reuse_definition_with_angled_url_and_quoted_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com> "the page description"
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com> "the page description"
+            """
+        )
+
+    def test_reuse_definition_with_angled_url_and_parenthesed_description(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com) link.
+
+            [GitHub]: <https://github.com> (the page description)
+            """
+        )
+        self.setCaretTo(2, 10)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][] link.
+
+            [GitHub]: <https://github.com> (the page description)
+            """
+        )
+
+    def test_reuse_definition_in_blockquote(self):
+        self.setBlockText(
+            """
+            > First [GitHub][] link.
+            > Second [GitHub](https://github.com) link.
+            >
+            > [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 12)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            > First [GitHub][] link.
+            > Second [GitHub][] link.
+            >
+            > [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_in_listitem(self):
+        self.setBlockText(
+            """
+            - First [GitHub][] link.
+              - Second [GitHub](https://github.com) link.
+
+                [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 15)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            - First [GitHub][] link.
+              - Second [GitHub][] link.
+
+                [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_quoted_in_listitem(self):
+        self.setBlockText(
+            """
+            > - First [GitHub][] link.
+            >   - Second [GitHub](https://github.com) link.
+            >
+            >     [GitHub]: https://github.com
+            """
+        )
+        self.setCaretTo(2, 15)
+        self.view.run_command("mde_convert_inline_link_to_reference")
+        self.assertEqualBlockText(
+            """
+            > - First [GitHub][] link.
+            >   - Second [GitHub][] link.
+            >
+            >     [GitHub]: https://github.com
+            """
+        )
+
+    def test_reuse_definition_but_create_new_for_differnt_url(self):
+        self.setBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub](https://github.com/user) link.
+            Third [GitHub](https://github.com) link.
+
+            [GitHub]: https://github.com
+            """
+        )
+        self.view.run_command("mde_convert_inline_links_to_references")
+        self.assertEqualBlockText(
+            """
+            First [GitHub][] link.
+            Second [GitHub][GitHub2] link.
+            Third [GitHub][] link.
+
+            [GitHub]: https://github.com
+            [GitHub2]: https://github.com/user
+            """
+        )

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -1,0 +1,78 @@
+from MarkdownEditing.tests import DereferrablePanelTestCase
+
+
+class TestMdeReferenceNewFootnoteCommand(DereferrablePanelTestCase):
+
+    def test_new_footnote_in_first_line(self):
+        self.setBlockText(
+            """
+            # Test 1
+
+            First inline.
+            Second inline.
+
+            Third inline.
+
+            # Test 2
+
+            paragraph
+            """
+        )
+        self.setCaretTo(3,6)
+        self.view.run_command("mde_reference_new_footnote")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+
+            First[^1] inline.
+            Second inline.
+
+            Third inline.
+
+            # Test 2
+
+            paragraph
+            [^1]:\x20
+            """
+        )
+
+    def test_new_footnote_in_second_line(self):
+        self.setBlockText(
+            """
+            # Test 1
+
+            First[^1] inline.
+            Second inline.
+
+            Third inline.
+
+            # Test 2
+
+            paragraph
+
+            [^1]:
+                Footnote text
+                with second line
+            """
+        )
+        self.setCaretTo(4,7)
+        self.view.run_command("mde_reference_new_footnote")
+        self.assertEqualBlockText(
+            """
+            # Test 1
+
+            First[^1] inline.
+            Second[^2] inline.
+
+            Third inline.
+
+            # Test 2
+
+            paragraph
+
+            [^1]:
+                Footnote text
+                with second line
+            [^2]:\x20
+            """
+        )

--- a/tests/test_insert_task_list_item.py
+++ b/tests/test_insert_task_list_item.py
@@ -4,7 +4,7 @@ from MarkdownEditing.tests import DereferrablePanelTestCase
 class InsertTaskListItemTestCase(DereferrablePanelTestCase):
 
     def setUp(self):
-        self.setText("")
+        self.setBlockText("")
 
     def test_insert_unaligned_task_with_asterisk(self):
         self.view.settings().set("mde.list_align_text", False)
@@ -30,7 +30,7 @@ class InsertTaskListItemTestCase(DereferrablePanelTestCase):
             """
         )
 
-    def test_insert_unaligned_task_with_minus(self):
+    def test_insert_unaligned_task_with_plus(self):
         self.view.settings().set("mde.list_align_text", False)
         self.view.settings().set("mde.list_indent_bullets", ["+", "-", "*"])
 
@@ -66,7 +66,7 @@ class InsertTaskListItemTestCase(DereferrablePanelTestCase):
             """
         )
 
-    def test_insert_aligned_task_with_minus(self):
+    def test_insert_aligned_task_with_plus(self):
         self.view.settings().set("mde.list_align_text", True)
         self.view.settings().set("mde.list_indent_bullets", ["+", "-", "*"])
 

--- a/tests/test_join_lines.py
+++ b/tests/test_join_lines.py
@@ -78,7 +78,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
 
         self.setCaretTo(1, 1)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_subitems(self):
         self.setBlockText(
@@ -110,7 +114,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
 
         self.setCaretTo(1, 1)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("* item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            * item 1 foo bar item 2
+            """
+        )
 
     def test_join_ordered_list_with_subitems_multi_caret(self):
         self.setBlockText(
@@ -125,7 +133,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_subitems_multi_caret(self):
         self.setBlockText(
@@ -140,8 +152,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("* item 1 foo bar item 2")
-
+        self.assertEqualBlockText(
+            """
+            * item 1 foo bar item 2
+            """
+        )
     def test_join_ordered_list_with_text_multi_caret(self):
         self.setBlockText(
             """
@@ -155,7 +170,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_text_multi_caret(self):
         self.setBlockText(
@@ -170,7 +189,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("* item 1 bar baz item")
+        self.assertEqualBlockText(
+        """
+        * item 1 bar baz item
+        """
+    )
 
     def test_join_selected_ordered_list_with_subitems(self):
         self.setBlockText(
@@ -183,7 +206,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_selected_unordered_list_with_subitems(self):
         self.setBlockText(
@@ -196,7 +223,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("* item 1 foo bar item 2")
+        self.assertEqualBlockText(
+        """
+        * item 1 foo bar item 2
+        """
+    )
 
     def test_join_selected_ordered_list_with_text(self):
         self.setBlockText(
@@ -209,7 +240,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_selected_unordered_list_with_text(self):
         self.setBlockText(
@@ -222,7 +257,11 @@ class JoinListItemsTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("* item 1 bar baz item")
+        self.assertEqualBlockText(
+        """
+        * item 1 bar baz item
+        """
+    )
 
     def test_join_lines_keep_ordered_list_bullet(self):
         self.setBlockText(
@@ -275,7 +314,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> foo bar baz")
+        self.assertEqualBlockText(
+            """
+            > foo bar baz
+            """
+        )
 
     def test_join_selected_text_level2(self):
         self.setBlockText(
@@ -287,7 +330,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> > foo bar baz")
+        self.assertEqualBlockText(
+        """
+        > > foo bar baz
+        """
+    )
 
     def test_join_two_ordered_list_items_with_dot(self):
         self.setBlockText(
@@ -364,7 +411,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
 
         self.setCaretTo(1, 1)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> 1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            > 1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_subitems(self):
         self.setBlockText(
@@ -396,7 +447,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
 
         self.setCaretTo(1, 1)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> * item 1 foo bar item 2")
+        self.assertEqualBlockText(
+        """
+        > * item 1 foo bar item 2
+        """
+    )
 
     def test_join_ordered_list_with_subitems_multi_caret(self):
         self.setBlockText(
@@ -411,7 +466,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> 1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            > 1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_subitems_multi_caret(self):
         self.setBlockText(
@@ -426,7 +485,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> * item 1 foo bar item 2")
+        self.assertEqualBlockText(
+        """
+        > * item 1 foo bar item 2
+        """
+    )
 
     def test_join_ordered_list_with_text_multi_caret(self):
         self.setBlockText(
@@ -441,7 +504,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> 1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            > 1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_unordered_list_with_text_multi_caret(self):
         self.setBlockText(
@@ -456,7 +523,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         self.addCaretAt(2, 3)
         self.addCaretAt(3, 3)
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> * item 1 bar baz item")
+        self.assertEqualBlockText(
+        """
+        > * item 1 bar baz item
+        """
+    )
 
     def test_join_selected_ordered_list_with_subitems(self):
         self.setBlockText(
@@ -469,7 +540,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> 1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            > 1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_selected_unordered_list_with_subitems(self):
         self.setBlockText(
@@ -482,7 +557,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> * item 1 foo bar item 2")
+        self.assertEqualBlockText(
+        """
+        > * item 1 foo bar item 2
+        """
+    )
 
     def test_join_selected_ordered_list_with_text(self):
         self.setBlockText(
@@ -495,7 +574,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> 1) item 1 foo bar item 2")
+        self.assertEqualBlockText(
+            """
+            > 1) item 1 foo bar item 2
+            """
+        )
 
     def test_join_selected_unordered_list_with_text(self):
         self.setBlockText(
@@ -508,7 +591,11 @@ class JoinBlockQuoteLinesTestCase(DereferrablePanelTestCase):
         )
         self.view.run_command("select_all")
         self.view.run_command("mde_join_lines")
-        self.assertEqualText("> * item 1 bar baz item")
+        self.assertEqualBlockText(
+        """
+        > * item 1 bar baz item
+        """
+    )
 
     def test_join_lines_keep_ordered_list_bullet_if_caret_after_blockquote_sign(self):
         self.setBlockText(

--- a/tests/test_reference_completions.md
+++ b/tests/test_reference_completions.md
@@ -1,0 +1,38 @@
+# Reference Completion TestFile
+
+[][] is used for completion tests!
+
+## Docment Reference Definitions
+
+The repo of [MarkdownEditing][main-page] and a [^1].
+
+Create [issues] for things.
+
+The ![preview][preview-url] is here.
+
+[^1]: This is my footnote text.
+
+[main-page]: https://github.com/SublimeText-Markdown/MarkdownEditing "reference description"
+   [issues]: 
+        https://github.com/SublimeText-Markdown/MarkdownEditing/issues
+        "Create issues here!"
+  [preview-url]:
+      https://github.com/SublimeText-Markdown/MarkdownEditing/raw/master/docs/img/preview.png "Main Preview Image"
+
+
+## List Item References
+
+1. List item with [list-ref]
+
+   [list-ref]: docs/configuration.html
+
+
+## Block Quote References
+
+> Block quotes with ![image][quoted-image]
+> 
+> 1. List item with [quoted-list-ref]
+> 
+>    [quoted-list-ref]: docs/configuration.html
+>
+> [quoted-image]: assets/images/foo.png

--- a/tests/test_reference_completions.py
+++ b/tests/test_reference_completions.py
@@ -1,0 +1,52 @@
+import sublime
+
+from MarkdownEditing.tests import DereferrablePanelTestCase
+from MarkdownEditing.plugin import MdeReferenceCompletionsProvider
+
+class TestReferenceCompletions(DereferrablePanelTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create output panel and load text from `test_folding.md` into.
+        """
+        super().setUpClass()
+        with open(__file__[:-2] + "md") as f:
+            cls.setText(f.read().replace("\r\n", "\n").replace("\r", "\n"))
+
+    def test_st3_reference_completions(self):
+        if hasattr(sublime, "KIND_ID_MARKUP"):
+            return
+
+        expected_items = (
+            [
+                ['main-page\thttps://github.com/SublimeTex…', 'main-page'],
+                ['issues\thttps://github.com/SublimeTex…', 'issues'],
+                ['preview-url\thttps://github.com/SublimeTex…', 'preview-url'],
+                ['list-ref\tdocs/configuration.html', 'list-ref'],
+                ['quoted-list-ref\tdocs/configuration.html', 'quoted-list-ref'],
+                ['quoted-image\tassets/images/foo.png', 'quoted-image']
+            ],
+            24
+        )
+
+        provider = MdeReferenceCompletionsProvider(self.view)
+        completion_list = provider.on_query_completions("", [34])
+        self.assertEqual(completion_list, expected_items)
+
+    def test_st4_reference_completions(self):
+        if not hasattr(sublime, "KIND_ID_MARKUP"):
+            return
+
+        expected_items = [
+            sublime.CompletionItem('main-page', annotation='https://github.com/SublimeTex…', completion='main-page', completion_format=0, kind=(6, 'R', 'Ref'), details='reference description'),
+            sublime.CompletionItem('issues', annotation='https://github.com/SublimeTex…', completion='issues', completion_format=0, kind=(6, 'R', 'Ref'), details='Create issues here!'),
+            sublime.CompletionItem('preview-url', annotation='https://github.com/SublimeTex…', completion='preview-url', completion_format=0, kind=(6, 'R', 'Ref'), details='Main Preview Image'),
+            sublime.CompletionItem('list-ref', annotation='docs/configuration.html', completion='list-ref', completion_format=0, kind=(6, 'R', 'Ref'), details='No title'),
+            sublime.CompletionItem('quoted-list-ref', annotation='docs/configuration.html', completion='quoted-list-ref', completion_format=0, kind=(6, 'R', 'Ref'), details='No title'),
+            sublime.CompletionItem('quoted-image', annotation='assets/images/foo.png', completion='quoted-image', completion_format=0, kind=(6, 'R', 'Ref'), details='No title')
+        ]
+
+        provider = MdeReferenceCompletionsProvider(self.view)
+        completion_list = provider.on_query_completions("", [34])
+        self.assertEqual(completion_list.completions, expected_items)


### PR DESCRIPTION
## Bug Fixes

* fix regression with latex block highlighting in list items
* fix CommonMark compatibility of backslash escapes
* fix CommonMark compatibility of block quotes
* fix CommonMark compatibility of html entities
* fix CommonMark compatibility of fenced code blocks
* fix CommonMark compatibility of indented code blocks (mixed tabs/spaces)
* fix CommonMark compatibility of reference definitions
* fix CommonMark compatibility of thematic breaks
* fix `mde_convert_inline_link_to_reference` producing duplicate definitions (fixes #559)
* update strikethough markup to use 2 tildes (fixes #637)
* restore link/image/reference description colors for Mariana/Monokai (fixes #670)
* fix strikethrough colors in Monokai/Mariana (fixes #678)
* fix wiki link bindings and their docs (see #679)

## New Features

* `Organize References` learned to sort reference definitions using `"mde.ref_organize_sort"` setting

## Changes

* Fully support xonsh fenced code instead of using Python syntax 
  (if supported syntax is installed)
* Removes indended code block highlighting from list blocks (fixes #663)
  ST's syntax engine can't count indentation, so reliably highlighting
  indended code blocks in maybe nested list items is impossible.
  Use fenced code blocks instead.
