### PR TITLE
MarkdownEditing 3.1.4 (ST3176)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -239,7 +239,7 @@ Following key bindings may be used to create or toggle tasks.
 | Linux/Windows | MacOS | Description
 |---------------|-------|-------------
 | <kbd>Alt</kbd> + <kbd>t</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>t</kbd> | Creates new GFM task (`* [ ] task`)
-| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [X] task`)
+| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [x] task`)
 
 # References
 

--- a/make.cmd
+++ b/make.cmd
@@ -56,14 +56,14 @@ goto :usage
         echo Missing release-%2.md
         exit /b 1
     )
-    git checkout st3176 && git merge %2 --no-ff
+    git checkout st3176 --autostash && git merge st3-develop --no-ff
     if not errorlevel 0 (
-        echo Unable to merge %2 into st3176!
+        echo Unable to merge st3-develop into st3176!
         exit /b 1
     )
-    git checkout master && git merge %2 --no-ff
+    git checkout master --autostash && git merge st4-develop --no-ff
     if not errorlevel 0 (
-        echo Unable to merge %2 into master!
+        echo Unable to merge st4-develop into master!
         exit /b 1
     )
     echo Hit any key to push branches!

--- a/make.cmd
+++ b/make.cmd
@@ -56,12 +56,12 @@ goto :usage
         echo Missing release-%2.md
         exit /b 1
     )
-    git checkout st3176 --autostash && git merge st3-develop --no-ff
+    git checkout st3176 && git merge st3-develop --no-ff
     if not errorlevel 0 (
         echo Unable to merge st3-develop into st3176!
         exit /b 1
     )
-    git checkout master --autostash && git merge st4-develop --no-ff
+    git checkout master && git merge st4-develop --no-ff
     if not errorlevel 0 (
         echo Unable to merge st4-develop into master!
         exit /b 1

--- a/messages.json
+++ b/messages.json
@@ -37,5 +37,6 @@
 	"3.1.0": "messages/3.1.0.md",
 	"3.1.1": "messages/3.1.1.md",
 	"3.1.2": "messages/3.1.2.md",
-	"3.1.3": "messages/3.1.3.md"
+	"3.1.3": "messages/3.1.3.md",
+	"3.1.4": "messages/3.1.4.md"
 }

--- a/messages/3.1.4.md
+++ b/messages/3.1.4.md
@@ -11,6 +11,6 @@ feedback you can use [GitHub issues][issues].
 
 ## Changes
 
-* use lower case check mark completed gfm tasks `- [x] task` (#696)
+* Use lower case `x` for completed gfm tasks `- [x] task` (#696)
 
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.4.md
+++ b/messages/3.1.4.md
@@ -1,0 +1,12 @@
+# MarkdownEditing 3.1.4 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.4.md
+++ b/messages/3.1.4.md
@@ -11,4 +11,6 @@ feedback you can use [GitHub issues][issues].
 
 ## Changes
 
+* use lower case check mark completed gfm tasks `- [x] task` (#696)
+
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.4.md
+++ b/messages/3.1.4.md
@@ -7,6 +7,8 @@ feedback you can use [GitHub issues][issues].
 
 ## New Features
 
+* syntax highlighting for _Twee_ in fenced code blocks
+
 ## Changes
 
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/plugins/lists.py
+++ b/plugins/lists.py
@@ -205,21 +205,21 @@ class MdeToggleTaskListItemCommand(MdeTextCommand):
     **Examples:**
 
     ```markdown
-    # Orderd Task List
+    # Ordered Task List
 
     1. [ ] task 1
-    2. [X] task 2
+    2. [x] task 2
 
-    # Unorderd Task List
+    # Unordered Task List
 
     * [ ] task 1
-    - [X] task 2
+    - [x] task 2
     + [ ] task 3
 
     # Quoted Task List
 
     > * [ ] task 1
-    > * [X] task 2
+    > * [x] task 2
     ```
     """
 
@@ -245,7 +245,7 @@ class MdeToggleTaskListItemCommand(MdeTextCommand):
                 region.a += match.start(1)
                 region.b = region.a + 1
 
-                self.view.replace(edit, region, "X" if match.group(1) == " " else " ")
+                self.view.replace(edit, region, "x" if match.group(1) == " " else " ")
 
 
 class MdeJoinLines(MdeTextCommand):

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -331,6 +331,13 @@ contexts:
     - include: atx-headings
     - include: setext-heading-or-paragraph
 
+  indented-markdown:
+    # This is a public context which can be embedded by 3rd-party syntaxes
+    # to support Markdown highlighting in locations of arbitrary indentation,
+    # but without reference to list blocks as this is an implementation detail.
+    # The content may diverge from list block content in future.
+    - include: list-block-content
+
 ###[ CONTAINER BLOCKS: BLOCK QUOTES ]#########################################
 
   block-quotes:

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -963,6 +963,7 @@ contexts:
     - include: fenced-swift
     - include: fenced-terraform
     - include: fenced-toml
+    - include: fenced-twee
     - include: fenced-twig
     - include: fenced-verilog
     - include: fenced-xonsh
@@ -2160,6 +2161,25 @@ contexts:
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.toml.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+
+  fenced-twee:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          ((?i:twee))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.twee.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+      embed: scope:text.twee
+      embed_scope:
+        markup.raw.code-fence.twee.markdown-gfm
+        text.twee.embedded.markdown
+      escape: '{{fenced_code_block_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.twee.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
 
   fenced-twig:

--- a/syntaxes/MultiMarkdown.sublime-syntax
+++ b/syntaxes/MultiMarkdown.sublime-syntax
@@ -22,7 +22,6 @@ contexts:
       captures:
         0: meta.frontmatter.multimarkdown
         1: punctuation.section.block.begin.frontmatter.multimarkdown
-        2: constant.other.language-name.multimarkdown
       embed: frontmatter-content
       embed_scope: meta.frontmatter.multimarkdown
       escape: ^(---|\.{3})\s*\n

--- a/tests/syntax_test_multimarkdown.md
+++ b/tests/syntax_test_multimarkdown.md
@@ -1,36 +1,5 @@
-T: SYNTAX TEST "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
-Title:   A Sample MultiMarkdown Document
-T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Author:  Fletcher T. Penney
-T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Date:    February 9, 2011
-Comment: This is a comment intended to demonstrate
-         metadata that spans multiple lines, yet
-         is treated as a single value.
-T:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-Test:    And this is a new key-value pair
-With-Dash: Test
-T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-With Space: Test
-T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
-HTML Header: <style>
-             body { width:100ex; margin:auto; text-align:justify; }
-T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html
-HTML Header: <style>
-             body { width:100ex; margin:auto; text-align:justify; }
-             /* Some more style. */
-             </style>
-T:           ^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown meta.tag.style.end.html
+| SYNTAX TEST "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
 
-T: <- - meta.frontmatter.multimarkdown
-# Heading
-T: <- markup.heading punctuation.definition.heading - meta.frontmatter.multimarkdown
-T:^^^^^^^ markup.heading - meta.frontmatter.multimarkdown
+# MultiMarkdown without frontmatter
+| <- markup.heading.1.markdown punctuation.definition.heading.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.heading.1.markdown

--- a/tests/syntax_test_multimarkdown_frontmatter.md
+++ b/tests/syntax_test_multimarkdown_frontmatter.md
@@ -1,0 +1,36 @@
+T: SYNTAX TEST "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
+Title:   A Sample MultiMarkdown Document
+T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Author:  Fletcher T. Penney
+T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Date:    February 9, 2011
+Comment: This is a comment intended to demonstrate
+         metadata that spans multiple lines, yet
+         is treated as a single value.
+T:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+Test:    And this is a new key-value pair
+With-Dash: Test
+T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+With Space: Test
+T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
+T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html
+HTML Header: <style>
+             body { width:100ex; margin:auto; text-align:justify; }
+             /* Some more style. */
+             </style>
+T:           ^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown meta.tag.style.end.html
+
+T: <- - meta.frontmatter.multimarkdown
+# Heading
+T: <- markup.heading punctuation.definition.heading - meta.frontmatter.multimarkdown
+T:^^^^^^^ markup.heading - meta.frontmatter.multimarkdown

--- a/tests/test_toggle_tasks.py
+++ b/tests/test_toggle_tasks.py
@@ -28,7 +28,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            * [X] task 1
+            * [x] task 1
             """
         )
 
@@ -50,7 +50,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_asterisk_undone(self, col):
         self.setBlockText(
             """
-            * [X] task 1
+            * [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -86,7 +86,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            - [X] task 1
+            - [x] task 1
             """
         )
 
@@ -108,7 +108,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_minus_undone(self, col):
         self.setBlockText(
             """
-            - [X] task 1
+            - [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -144,7 +144,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            + [X] task 1
+            + [x] task 1
             """
         )
 
@@ -166,7 +166,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_plus_undone(self, col):
         self.setBlockText(
             """
-            + [X] task 1
+            + [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -202,7 +202,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > * [X] task 1
+            > * [x] task 1
             """
         )
 
@@ -224,7 +224,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_asterisk_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > * [X] task 1
+            > * [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -260,7 +260,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > - [X] task 1
+            > - [x] task 1
             """
         )
 
@@ -282,7 +282,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_minus_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > - [X] task 1
+            > - [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -318,7 +318,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
         self.view.run_command("mde_toggle_task_list_item")
         self.assertEqualBlockText(
             """
-            > + [X] task 1
+            > + [x] task 1
             """
         )
 
@@ -340,7 +340,7 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def _test_set_task_with_plus_in_quote_undone(self, col):
         self.setBlockText(
             """
-            > + [X] task 1
+            > + [x] task 1
             """
         )
         self.setCaretTo(1, col)
@@ -354,15 +354,15 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
     def test_toggle_multi_caret_tasks(self):
         self.setBlockText(
             """
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
@@ -377,30 +377,30 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             """
         )
 
     def test_toggle_selected_tasks(self):
         self.setBlockText(
             """
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
@@ -413,14 +413,14 @@ class MdeToggleTaskListItemTestCase(DereferrablePanelTestCase):
             * [ ] task 1
                 - [ ] sub task
                     + [ ] sub task
-            * [X] task 1
-                - [X] sub task
-                    + [X] sub task
+            * [x] task 1
+                - [x] sub task
+                    + [x] sub task
             > * [ ] task 1
             >     - [ ] sub task
             >         + [ ] sub task
-            > * [X] task 1
-            >     - [X] sub task
-            >         + [X] sub task
+            > * [x] task 1
+            >     - [x] sub task
+            >         + [x] sub task
             """
         )


### PR DESCRIPTION
## Bug Fixes

## New Features

* syntax highlighting for _Twee_ in fenced code blocks

## Changes

* use lower case check mark completed gfm tasks `- [x] task` (#696)
