### PR TITLE
v3.1.9 (ST4107)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -30,9 +30,9 @@ jobs:
           - 'x64'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}

--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   syntax_tests:
     name: Sublime Text ${{ matrix.build }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15 # default is 6 hours!
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
           - build: latest
             default_packages: master
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: SublimeText/syntax-test-action@v2
         with:
           build: ${{ matrix.build }}

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -21,14 +21,14 @@ on:
 jobs:
   test:
     name: Sublime Text ${{ matrix.st-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15 # default is 6 hours!
     strategy:
       fail-fast: false
       matrix:
         st-version: [4]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: SublimeText/UnitTesting/actions/setup@v1
         with:
           sublime-text-version: ${{ matrix.st-version }}

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
     name: Deploy Docs to Github Pages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -9,11 +9,11 @@
 			},
 			{
 				"caption": "Fold Section",
-				"command": "mde_fold_section_context"
+				"command": "mde_fold_section"
 			},
 			{
 				"caption": "Unfold Section",
-				"command": "mde_unfold_section_context"
+				"command": "mde_unfold_section"
 			},
 			{
 				"caption": "-",

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["super+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["super+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -678,24 +678,20 @@
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw", "match_all": true }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+["], "command": "mde_fold_section", "context":
 		[
 			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "preceding_text", "operator": "not_regex_match", "operand": "^\\s+", "match_all": true }
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
-	{ "keys": ["shift+tab"], "command": "mde_fold_section", "context":
+	{ "keys": ["ctrl+shift+]"], "command": "mde_unfold_section", "context":
 		[
-			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.raw - markup.list", "match_all": true },
 			{ "key": "setting.mde.keymap_disable.fold_section", "operator": "not_equal", "operand": true },
-			{ "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
 			{ "key": "has_prev_field", "operator": "equal", "operand": false },
-			{ "key": "overlay_visible", "operator": "equal", "operand": false },
-			{ "key": "text", "operator": "regex_contains", "operand": "^(#{1,6}(?!#))|^(-{3,}|={3,})$"}
+			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
 	{ "keys": ["ctrl+shift+tab"], "command": "mde_show_fold_all_sections", "context":

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -146,8 +146,12 @@
 	//
 
 	{
-		"caption": "MarkdownEditing: Toggle Folding Current Section",
+		"caption": "MarkdownEditing: Fold Current Section",
 		"command": "mde_fold_section"
+	},
+	{
+		"caption": "MarkdownEditing: Unold Current Section",
+		"command": "mde_unfold_section"
 	},
 	{
 		"caption": "MarkdownEditing: Fold Level 1 Sections",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,14 +133,21 @@ Adding or removing `#` at the beginning of lines also modifies heading levels im
 
 Irrelevant sections of documents can be folded/collapsed via Command Palette:
 
-*   **MarkdownEditing: Toggle Folding Current Section**  
-    Whether child sections are folded or unfolded as well depends on folding level defined by calling one of the following commands.
+*   **MarkdownEditing: Fold Current Section**  
+    Whether child sections are folded depends on folding level defined by calling one of the following commands.
 
-    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is (un)folded only.
+    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is folded only.
+
+    If `Unfold All Sections` was called before, all child sections are folded.
+
+*   **MarkdownEditing: Unfold Current Section**  
+    Whether child sections are unfolded depends on folding level defined by calling one of the following commands.
+
+    If `Fold All Sections` was called before _("outline mode" is active)_, the region between current and following sibling or child heading is unfolded only.
 
     If `Fold Level 1-6 Sections` was called before, all child sections with lower level keep folded when unfolding their parent section.
 
-    If `Unfold All Sections` was called before, all child sections are (un)folded.
+    If `Unfold All Sections` was called before, all child sections are unfolded.
 
 *   **MarkdownEditing: Fold Level 1-6 Sections**  
     Folds all sections of headings of specific level. Also hides lower level headings.
@@ -158,7 +165,8 @@ Folding is bound to following keys by default:
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>0</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>0</kbd> | Unfold all sections
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>1..6</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>1..6</kbd> | Fold sections by level 1..6
 | <kbd>Ctrl</kbd> + <kbd>k</kbd>, <kbd>Ctrl</kbd> + <kbd>9</kbd> | <kbd>⌥</kbd> + <kbd>k</kbd>, <kbd>⌥</kbd> + <kbd>9</kbd> | Fold all sections, but keep headings of any level visible
-| <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold/Unfold current section.
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold current section.
+| <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Unfold current section.
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Tab</kbd> | <kbd>^</kbd> + <kbd>⇧</kbd> + <kbd>Tab</kbd> | Fold all sections under headings of a certain level.
 
 ## Automatic Link Url Folding

--- a/messages.json
+++ b/messages.json
@@ -42,5 +42,6 @@
 	"3.1.5": "messages/3.1.5.md",
 	"3.1.6": "messages/3.1.6.md",
 	"3.1.7": "messages/3.1.7.md",
-	"3.1.8": "messages/3.1.8.md"
+	"3.1.8": "messages/3.1.8.md",
+	"3.1.9": "messages/3.1.9.md"
 }

--- a/messages/3.1.9.md
+++ b/messages/3.1.9.md
@@ -1,0 +1,25 @@
+# MarkdownEditing 3.1.9 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* Remove blank spaces critic markup snippets (#711)
+* Fix duplicate Markdown syntaxes (#717)
+
+## New Features
+
+## Changes
+
+* MarkdownEditing no longer disables but augoments ST's default Markdown 
+  package. Hence you'll no longer find MarkdownEditing/Markdown syntax.
+
+  This change is required to properly support 3rd-party packages which
+  extend default Markdown syntax in ST4.
+
+* Replace "Toggle Folding Current Section" via <kbd>shift+tab</kbd> by 
+  - "Fold Current Section" via <kbd>ctrl+shift+[</kbd>
+  - "Unfold Current Section" via <kbd>ctrl+shift+]</kbd>
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,11 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.progressbar:
   - pymdownx.arithmatex:
+  - pymdownx.magiclink:
+      repo_url_shortener: true
+      repo_url_shorthand: true
+      user: SublimeText-Markdown
+      repo: MarkdownEditing
   - pymdownx.mark:
   - pymdownx.tilde:
   - pymdownx.striphtml:

--- a/plugin.py
+++ b/plugin.py
@@ -32,10 +32,9 @@ else:
         MdeFoldLinksCommand,
         MdeFoldLinksListener,
         MdeFoldSectionCommand,
-        MdeFoldSectionContextCommand,
         MdeShowFoldAllSectionsCommand,
         MdeUnfoldAllSectionsCommand,
-        MdeUnfoldSectionContextCommand,
+        MdeUnfoldSectionCommand,
     )
     from .plugins.footnotes import (
         MdeGatherMissingFootnotesCommand,
@@ -110,8 +109,11 @@ else:
     )
 
     def plugin_loaded():
-        load_logger()
-        on_after_install()
+        def worker():
+            load_logger()
+            on_after_install()
+
+        sublime.set_timeout(worker, 10)
 
     def plugin_unloaded():
         unload_logger()

--- a/plugins/bootstrap.py
+++ b/plugins/bootstrap.py
@@ -8,85 +8,97 @@ from .color_schemes import clear_color_schemes, clear_invalid_color_schemes, sel
 
 BOOTSTRAP_VERSION = "3.0.3"
 
-package_name = "MarkdownEditing"
+package_name = __package__.split(".")[0]
 
 
-def get_ingored_packages():
-    settings = sublime.load_settings("Preferences.sublime-settings")
-    return settings.get("ignored_packages") or []
-
-
-def save_ingored_packages(ignored_packages):
-    settings = sublime.load_settings("Preferences.sublime-settings")
-    settings.set("ignored_packages", ignored_packages)
-    sublime.save_settings("Preferences.sublime-settings")
-
-
-def disable_native_markdown_package():
-    ignored_packages = get_ingored_packages()
-    if "Markdown" not in ignored_packages:
-        ignored_packages.append("Markdown")
-        save_ingored_packages(ignored_packages)
-
-
-def enable_native_markdown_package():
-    ignored_packages = get_ingored_packages()
-    if "Markdown" in ignored_packages:
-        ignored_packages.remove("Markdown")
-        save_ingored_packages(ignored_packages)
-
-        def reassign():
-            reassign_syntax(
-                "Markdown.sublime-syntax",
-                "Packages/Markdown/Markdown.sublime-syntax",
-            )
-            reassign_syntax(
-                "MultiMarkdown.sublime-syntax",
-                "Packages/Markdown/MultiMarkdown.sublime-syntax",
-            )
-
-        sublime.set_timeout(reassign, 100)
-
-
-def reassign_syntax(current_syntax, new_syntax):
-    for window in sublime.windows():
-        for view in window.views():
-            syntax = view.settings().get("syntax")
-            if syntax and syntax.endswith(current_syntax) and syntax != new_syntax:
-                view.assign_syntax(new_syntax)
-
-
-def bootstrap_syntax_assignments():
+def augment_default_markdown():
     """
-    Reassign syntax to all open Markdown, MultiMarkdown or Plain Text files.
+    Augment ST's default Markdown.sublime-package with MDE's syntaxes.
 
-    Repair syntax assignments of open views after install or upgrade, in case
-    old ones no longer exist.
+    As of ST 4134 builtin Markdown syntax can be used as base syntax for various packages.
+    Hence disabling default package may break at least HAML, Astro, Liquid and probably more.
+
+    To avoid that from happening, MDE creates a Markdown.sublime-package to completely
+    override default package instead. This step prevents MarkdownEditing from extending
+    default Markdown syntax, but it's probably the most safest way to provide all its
+    benefits (additional fenced code blocks) to all other 3rd-party packages.
     """
-    markdown = "Packages/MarkdownEditing/syntaxes/Markdown.sublime-syntax"
-    multimarkdown = "Packages/MarkdownEditing/syntaxes/MultiMarkdown.sublime-syntax"
 
-    for window in sublime.windows():
-        for view in window.views():
-            syntax = view.settings().get("syntax")
-            if syntax:
-                syntax = os.path.basename(syntax)
-                if syntax in ("Markdown.tmLanguage", "Markdown.sublime-syntax"):
-                    view.assign_syntax(markdown)
-                    continue
-                if syntax in ("MultiMarkdown.tmLanguage", "MultiMarkdown.sublime-syntax"):
-                    view.assign_syntax(multimarkdown)
-                    continue
+    dst_path = os.path.join(sublime.installed_packages_path(), "Markdown.sublime-package")
+    if os.path.isfile(dst_path):
+        return
 
-            file_name = view.file_name()
-            if file_name:
-                _, ext = os.path.splitext(file_name)
-                if ext in (".md", ".mdown", ".markdown"):
-                    view.assign_syntax(markdown)
+    from textwrap import dedent
+    from zipfile import ZipFile, ZIP_DEFLATED
+
+    def load_res(syntax):
+        return (
+            sublime.load_resource("/".join(("Packages", package_name, "syntaxes", syntax)))
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+        )
+
+    tmp_path = os.path.join(sublime.installed_packages_path(), "Markdown.tmp")
+    with ZipFile(tmp_path, "w", compression=ZIP_DEFLATED) as pkg:
+        # copy unhidden Markdown syntax and assign default file extensions
+        pkg.writestr(
+            "Markdown.sublime-syntax",
+            load_res("Markdown.sublime-syntax").replace(
+                "\nhidden: true\n",
+                dedent(
+                    """
+
+                    file_extensions:
+                      - md
+                      - mdown
+                      - markdown
+                      - markdn
+                    """
+                ),
+            ),
+        )
+        # copy unhidden MultiMarkdown syntax
+        pkg.writestr(
+            "MultiMarkdown.sublime-syntax",
+            load_res("MultiMarkdown.sublime-syntax").replace("\nhidden: true\n", "\n"),
+        )
+        pkg.writestr(
+            "Shell (for Markdown).sublime-syntax",
+            load_res("Shell (for Markdown).sublime-syntax"),
+        )
+        pkg.writestr(
+            "README.md",
+            dedent(
+                """
+                NOTE
+                ====
+
+                This file is auto generated by MarkdownEditing
+                to augment ST's default Markdown syntax.
+                """
+            ).lstrip(),
+        )
+    os.rename(tmp_path, dst_path)
+
+    prefs = sublime.load_settings("Preferences.sublime-settings")
+    ignored = prefs.get("ignored_packages", [])
+    if ignored and "Markdown" in ignored:
+        ignored.remove("Markdown")
+        prefs.set("ignored_packages", ignored)
+        sublime.save_settings("Preferences.sublime-settings")
+
+
+def restore_default_markdown():
+    try:
+        os.remove(os.path.join(sublime.installed_packages_path(), "Markdown.sublime-package"))
+    except OSError:
+        pass
 
 
 def on_after_install():
-    cache_path = os.path.join(sublime.cache_path(), "MarkdownEditing")
+    augment_default_markdown()
+
+    cache_path = os.path.join(sublime.cache_path(), package_name)
     bootstrapped = os.path.join(cache_path, "bootstrapped")
 
     # Check bootstrapped cookie.
@@ -101,9 +113,6 @@ def on_after_install():
     os.makedirs(cache_path, exist_ok=True)
 
     def async_worker():
-        bootstrap_syntax_assignments()
-        if int(sublime.version()) < 4132:
-            disable_native_markdown_package()
         clear_invalid_color_schemes()
         # Update bootstrap cookie.
         open(bootstrapped, "w").write(BOOTSTRAP_VERSION)
@@ -114,11 +123,10 @@ def on_after_install():
 
 
 def on_before_uninstall():
+    restore_default_markdown()
+
     if "package_control" in sys.modules:
         from package_control import events
 
         if events.remove(package_name):
-            # Native package causes some conflicts.
-            enable_native_markdown_package()
-            # Remove syntax specific color schemes.
             clear_color_schemes()

--- a/snippets/Critic Addition.sublime-snippet
+++ b/snippets/Critic Addition.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{++ ${1:$SELECTION} ++}]]></content>
+	<content><![CDATA[{++${1:$SELECTION}++}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Addition</description>
 </snippet>

--- a/snippets/Critic Comment.sublime-snippet
+++ b/snippets/Critic Comment.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{>> ${1:$SELECTION} <<}]]></content>
+	<content><![CDATA[{>>${1:$SELECTION}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Comment</description>
 </snippet>

--- a/snippets/Critic Deletion.sublime-snippet
+++ b/snippets/Critic Deletion.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{-- $SELECTION --}]]></content>
+	<content><![CDATA[{--$SELECTION--}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Deletion</description>
 </snippet>

--- a/snippets/Critic Highlight.sublime-snippet
+++ b/snippets/Critic Highlight.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{== $SELECTION ==}{>> ${1:comment} <<}]]></content>
+	<content><![CDATA[{==$SELECTION==}{>>${1:comment}<<}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Highlight</description>
 </snippet>

--- a/snippets/Critic Substitution.sublime-snippet
+++ b/snippets/Critic Substitution.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[{~~ $SELECTION ~> ${1:substitution} ~~}]]></content>
+	<content><![CDATA[{~~$SELECTION~>${1:substitution}~~}]]></content>
 	<scope>text.html.markdown - meta.frontmatter - meta.disable-markdown - markup.critic - meta.code-fence - markup.raw - markup.kbd</scope>
 	<description>Markdown Critic Substitution</description>
 </snippet>

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -12,12 +12,7 @@
 name: Markdown
 scope: text.html.markdown
 version: 2
-
-file_extensions:
-  - md
-  - mdown
-  - markdown
-  - markdn
+hidden: true
 
 variables:
   atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line

--- a/syntaxes/MultiMarkdown.sublime-syntax
+++ b/syntaxes/MultiMarkdown.sublime-syntax
@@ -3,6 +3,7 @@
 name: MultiMarkdown
 scope: text.html.markdown.multimarkdown
 version: 2
+hidden: true
 
 extends: Markdown.sublime-syntax
 

--- a/tests/test_folding.py
+++ b/tests/test_folding.py
@@ -158,7 +158,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(11, 470)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([(37, 52), (184, 199), (367, 382), (417, 432)])
 
         # setup test
@@ -170,7 +170,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(11, 470)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding setext heading level 1
@@ -204,7 +204,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(522, 610)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding setext heading level 2
@@ -238,7 +238,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
         self.assertFoldedRegions([(547, 567)])
 
         # unfold heading
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([])
 
     # test folding and unfolding by level
@@ -466,7 +466,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold heading
         self.setCaretTo(row, 1)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions(expected_regions)
 
         # fold heading
@@ -494,7 +494,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1 Heading" with caret before folding marker
         self.setCaretTo(1, 11)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (98, 357),
@@ -518,7 +518,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1 Heading" with caret after folding marker
         self.setCaretTo(40, 1)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (98, 357),
@@ -532,7 +532,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1.1 Heading"
         self.setCaretTo(9, 9)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (117, 274),
@@ -547,7 +547,7 @@ class FoldingTestCase(DereferrablePanelTestCase):
 
         # unfold "1.1.2 Heading"
         self.setCaretTo(25, 9)
-        self.view.run_command("mde_fold_section")
+        self.view.run_command("mde_unfold_section")
         self.assertFoldedRegions([
             (37, 52),
             (117, 274),


### PR DESCRIPTION
## Bug Fixes

* Remove blank spaces critic markup snippets (#711)
* Fix duplicate Markdown syntaxes (#717)

## New Features

## Changes

* MarkdownEditing no longer disables but augoments ST's default Markdown 
  package. Hence you'll no longer find MarkdownEditing/Markdown syntax.

  This change is required to properly support 3rd-party packages which
  extend default Markdown syntax in ST4.

* Replace "Toggle Folding Current Section" via <kbd>shift+tab</kbd> by 
  - "Fold Current Section" via <kbd>ctrl+shift+[</kbd>
  - "Unfold Current Section" via <kbd>ctrl+shift+]</kbd>
