### PR TITLE
MarkdownEditing 3.1.5 (ST3176)

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -20,25 +20,19 @@ on:
 
 jobs:
   test:
-    name: Sublime Text ${{ matrix.st_version }}
+    name: Sublime Text ${{ matrix.st-version }}
     runs-on: ubuntu-18.04
     timeout-minutes: 15 # default is 6 hours!
     strategy:
       fail-fast: false
       matrix:
-        st_version: [3, 4]
-    container:
-      image: sublimetext/unittesting
-      options: --cap-add=NET_ADMIN
-    env:
-      SUBLIME_TEXT_VERSION: ${{ matrix.st_version }}
+        st-version: [3, 4]
     steps:
-      - uses: actions/checkout@v1
-      - run: sh -e /etc/init.d/xvfb start
-      - run: curl -OL https://raw.githubusercontent.com/SublimeText/UnitTesting/master/sbin/github.sh
-      - run: apt-get update
-      - run: |
-          PATH="$HOME/.local/bin:$PATH"
-          sh github.sh bootstrap
-          sh github.sh install_package_control
-          sh github.sh run_tests
+      - uses: actions/checkout@v2
+      - uses: SublimeText/UnitTesting/actions/setup@v1
+        with:
+          sublime-text-version: ${{ matrix.st-version }}
+      - uses: SublimeText/UnitTesting/actions/run-tests@v1
+        with:
+          coverage: true
+          codecov-upload: true

--- a/messages.json
+++ b/messages.json
@@ -38,5 +38,6 @@
 	"3.1.1": "messages/3.1.1.md",
 	"3.1.2": "messages/3.1.2.md",
 	"3.1.3": "messages/3.1.3.md",
-	"3.1.4": "messages/3.1.4.md"
+	"3.1.4": "messages/3.1.4.md",
+	"3.1.5": "messages/3.1.5.md"
 }

--- a/messages/3.1.5.md
+++ b/messages/3.1.5.md
@@ -5,6 +5,7 @@ feedback you can use [GitHub issues][issues].
 
 ## Bug Fixes
 
+* Fix legacy MultiMarkdown frontmatter detection (#700)
 * `mdc` snippet now includes trailing newline
 
 ## New Features

--- a/messages/3.1.5.md
+++ b/messages/3.1.5.md
@@ -1,0 +1,12 @@
+# MarkdownEditing 3.1.5 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.5.md
+++ b/messages/3.1.5.md
@@ -5,6 +5,8 @@ feedback you can use [GitHub issues][issues].
 
 ## Bug Fixes
 
+* `mdc` snippet now includes trailing newline
+
 ## New Features
 
 ## Changes

--- a/snippets/Code Block (mdc).sublime-snippet
+++ b/snippets/Code Block (mdc).sublime-snippet
@@ -1,7 +1,9 @@
 <snippet>
 	<content><![CDATA[```${1:language}
 ${2:code}
-```]]></content>
+```
+
+]]></content>
 	<tabTrigger>mdc</tabTrigger>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - meta.code-fence - markup.raw</scope>
 	<description>Markdown Codeblock</description>

--- a/syntaxes/MultiMarkdown.sublime-syntax
+++ b/syntaxes/MultiMarkdown.sublime-syntax
@@ -6,7 +6,7 @@ scope: text.html.markdown.multimarkdown
 first_line_match: (?i:^format:\s*complete\s*$)
 
 variables:
-  header: ([A-Za-z0-9][\w -]*)(:)
+  header: ([A-Za-z0-9][\w -]*)((:)\s+)
 
 contexts:
   main:
@@ -38,7 +38,8 @@ contexts:
     - match: ^{{header}}
       captures:
         1: meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
-        2: meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
+        2: meta.mapping.multimarkdown
+        3: punctuation.separator.key-value.multimarkdown
       embed: Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax#html-content
       embed_scope: meta.mapping.value.multimarkdown
       escape: ^(?={{header}})

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -1592,7 +1592,7 @@ graph n {}
 
 ```html+php
 <div></div>
-|^^^ entity.name.tag.block.any.html
+|^^^ entity.name.tag.block
 <?php
 | <- markup.raw.code-fence.html-php.markdown-gfm embedding.php meta.embedded punctuation.section.embedded.begin.php
 var_dump(expression);
@@ -1830,7 +1830,7 @@ okay.
 | ^^^^^^^ meta.paragraph markup.italic - meta.disable-markdown
 
 </DIV>
-| ^^^ meta.disable-markdown meta.tag.block.any.html
+| ^^^ meta.disable-markdown meta.tag.block
 
 ## https://spec.commonmark.org/0.30/#example-153
 
@@ -1888,7 +1888,7 @@ int x = 33;
 | <- meta.disable-markdown - markup.italic - punctuation
 |^^^^^ meta.disable-markdown - markup.italic
 </Warning>
-| ^^^^^^^ meta.disable-markdown meta.tag.other.html entity.name.tag.other.html
+| ^^^^^^^ meta.disable-markdown meta.tag.other entity.name.tag.other.html
 
 ## https://spec.commonmark.org/0.30/#example-164
 
@@ -1947,7 +1947,7 @@ int x = 33;
 ## https://spec.commonmark.org/0.30/#example-169
 
 <pre language="haskell"><code>
-| ^^ meta.disable-markdown meta.tag.block.any.html entity.name.tag.block.any.html
+| ^^ meta.disable-markdown meta.tag.block entity.name.tag.block
 import Text.HTML.TagSoup
 
 main :: IO ()
@@ -1955,7 +1955,7 @@ main :: IO ()
 main = print $ parseTags tags
 </code></pre>
 | ^^^^^^^^^^^ meta.disable-markdown
-|        ^^^ meta.tag.block.any.html entity.name.tag.block.any.html
+|        ^^^ meta.tag.block entity.name.tag.block
 okay
 | <- - meta.disable-markdown
 
@@ -2193,7 +2193,7 @@ non-disabled markdown
 <div>this is HTML until there are two blank lines
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
 still <span>HTML</span>
-|      ^^^^ meta.tag.inline.any.html entity.name.tag.inline.any.html
+|      ^^^^ meta.tag.inline entity.name.tag.inline
 </div>
 | ^^^^ meta.disable-markdown
 
@@ -2201,14 +2201,14 @@ non-disabled markdown
 | <- - meta.disable-markdown
 
 <pre>nested tags don't count <pre>test</pre>
-|                                     ^^^^^^ meta.disable-markdown meta.tag.block.any.html
+|                                     ^^^^^^ meta.disable-markdown meta.tag.block
 non-disabled markdown
 | <- - meta.disable-markdown
 
 <div>nested tags don't count <div>test
 |                                 ^^^^^ meta.disable-markdown
 </div>
-| ^^^ meta.disable-markdown entity.name.tag.block.any.html
+| ^^^ meta.disable-markdown entity.name.tag.block
 
 non-disabled markdown
 | <- - meta.disable-markdown
@@ -2223,7 +2223,7 @@ non-disabled markdown
 
 <div>another</div> <span>disable</span> test
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.disable-markdown
-|                  ^^^^^^ meta.tag.inline.any.html
+|                  ^^^^^^ meta.tag.inline
 disabled markdown
 | <- meta.disable-markdown
 
@@ -5387,7 +5387,7 @@ blah*
 | ^ punctuation.definition.raw.begin.markdown
 |      ^ punctuation.definition.raw.end.markdown
 |        ^ - punctuation
-|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline.a.html 
+|          ^^^^^^^^^^^^^^^^^^^ meta.tag.inline
 
 - list item
 
@@ -5648,7 +5648,7 @@ foo
 ## https://spec.commonmark.org/0.30/#example-344
 
 <a href="`">`
-| ^^^^^^^^^ meta.tag.inline.a
+| ^^^^^^^^^ meta.tag.inline
 |           ^ punctuation.definition.raw.begin
 
 | <- invalid.illegal.non-terminated.raw
@@ -6620,38 +6620,38 @@ testing__
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _italic text <SPAN>HTML element</SPAN> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 **bold text <span>HTML element</span> end of bold text**
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.inline
+|                             ^^^^^^^ meta.tag.inline
 
 __bold text <span>HTML element</span> end of bold text__
 | <- punctuation.definition.bold
 |                                                     ^^ punctuation.definition.bold
-|           ^^^^^^ meta.tag.inline.any.html
-|                             ^^^^^^^ meta.tag.inline.any.html
+|           ^^^^^^ meta.tag.inline
+|                             ^^^^^^^ meta.tag.inline
 
 *italic text <span>HTML element</span> end of italic text*
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _italic text <span>HTML element</span> end of italic text_
 | <- punctuation.definition.italic
 |                                                        ^ punctuation.definition.italic
-|            ^^^^^^ meta.tag.inline.any.html
-|                              ^^^^^^^ meta.tag.inline.any.html
+|            ^^^^^^ meta.tag.inline
+|                              ^^^^^^^ meta.tag.inline
 
 _test <span>text_ foobar</span>
 | <- punctuation

--- a/tests/syntax_test_multimarkdown_frontmatter.md
+++ b/tests/syntax_test_multimarkdown_frontmatter.md
@@ -1,12 +1,15 @@
 T: SYNTAX TEST "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
+T: <- meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 Title:   A Sample MultiMarkdown Document
 T: ^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:   ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:    ^^^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Author:  Fletcher T. Penney
 T:^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:    ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:     ^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:     ^^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:       ^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 Date:    February 9, 2011
 Comment: This is a comment intended to demonstrate
          metadata that spans multiple lines, yet
@@ -16,11 +19,13 @@ Test:    And this is a new key-value pair
 With-Dash: Test
 T: ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:       ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:        ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:         ^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 With Space: Test
 T: ^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.key.multimarkdown entity.other.attribute-name.multimarkdown
 T:        ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown punctuation.separator.key-value.multimarkdown
-T:         ^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
+T:         ^ meta.frontmatter.multimarkdown meta.mapping.multimarkdown
+T:          ^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown
 HTML Header: <style>
              body { width:100ex; margin:auto; text-align:justify; }
 T:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.frontmatter.multimarkdown meta.mapping.value.multimarkdown source.css.embedded.html

--- a/tests/syntax_test_multimarkdown_no_frontmatter.md
+++ b/tests/syntax_test_multimarkdown_no_frontmatter.md
@@ -1,0 +1,2 @@
+T:SYNTAX TEST "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
+T: <- meta.paragraph.markdown - meta.frontmatter


### PR DESCRIPTION
## Bug Fixes

* Fix legacy MultiMarkdown frontmatter detection (#700)
* `mdc` snippet now includes trailing newline

## New Features

## Changes
