### PR TITLE
Remove blank spaces critic markup snippets

### DIFF
--- a/snippets/Critic Addition.sublime-snippet
+++ b/snippets/Critic Addition.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{++ ${1:$SELECTION} ++}]]></content>
+	<content><![CDATA[{++${1:$SELECTION}++}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Addition</description>
 </snippet>

--- a/snippets/Critic Comment.sublime-snippet
+++ b/snippets/Critic Comment.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{>> ${1:$SELECTION} <<}]]></content>
+	<content><![CDATA[{>>${1:$SELECTION}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Comment</description>
 </snippet>

--- a/snippets/Critic Deletion.sublime-snippet
+++ b/snippets/Critic Deletion.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{-- $SELECTION --}]]></content>
+	<content><![CDATA[{--$SELECTION--}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Deletion</description>
 </snippet>

--- a/snippets/Critic Highlight.sublime-snippet
+++ b/snippets/Critic Highlight.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{== $SELECTION ==}{>> ${1:comment} <<}]]></content>
+	<content><![CDATA[{==$SELECTION==}{>>${1:comment}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Highlight</description>
 </snippet>

--- a/snippets/Critic Substitution.sublime-snippet
+++ b/snippets/Critic Substitution.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{~~ $SELECTION ~> ${1:substitution} ~~}]]></content>
+	<content><![CDATA[{~~$SELECTION~>${1:substitution}~~}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Substitution</description>
 </snippet>


### PR DESCRIPTION
Hey! 

I believe that for the markup to work properly shouldn't be any blank space between the text and the markup. When you leave spaces on the markup it isn't rendered correctly, specially when it interacts with the other blank spaces. 

On the creator [repo](https://github.com/CriticMarkup/CriticMarkup-toolkit) there are not blank spaces better the desired text to be markup and the markup itself. For example

>Deletions are denoted with a similar syntax. The text to be deleted is surrounded with curly braces and double hyphens.

	Lorem{‐‐ ipsum‐‐} dolor sit amet…

>The word "ipsum" and a space character are marked for deletion in the above example. These deletions are rendered as `<del>` tags in the processed HTML.

	Lorem<del> ipsum</del> dolor sit amet…

The space is select for deletion too, and if there were space between the selected text and the markup this wouldn't work. 