### PR TITLE
Completed tasks look like `- [x] ...`, not `- [X] ...`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -239,7 +239,7 @@ Following key bindings may be used to create or toggle tasks.
 | Linux/Windows | MacOS | Description
 |---------------|-------|-------------
 | <kbd>Alt</kbd> + <kbd>t</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>t</kbd> | Creates new GFM task (`* [ ] task`)
-| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [X] task`)
+| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [x] task`)
 
 # References
 

--- a/plugins/lists.py
+++ b/plugins/lists.py
@@ -205,21 +205,21 @@ class MdeToggleTaskListItemCommand(MdeTextCommand):
     **Examples:**
 
     ```markdown
-    # Orderd Task List
+    # Ordered Task List
 
     1. [ ] task 1
-    2. [X] task 2
+    2. [x] task 2
 
-    # Unorderd Task List
+    # Unordered Task List
 
     * [ ] task 1
-    - [X] task 2
+    - [x] task 2
     + [ ] task 3
 
     # Quoted Task List
 
     > * [ ] task 1
-    > * [X] task 2
+    > * [x] task 2
     ```
     """
 
@@ -245,7 +245,7 @@ class MdeToggleTaskListItemCommand(MdeTextCommand):
                 region.a += match.start(1)
                 region.b = region.a + 1
 
-                self.view.replace(edit, region, "X" if match.group(1) == " " else " ")
+                self.view.replace(edit, region, "x" if match.group(1) == " " else " ")
 
 
 class MdeJoinLines(MdeTextCommand):

--- a/tests/test_toggle_tasks.py
+++ b/tests/test_toggle_tasks.py
@@ -28,7 +28,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            * [X] task 1
+            * [x] task 1
             """
         )
 
@@ -50,7 +50,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_asterisk_undone(self, col):
         self.setBlockText(
             """
-            * [X] task 1
+            * [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -86,7 +86,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            - [X] task 1
+            - [x] task 1
             """
         )
 
@@ -108,7 +108,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_minus_undone(self, col):
         self.setBlockText(
             """
-            - [X] task 1
+            - [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -144,7 +144,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            + [X] task 1
+            + [x] task 1
             """
         )
 
@@ -166,7 +166,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_plus_undone(self, col):
         self.setBlockText(
             """
-            + [X] task 1
+            + [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -202,7 +202,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > * [X] task 1
+            > * [x] task 1
             """
         )
 
@@ -224,7 +224,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_asterisk_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > * [X] task 1
+            > * [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -260,7 +260,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > - [X] task 1
+            > - [x] task 1
             """
         )
 
@@ -282,7 +282,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_minus_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > - [X] task 1
+            > - [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -318,7 +318,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > + [X] task 1
+            > + [x] task 1
             """
         )
 
@@ -340,7 +340,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_plus_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > + [X] task 1
+            > + [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -354,15 +354,15 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def test_toggle_multi_caret_tasks(self):
         self.setBlockText(
             """
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
@@ -377,30 +377,30 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             """
         )
 
     def test_toggle_selected_tasks(self):
         self.setBlockText(
             """
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
@@ -413,14 +413,14 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             """
         )


### PR DESCRIPTION
When marking a task as completed, use a lowercase `x` instead of uppercase `X`

E.g. `- [x] task 1` instead of `- [X] task 1`

This PR also updates docs and tests to reflect this change.

This follows [the GFM spec](https://github.github.com/gfm/#task-list-items-extension-). Similar info about the spec [can be found here](https://www.markdownguide.org/extended-syntax/#task-lists).