### PR TITLE
v3.1.9 (ST3176)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -31,9 +31,9 @@ jobs:
           - 'x64'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}

--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   syntax_tests:
     name: Sublime Text ${{ matrix.build }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15 # default is 6 hours!
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
           - build: latest
             default_packages: master
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: SublimeText/syntax-test-action@v2
         with:
           build: ${{ matrix.build }}

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -21,14 +21,14 @@ on:
 jobs:
   test:
     name: Sublime Text ${{ matrix.st-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15 # default is 6 hours!
     strategy:
       fail-fast: false
       matrix:
         st-version: [3, 4]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: SublimeText/UnitTesting/actions/setup@v1
         with:
           sublime-text-version: ${{ matrix.st-version }}

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
     name: Deploy Docs to Github Pages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -9,11 +9,11 @@
 			},
 			{
 				"caption": "Fold Section",
-				"command": "mde_fold_section_context"
+				"command": "mde_fold_section"
 			},
 			{
 				"caption": "Unfold Section",
-				"command": "mde_unfold_section_context"
+				"command": "mde_unfold_section"
 			},
 			{
 				"caption": "-",

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["super+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["super+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -146,8 +146,12 @@
 	//
 
 	{
-		"caption": "MarkdownEditing: Toggle Folding Current Section",
+		"caption": "MarkdownEditing: Fold Current Section",
 		"command": "mde_fold_section"
+	},
+	{
+		"caption": "MarkdownEditing: Unold Current Section",
+		"command": "mde_unfold_section"
 	},
 	{
 		"caption": "MarkdownEditing: Fold Level 1 Sections",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,14 +133,21 @@ Adding or removing `#` at the beginning of lines also modifies heading levels im
 
 Irrelevant sections of documents can be folded/collapsed via Command Palette:
 
-*   **MarkdownEditing: Toggle Folding Current Section**  
-    Whether child sections are folded or unfolded as well depends on folding level defined by calling one of the following commands.
+*   **MarkdownEditing: Fold Current Section**  
+    Whether child sections are folded depends on folding level defined by calling one of the following commands.
 
-    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is (un)folded only.
+    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is folded only.
+
+    If `Unfold All Sections` was called before, all child sections are folded.
+
+*   **MarkdownEditing: Unfold Current Section**  
+    Whether child sections are unfolded depends on folding level defined by calling one of the following commands.
+
+    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is unfolded only.
 
     If `Fold Level 1-6 Sections` was called before, all child sections with lower level keep folded when unfolding their parent section.
 
-    If `Unfold All Sections` was called before, all child sections are (un)folded.
+    If `Unfold All Sections` was called before, all child sections are unfolded.
 
 *   **MarkdownEditing: Fold Level 1-6 Sections**  
     Folds all sections of headings of specific level. Also hides lower level headings.
@@ -158,7 +165,8 @@ Folding is bound to following keys by default:
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>0</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>0</kbd> | Unfold all sections
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>1..6</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>1..6</kbd> | Fold sections by level 1..6
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>9</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>9</kbd> | Fold all sections, but keep headings of any level visible
-| <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold/Unfold current section.
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold current section.
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Unfold current section.
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold all sections under headings of a certain level.
 
 ## Automatic Link Url Folding

--- a/messages.json
+++ b/messages.json
@@ -42,5 +42,6 @@
 	"3.1.5": "messages/3.1.5.md",
 	"3.1.6": "messages/3.1.6.md",
 	"3.1.7": "messages/3.1.7.md",
-	"3.1.8": "messages/3.1.8.md"
+	"3.1.8": "messages/3.1.8.md",
+	"3.1.9": "messages/3.1.9.md"
 }

--- a/messages/3.1.9.md
+++ b/messages/3.1.9.md
@@ -5,6 +5,7 @@ feedback you can use [GitHub issues][issues].
 
 ## Bug Fixes
 
+* Remove blank spaces critic markup snippets (#711)
 * Fix duplicate Markdown syntaxes (#717)
 
 ## New Features

--- a/messages/3.1.9.md
+++ b/messages/3.1.9.md
@@ -17,4 +17,8 @@ feedback you can use [GitHub issues][issues].
   This change is required to properly support 3rd-party packages which
   extend default Markdown syntax in ST4.
 
+* Replace "Toggle Folding Current Section" via <kbd>shift+tab</kbd> by 
+  - "Fold Current Section" via <kbd>ctrl+shift+[</kbd>
+  - "Unfold Current Section" via <kbd>ctrl+shift+]</kbd>
+
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.9.md
+++ b/messages/3.1.9.md
@@ -5,8 +5,16 @@ feedback you can use [GitHub issues][issues].
 
 ## Bug Fixes
 
+* Fix duplicate Markdown syntaxes (#717)
+
 ## New Features
 
 ## Changes
+
+* MarkdownEditing no longer disables but augoments ST's default Markdown 
+  package. Hence you'll no longer find MarkdownEditing/Markdown syntax.
+
+  This change is required to properly support 3rd-party packages which
+  extend default Markdown syntax in ST4.
 
 [issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.1.9.md
+++ b/messages/3.1.9.md
@@ -1,0 +1,12 @@
+# MarkdownEditing 3.1.9 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,11 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.progressbar:
   - pymdownx.arithmatex:
+  - pymdownx.magiclink:
+      repo_url_shortener: true
+      repo_url_shorthand: true
+      user: SublimeText-Markdown
+      repo: MarkdownEditing
   - pymdownx.mark:
   - pymdownx.tilde:
   - pymdownx.striphtml:

--- a/plugin.py
+++ b/plugin.py
@@ -32,10 +32,9 @@ else:
         MdeFoldLinksCommand,
         MdeFoldLinksListener,
         MdeFoldSectionCommand,
-        MdeFoldSectionContextCommand,
         MdeShowFoldAllSectionsCommand,
         MdeUnfoldAllSectionsCommand,
-        MdeUnfoldSectionContextCommand,
+        MdeUnfoldSectionCommand,
     )
     from .plugins.footnotes import (
         MdeGatherMissingFootnotesCommand,

--- a/plugin.py
+++ b/plugin.py
@@ -110,8 +110,11 @@ else:
     )
 
     def plugin_loaded():
-        load_logger()
-        on_after_install()
+        def worker():
+            load_logger()
+            on_after_install()
+
+        sublime.set_timeout(worker, 10)
 
     def plugin_unloaded():
         unload_logger()

--- a/plugins/folding.py
+++ b/plugins/folding.py
@@ -208,7 +208,7 @@ class MdeFoldSectionCommand(MdeTextCommand):
     """
     This class describes a `mde_fold_section` command.
 
-    The command folds or unfolds sections at least one caret is within.
+    The command folds sections at least one caret is within.
 
     It's behavior depends on former call of `mde_fold_all_secitons` command and
     the active `mde.folding.target_level` setting respectively.
@@ -222,15 +222,68 @@ class MdeFoldSectionCommand(MdeTextCommand):
         keep folded if their parent section is unfolded.
     """
 
-    def description(self):
-        return "Toggle fold/unfold on current section"
+    def is_enabled(self):
+        view = self.view
+        target_level = folding_target_level(view)
+        for sel in view.sel():
+            section, _ = section_region_and_level(view, sel.a, target_level)
+            if section:
+                return not bool(folded_region(view, section))
+        return False
+
+    def run(self, edit):
+        view = self.view
+        target_level = folding_target_level(view)
+        sections = []
+        for sel in view.sel():
+            if any(s.contains(sel) for s in sections):
+                continue
+            section, _ = section_region_and_level(view, sel.begin(), target_level)
+            if not section:
+                continue
+            folded_section = folded_region(view, section)
+            if not folded_section:
+                sections.append(section)
+
+        view.fold(sections)
+
+        sublime.status_message(
+            "{} region{} folded".format(len(sections), "s" if len(sections) > 1 else "")
+        )
+
+
+class MdeUnfoldSectionCommand(MdeTextCommand):
+    """
+    This class describes a `mde_unfold_section` command.
+
+    The command unfolds sections at least one caret is within.
+
+    It's behavior depends on former call of `mde_fold_all_secitons` command and
+    the active `mde.folding.target_level` setting respectively.
+
+    -1: The whole section, including all child sections is folded and unfolded.
+        The folded region begins after the nearest heading found before a caret's
+        position and ends with the next heading of same level after the caret.
+     0: The region between two the headings enclosing the caret's position
+        is folded or unfolded. That's the so called outline mode.
+    >0: Like (-1) but all child sections of higher level then `target_level`
+        keep folded if their parent section is unfolded.
+    """
+
+    def is_enabled(self):
+        view = self.view
+        target_level = folding_target_level(view)
+        for sel in view.sel():
+            section, _ = section_region_and_level(view, sel.a, target_level)
+            if section:
+                return bool(folded_region(view, section))
+        return False
 
     def run(self, edit):
         view = self.view
         target_level = folding_target_level(view)
         sections = []
         levels = []
-        unfold = False
         for sel in view.sel():
             if any(s.contains(sel) for s in sections):
                 continue
@@ -242,78 +295,25 @@ class MdeFoldSectionCommand(MdeTextCommand):
                 if folded_section != section:
                     level = section_level(view, folded_section.begin())
                 sections.append(folded_section)
-                unfold = True
-            else:
-                sections.append(section)
             levels.append(level)
 
-        if unfold:
-            regions_to_fold = []
-            if target_level > -1:
-                # keep all child sections folded
-                for section, level in zip(sections, levels):
-                    regions_to_fold.extend(
-                        sections_to_fold(view, section, max(target_level, level + 1))
-                    )
-            else:
-                for section in sections:
-                    regions_to_fold.extend(sections_to_fold(view, section, -1))
-
-            view.unfold(sections)
-            view.fold(regions_to_fold + urls_to_fold(view))
-
+        regions_to_fold = []
+        if target_level > -1:
+            # keep all child sections folded
+            for section, level in zip(sections, levels):
+                regions_to_fold.extend(
+                    sections_to_fold(view, section, max(target_level, level + 1))
+                )
         else:
-            view.fold(sections)
+            for section in sections:
+                regions_to_fold.extend(sections_to_fold(view, section, -1))
+
+        view.unfold(sections)
+        view.fold(regions_to_fold + urls_to_fold(view))
 
         sublime.status_message(
-            "{} region{} {}folded".format(
-                len(sections), "s" if len(sections) > 1 else "", "un" if unfold else ""
-            )
+            "{} region{} unfolded".format(len(sections), "s" if len(sections) > 1 else "")
         )
-
-
-class MdeFoldSectionContextCommand(MdeFoldSectionCommand):
-    """
-    This class describes a `mde_fold_section_context` command.
-    """
-
-    def is_visible(self):
-        if not super().is_visible():
-            return False
-        view = self.view
-        target_level = folding_target_level(view)
-        hasSection = False
-        for sel in view.sel():
-            section, _ = section_region_and_level(view, sel.a, target_level)
-            if section:
-                folded = folded_region(view, section)
-                if folded:
-                    return False
-                else:
-                    hasSection = True
-        return hasSection
-
-
-class MdeUnfoldSectionContextCommand(MdeFoldSectionCommand):
-    """
-    This class describes a `mde_unfold_section_context` command.
-    """
-
-    def is_visible(self):
-        if not super().is_visible():
-            return False
-        view = self.view
-        target_level = folding_target_level(view)
-        hasSection = False
-        for sel in view.sel():
-            section, _ = section_region_and_level(view, sel.a, target_level)
-            if section:
-                folded = folded_region(view, section)
-                if folded:
-                    hasSection = True
-                else:
-                    return False
-        return hasSection
 
 
 class MdeShowFoldAllSectionsCommand(MdeTextCommand):

--- a/plugins/folding.py
+++ b/plugins/folding.py
@@ -322,10 +322,11 @@ class MdeShowFoldAllSectionsCommand(MdeTextCommand):
     """
 
     def run(self, edit):
-        view = self.view
-        view.window().run_command(
-            "show_overlay", {"overlay": "command_palette", "text": "MarkdownEditing: Fold"}
-        )
+        window = self.view.window()
+        if window:
+            window.run_command(
+                "show_overlay", {"overlay": "command_palette", "text": "MarkdownEditing: Fold"}
+            )
 
 
 class MdeFoldAllSectionsCommand(MdeTextCommand):

--- a/snippets/Critic Addition.sublime-snippet
+++ b/snippets/Critic Addition.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{++ ${1:$SELECTION} ++}]]></content>
+	<content><![CDATA[{++${1:$SELECTION}++}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Addition</description>
 </snippet>

--- a/snippets/Critic Comment.sublime-snippet
+++ b/snippets/Critic Comment.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{>> ${1:$SELECTION} <<}]]></content>
+	<content><![CDATA[{>>${1:$SELECTION}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Comment</description>
 </snippet>

--- a/snippets/Critic Deletion.sublime-snippet
+++ b/snippets/Critic Deletion.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{-- $SELECTION --}]]></content>
+	<content><![CDATA[{--$SELECTION--}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Deletion</description>
 </snippet>

--- a/snippets/Critic Highlight.sublime-snippet
+++ b/snippets/Critic Highlight.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{== $SELECTION ==}{>> ${1:comment} <<}]]></content>
+	<content><![CDATA[{==$SELECTION==}{>>${1:comment}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Highlight</description>
 </snippet>

--- a/snippets/Critic Substitution.sublime-snippet
+++ b/snippets/Critic Substitution.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{~~ $SELECTION ~> ${1:substitution} ~~}]]></content>
+	<content><![CDATA[{~~$SELECTION~>${1:substitution}~~}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Substitution</description>
 </snippet>

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -11,12 +11,7 @@
 # to help make this syntax definition easier to maintain.
 name: Markdown
 scope: text.html.markdown
-
-file_extensions:
-  - md
-  - mdown
-  - markdown
-  - markdn
+hidden: true
 
 variables:
   atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line

--- a/syntaxes/MultiMarkdown.sublime-syntax
+++ b/syntaxes/MultiMarkdown.sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: MultiMarkdown
 scope: text.html.markdown.multimarkdown
+hidden: true
 
 first_line_match: (?i:^format:\s*complete\s*$)
 

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -158,7 +158,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(11, 470)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([(37, 52), (184, 199), (367, 382), (417, 432)])
 
         # setup test
@@ -170,7 +170,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(11, 470)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding setext heading level 1
@@ -204,7 +204,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(522, 610)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding setext heading level 2
@@ -238,7 +238,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(547, 567)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding by level
@@ -466,7 +466,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold heading
         self.setCaretTo(row, 1)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions(expected_regions)
 
         # fold heading
@@ -494,7 +494,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1 Heading" with caret before folding marker
         self.setCaretTo(1, 11)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (98, 357),
@@ -518,7 +518,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1 Heading" with caret after folding marker
         self.setCaretTo(40, 1)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (98, 357),
@@ -532,7 +532,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1.1 Heading"
         self.setCaretTo(9, 9)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (117, 274),
@@ -547,7 +547,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1.1.2 Heading"
         self.setCaretTo(25, 9)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (117, 274),


### PR DESCRIPTION
## Bug Fixes

* Remove blank spaces critic markup snippets (#711)
* Fix duplicate Markdown syntaxes (#717)

## New Features

## Changes

* MarkdownEditing no longer disables but augoments ST's default Markdown 
  package. Hence you'll no longer find MarkdownEditing/Markdown syntax.

  This change is required to properly support 3rd-party packages which
  extend default Markdown syntax in ST4.

* Replace "Toggle Folding Current Section" via <kbd>shift+tab</kbd> by 
  - "Fold Current Section" via <kbd>ctrl+shift+[</kbd>
  - "Unfold Current Section" via <kbd>ctrl+shift+]</kbd>
