### PR TITLE
fix fenced akh syntax typo

### DIFF
--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -1029,7 +1029,7 @@ contexts:
     - include: fenced-yaml
     # 3rd-party syntaxes
     - include: fenced-ada
-    - include: fenced-akh
+    - include: fenced-ahk
     - include: fenced-arduino
     - include: fenced-coffee
     - include: fenced-dart
@@ -2029,25 +2029,25 @@ contexts:
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
-  fenced-akh:
+  fenced-ahk:
     - match: |-
          (?x)
           {{fenced_code_block_start}}
-          (?i:\s*(akh))
+          (?i:\s*(ahk))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.akh.markdown-gfm
+        0: meta.code-fence.definition.begin.ahk.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
-      embed: scope:source.akh
+      embed: scope:source.ahk
       embed_scope:
-        markup.raw.code-fence.akh.markdown-gfm
-        source.akh
+        markup.raw.code-fence.ahk.markdown-gfm
+        source.ahk
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.akh.markdown-gfm
+        0: meta.code-fence.definition.end.ahk.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 


### PR DESCRIPTION
Autohotkey got broken with a typo during some old refacoring, reverting it back to `ahk`