### PR TITLE
Syntax: Add support for KDL fenced code blocks

### DIFF
--- a/messages/next.md
+++ b/messages/next.md
@@ -1,0 +1,13 @@
+# MarkdownEditing {version} Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+  - Syntax: Add support for KDL fenced code blocks - auto-v1/2-selection variant `kdl` as well as forced v1/v2 variants `kdl1` and `kdl2`
+
+## Changes
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -1167,6 +1167,9 @@ contexts:
     - include: fenced-jade
     - include: fenced-julia
     - include: fenced-kotlin
+    - include: fenced-kdl
+    - include: fenced-kdl1
+    - include: fenced-kdl2
     - include: fenced-less
     - include: fenced-mermaid
     - include: fenced-nim
@@ -2461,6 +2464,72 @@ contexts:
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
         0: meta.code-fence.definition.end.kotlin.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
+
+  fenced-kdl:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          (?i:\s*(kdl))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.kdl.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
+      embed: scope:text.kdl
+      embed_scope:
+        markup.raw.code-fence.kdl.markdown-gfm
+        text.kdl
+      escape: '{{fenced_code_block_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.kdl.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
+
+  fenced-kdl1:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          (?i:\s*(kdl1))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.kdl.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
+      embed: scope:text.kdl.1
+      embed_scope:
+        markup.raw.code-fence.kdl.markdown-gfm
+        text.kdl.1
+      escape: '{{fenced_code_block_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.kdl.markdown-gfm
+        1: punctuation.definition.raw.code-fence.end.markdown
+        2: meta.fold.code-fence.end.markdown
+
+  fenced-kdl2:
+    - match: |-
+         (?x)
+          {{fenced_code_block_start}}
+          (?i:\s*(kdl2))
+          {{fenced_code_block_trailing_infostring_characters}}
+      captures:
+        0: meta.code-fence.definition.begin.kdl.markdown-gfm
+        2: punctuation.definition.raw.code-fence.begin.markdown
+        5: constant.other.language-name.markdown
+        6: comment.line.infostring.markdown
+        7: meta.fold.code-fence.begin.markdown
+      embed: scope:text.kdl.2
+      embed_scope:
+        markup.raw.code-fence.kdl.markdown-gfm
+        text.kdl.2
+      escape: '{{fenced_code_block_escape}}'
+      escape_captures:
+        0: meta.code-fence.definition.end.kdl.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 


### PR DESCRIPTION
 auto-v1/2-selection variant `kdl` as well as forced v1/v2 variants `kdl1` and `kdl2`