### PR TITLE
Add fenced-yaml alias: `yml`

### DIFF
--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -1657,7 +1657,7 @@ contexts:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          ((?i:yaml))
+          ((?i:yaml|yml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
         0: meta.code-fence.definition.begin.yaml.markdown-gfm


### PR DESCRIPTION
On GitHub markdown, either `yaml` or `yml` works for fenced-yaml block

```yaml
# ```yaml
yaml: test
```

```yml
# ```yml
yaml: test
```

In this PR, I've added `yml` as an alias of fenced-yaml.