### PR TITLE
add a separate scope to URL protocol and www

### DIFF
--- a/messages/next.md
+++ b/messages/next.md
@@ -1,0 +1,13 @@
+# MarkdownEditing {version} Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+  - add a separate scope `markup.underline.link.protocol` to allow synax highlight e.g. `https` in urls separtely from the rest of the url
+  - add a separate scope `markup.underline.link.www` to allow synax highlight `www.` in urls separtely from the rest of the url
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -4045,9 +4045,12 @@ contexts:
     # Github Flavoured Markdown
     # After a valid domain, zero or more non-space non-< characters may follow
     # https://github.github.com/gfm/#autolinks-extension-
-    - match: (?:(?:https|http|ftp)(://)|www\.)[\w-]+
+    - match: (?:(https|http|ftp)(://))(www\.)?[\w-]+|(www\.)[\w-]+
       captures:
-        1: punctuation.separator.path.markdown
+        1: markup.underline.link.protocol
+        2: punctuation.separator.path.markdown
+        3: markup.underline.link.www
+        4: markup.underline.link.www
       push: autolink-inet-unquoted-content
 
   autolink-inet-angled-content:


### PR DESCRIPTION
I wanted to deemphasize protocol highlighting in links (`http`) as well as the usually optional `www.`, so added separate scopes to them

Syntax tests failed locally before my edits, and the number of failed tests didn't change

(btw, got confused by https://github.com/SublimeText-Markdown/MarkdownEditing/blob/master/CONTRIBUTING.md again, if there are no milestones, would you please update the doc to reflect whatever actual scheme you're maintaining in this repo?)
