### PR TITLE
ST3 next

### DIFF
--- a/schemes/MarkdownEditor-ArcDark.sublime-color-scheme
+++ b/schemes/MarkdownEditor-ArcDark.sublime-color-scheme
@@ -380,6 +380,12 @@
 			"scope": "markup.prompt",
 			"foreground": "#aaaaaa"
 		},
+		{
+			"name": "Markup: Highlight",
+			"scope": "markup.highlight",
+			"foreground": "var(critic_highlight_fg)",
+			"background": "var(critic_highlight_bg)"
+		},
 
 		//
 		// CriticMarkup

--- a/schemes/MarkdownEditor-Dark.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Dark.sublime-color-scheme
@@ -392,6 +392,12 @@
 			"scope": "markup.prompt",
 			"foreground": "#aaaaaa"
 		},
+		{
+			"name": "Markup: Highlight",
+			"scope": "markup.highlight",
+			"foreground": "var(critic_highlight_fg)",
+			"background": "var(critic_highlight_bg)"
+		},
 
 		//
 		// CriticMarkup

--- a/schemes/MarkdownEditor-Focus.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Focus.sublime-color-scheme
@@ -411,6 +411,12 @@
 			"scope": "markup.prompt",
 			"foreground": "#555555"
 		},
+		{
+			"name": "Markup: Highlight",
+			"scope": "markup.highlight",
+			"foreground": "var(critic_highlight_fg)",
+			"background": "var(critic_highlight_bg)"
+		},
 
 		//
 		// CriticMarkup

--- a/schemes/MarkdownEditor-Yellow.sublime-color-scheme
+++ b/schemes/MarkdownEditor-Yellow.sublime-color-scheme
@@ -390,6 +390,12 @@
 			"scope": "markup.prompt",
 			"foreground": "#705442"
 		},
+		{
+			"name": "Markup: Highlight",
+			"scope": "markup.highlight",
+			"foreground": "var(critic_highlight_fg)",
+			"background": "var(critic_highlight_bg)"
+		},
 
 		//
 		// CriticMarkup

--- a/schemes/MarkdownEditor.sublime-color-scheme
+++ b/schemes/MarkdownEditor.sublime-color-scheme
@@ -389,6 +389,12 @@
 			"scope": "markup.prompt",
 			"foreground": "#555555"
 		},
+		{
+			"name": "Markup: Highlight",
+			"scope": "markup.highlight",
+			"foreground": "var(critic_highlight_fg)",
+			"background": "var(critic_highlight_bg)"
+		},
 
 		//
 		// CriticMarkup

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -3780,7 +3780,7 @@ contexts:
     - meta_scope: meta.link.inet.markdown markup.underline.link.markdown-gfm
     # 1. When an autolink ends in ), we scan the entire autolink for the total
     #    number of parentheses. If there is a greater number of closing parentheses
-    #    than opening ones, we don’t consider the last character part of the
+    #    than opening ones, we don't consider the last character part of the
     #    autolink, in order to facilitate including an autolink inside a parenthesis
     # 2. If an autolink ends in a semicolon (;), we check to see if it appears to
     #    resemble an entity reference; if the preceding text is & followed by one


### PR DESCRIPTION
- add ==highlight== color scheme rules
- replace utf-8 incompatible char in Markdown.sublime-syntax, causing trouble with auto-generating syntax packages and syntax tests.