### PR TITLE
Next

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1462,6 +1462,18 @@
 		]
 	},
 
+	// navigate between critics
+	{ "keys": ["alt+c", "alt+down"], "command": "mde_goto_next_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+	{ "keys": ["alt+c", "alt+up"], "command": "mde_goto_prev_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+
 	//
 	// Wiki
 	//

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1084,6 +1084,12 @@
 			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
+	// Reset GFM tasks
+	{ "keys": ["alt+shift+x"], "command": "mde_reset_task_list_items", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
 	// Toggle GFM tasks
 	{ "keys": ["alt+x"], "command": "mde_toggle_task_list_item", "context":
 		[

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1462,6 +1462,18 @@
 		]
 	},
 
+	// navigate between critics
+	{ "keys": ["super+alt+c", "super+alt+down"], "command": "mde_goto_next_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+	{ "keys": ["super+alt+c", "super+alt+up"], "command": "mde_goto_prev_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+
 	//
 	// Wiki
 	//

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1084,6 +1084,12 @@
 			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
+	// Reset GFM tasks
+	{ "keys": ["alt+shift+x"], "command": "mde_reset_task_list_items", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
 	// Toggle GFM tasks
 	{ "keys": ["alt+x"], "command": "mde_toggle_task_list_item", "context":
 		[

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1462,6 +1462,18 @@
 		]
 	},
 
+	// navigate between critics
+	{ "keys": ["alt+c", "alt+down"], "command": "mde_goto_next_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+	{ "keys": ["alt+c", "alt+up"], "command": "mde_goto_prev_critic", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
+
 	//
 	// Wiki
 	//

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1084,6 +1084,12 @@
 			{ "key": "overlay_visible", "operator": "equal", "operand": false }
 		]
 	},
+	// Reset GFM tasks
+	{ "keys": ["alt+shift+x"], "command": "mde_reset_task_list_items", "context":
+		[
+			{ "key": "selector", "operator": "equal", "operand": "text.html.markdown", "match_all": true }
+		]
+	},
 	// Toggle GFM tasks
 	{ "keys": ["alt+x"], "command": "mde_toggle_task_list_item", "context":
 		[

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -263,6 +263,19 @@
 	},
 
 	//
+	// CriticMarkup
+	//
+
+	{
+		"caption": "MarkdownEditing: Goto Next Critic",
+		"command": "mde_goto_next_critic"
+	},
+	{
+		"caption": "MarkdownEditing: Goto Previous Critic",
+		"command": "mde_goto_prev_critic"
+	},
+
+	//
 	// Wiki
 	//
 

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -206,6 +206,23 @@
 	},
 
 	//
+	// Tasks
+	//
+
+	{
+		"caption": "MarkdownEditing: Insert Task",
+		"command": "mde_insert_task_list_item"
+	},
+	{
+		"caption": "MarkdownEditing: Toggle Task",
+		"command": "mde_toggle_task_list_item"
+	},
+	{
+		"caption": "MarkdownEditing: Reset Tasks",
+		"command": "mde_reset_task_list_items"
+	},
+
+	//
 	// References
 	//
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,7 +250,7 @@ Further available key bindings:
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>,</kbd>  | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>,</kbd> | Decrease block quote level (remove a `> `)
 | <kbd>Ctrl</kbd> + <kbd>Enter</kbd>  | <kbd>⌘</kbd> + <kbd>Enterkbd> | Terminate block quote by adding two newline's.<br/>If the current line is empty, block quote signs are removed.
 
-# Lists and Tasks
+# Lists
 
 List bullets are automatically changed when indenting or unindenting list items by default. This behaviour can be disabled via `"mde.list_indent_auto_switch_bullet": false`.
 
@@ -261,12 +261,24 @@ Following commands are provided via Command Palette:
 *   **Switch List Bullet Type**
     Switches the highlighted list between numbered and bulleted style.
 
+# Tasks
+
+Following commands are provided via Command Palette to manage tasks:
+
+*   **Insert Task**
+    Creates new GFM task (`* [ ] task`)
+*   **Toggle Task**
+    Toggles GFM task check marks (`* [x] task`)
+*   **Reset Tasks**
+    Clear all task check boxes. If non-empty selection exists, only selected tasks are reset.
+
 Following key bindings may be used to create or toggle tasks.
 
 | Linux/Windows | MacOS | Description
 |---------------|-------|-------------
 | <kbd>Alt</kbd> + <kbd>t</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>t</kbd> | Creates new GFM task (`* [ ] task`)
-| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [x] task`)
+| <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>x</kbd>  | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>x</kbd> | Clear GFM all (selected) task check marks (`* [0] task`)
+| <kbd>Alt</kbd> + <kbd>x</kbd>  | <kbd>⌥</kbd> + <kbd>x</kbd> | Toggles GFM task check marks (`* [x] task`)
 
 # References
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -321,6 +321,11 @@ Important functions are bound to following keys by default:
 
 MarkdownEditing supports document review by highlighting critic markup and enable adding critic or accepting and rejecting proposed changes via key bindings.
 
+| Linux/Windows | MacOS | Description
+|---------------|-------|-------------
+| <kbd>Alt</kbd> + <kbd>c</kbd>, <kbd>Alt</kbd> + <kbd>down</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>c</kbd>,  <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>down</kbd> | Jump to next critic marker.
+| <kbd>Alt</kbd> + <kbd>c</kbd>, <kbd>Alt</kbd> + <kbd>up</kbd>  | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>c</kbd>,  <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>up</kbd> | Jump to previous critic marker.
+
 ## Reviewer
 
 A document reviewer can insert critic or propose changes for single words or selections with following key bindings:

--- a/make.cmd
+++ b/make.cmd
@@ -53,23 +53,12 @@ goto :usage
 :RELEASE
     if "%2"== "" goto :usage
 
-    git checkout st3176 && git merge st3-develop --no-ff
-    if not errorlevel 0 (
-        echo Unable to merge st3-develop into st3176!
-        exit /b 1
-    )
     git checkout master && git merge st4-develop --no-ff
     if not errorlevel 0 (
         echo Unable to merge st4-develop into master!
         exit /b 1
     )
-    echo Hit any key to push branches!
-    pause
-    call git push origin st3176
-    if not errorlevel 0 (
-        echo Failed to push st3176!
-        exit /b 1
-    )
+
     call git push origin master
     if not errorlevel 0 (
         echo Failed to push master!
@@ -80,22 +69,13 @@ goto :usage
 
     echo Createing assets for "%package%"...
 
-    :: create downloadable asset for ST4126+
-    set build=3176
-    set archive=%package%-%2-st%build%.sublime-package
-    set assets="%archive%#%archive%"
-    call git tag -f %build%-%2 st%build%
-    call git archive --format zip -o "%archive%" %build%-%2
-
     :: create downloadable asset for ST4134+
     set build=4107
     set archive=%package%-%2-st%build%.sublime-package
-    set assets=%assets% "%archive%#%archive%"
-    call git tag -f %build%-%2 master
-    call git archive --format zip -o "%archive%" %build%-%2
+    set assets="%archive%#%archive%"
+    call git archive --format zip -o "%archive%" master
 
     :: create the release
-    call git push --tags --force
     gh release create --target master -t "%package% %2" "%build%-%2" %assets%
     del /f /q *.sublime-package
     git fetch

--- a/messages.json
+++ b/messages.json
@@ -48,5 +48,7 @@
 	"3.1.11": "messages/3.1.11.md",
 	"3.1.12": "messages/3.1.12.md",
 	"3.1.13": "messages/3.1.13.md",
-	"3.1.14": "messages/3.1.14.md"
+	"3.1.14": "messages/3.1.14.md",
+	"3.2.0": "messages/3.2.0.md",
+	"3.3.0": "messages/3.3.0.md"
 }

--- a/messages/3.2.0.md
+++ b/messages/3.2.0.md
@@ -1,0 +1,17 @@
+# MarkdownEditing 3.2.0 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+* add support for auto-folding headings when loading document
+* add support for pandoc fenced divs
+
+## Changes
+
+* merge shellscript related fenced code block contexts
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/messages/3.3.0.md
+++ b/messages/3.3.0.md
@@ -1,0 +1,22 @@
+# MarkdownEditing 3.3.0 Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+* fix `==highlight==` not being scoped at beginning of paragraphs (#789)
+
+## New Features
+
+* add `Reset Task Items` (#786)
+* add `Goto Next Critic` and `Goto Previous Critic` (#787)
+
+## Changes
+
+* drop support for ST3 (latest available version for ST3 is 3.2.0)
+* align frontmatter punctuation scopes with ST's default Markdown syntax
+* align code fence scopes with ST's default Markdown syntax
+* optimize paragraph termination patterns to improve parsing performance
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/plugin.py
+++ b/plugin.py
@@ -27,6 +27,10 @@ else:
     from .plugins.color_schemes import (
         MdeSelectColorSchemeCommand,
     )
+    from .plugins.critic import (
+        MdeGotoNextCriticCommand,
+        MdeGotoPrevCriticCommand
+    )
     from .plugins.folding import (
         MdeAutoFoldListener,
         MdeFoldAllSectionsCommand,

--- a/plugin.py
+++ b/plugin.py
@@ -67,6 +67,7 @@ else:
         MdeNumberListCommand,
         MdeSwitchListBulletTypeCommand,
         MdeInsertTaskListItemCommand,
+        MdeResetTaskListItemsCommand,
         MdeToggleTaskListItemCommand,
         MdeJoinLines,
     )

--- a/plugins/critic.py
+++ b/plugins/critic.py
@@ -1,0 +1,37 @@
+import sublime_plugin
+
+from bisect import bisect_left, bisect_right
+
+
+class MdeGotoNextCriticCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        sel = self.view.sel()
+        if not sel:
+            return
+
+        critics = self.view.find_by_selector("markup.critic")
+        if not critics:
+            return
+
+        idx = bisect_right(critics, sel[0])
+        sel = critics[idx] if idx < len(critics) else critics[0]
+        self.view.sel().clear()
+        self.view.sel().add(sel)
+        self.view.show_at_center(sel)
+
+
+class MdeGotoPrevCriticCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        sel = self.view.sel()
+        if not sel:
+            return
+
+        critics = self.view.find_by_selector("markup.critic")
+        if not critics:
+            return
+
+        idx = bisect_left(critics, sel[0]) - 1
+        sel = critics[idx] if idx >= 0 else critics[-1]
+        self.view.sel().clear()
+        self.view.sel().add(sel)
+        self.view.show_at_center(sel)

--- a/plugins/critic.py
+++ b/plugins/critic.py
@@ -1,9 +1,8 @@
-import sublime_plugin
-
 from bisect import bisect_left, bisect_right
+from .view import MdeTextCommand
 
 
-class MdeGotoNextCriticCommand(sublime_plugin.TextCommand):
+class MdeGotoNextCriticCommand(MdeTextCommand):
     def run(self, edit):
         sel = self.view.sel()
         if not sel:
@@ -20,7 +19,7 @@ class MdeGotoNextCriticCommand(sublime_plugin.TextCommand):
         self.view.show_at_center(sel)
 
 
-class MdeGotoPrevCriticCommand(sublime_plugin.TextCommand):
+class MdeGotoPrevCriticCommand(MdeTextCommand):
     def run(self, edit):
         sel = self.view.sel()
         if not sel:

--- a/plugins/lists.py
+++ b/plugins/lists.py
@@ -196,6 +196,49 @@ class MdeInsertTaskListItemCommand(MdeTextCommand):
             self.view.insert(edit, sel.begin(), to_insert)
 
 
+class MdeResetTaskListItemsCommand(MdeTextCommand):
+    """
+    The `mde_reset_task_list_items` command resets check mark of all task list items.
+
+    It must be called in the line of the check mark.
+
+    **Examples:**
+
+    ```markdown
+    # Ordered Task List
+
+    1. [ ] task 1
+    2. [x] task 2
+
+    # Unordered Task List
+
+    * [ ] task 1
+    - [x] task 2
+    + [ ] task 3
+
+    # Quoted Task List
+
+    > * [ ] task 1
+    > * [x] task 2
+    ```
+    """
+
+    def run(self, edit):
+        sels = self.view.sel()
+        if not sels:
+            return
+
+        # list of non-empty selections
+        sels = [sel for sel in sels if not sel.empty()]
+
+        # replace all check marks by space
+        for mark in self.view.find_by_selector(
+            "text.html.markdown markup.list markup.checkbox.mark"
+        ):
+            if not sels or any(mark in sel for sel in sels):
+                self.view.replace(edit, mark, " ")
+
+
 class MdeToggleTaskListItemCommand(MdeTextCommand):
     """
     The `mde_toggle_task_list_item` command toggles the check mark of task list items.

--- a/syntaxes/Fold.tmPreferences
+++ b/syntaxes/Fold.tmPreferences
@@ -31,6 +31,14 @@
 				<key>excludeTrailingNewlines</key>
 				<false/>
 			</dict>
+			<dict>
+				<key>begin</key>
+				<string>punctuation.section.frontmatter.begin.markdown</string>
+				<key>end</key>
+				<string>punctuation.section.frontmatter.end.markdown</string>
+				<key>excludeTrailingNewlines</key>
+				<true/>
+			</dict>
 		</array>
 	</dict>
 </dict>

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -84,14 +84,14 @@ variables:
       )
       (\s*$\n?)      # any amount of whitespace until EOL (fold end marker)
     )
+
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
   # https://pandoc.org/MANUAL.html#divs-and-spans
   fenced_div_block: ':{3,}'
 
-  # https://spec.commonmark.org/0.30/#email-autolink
-  email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
-  email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
+  # HTML blocks
+  # ===========
 
   # https://spec.commonmark.org/0.30/#html-blocks
   html_block: |-
@@ -155,6 +155,7 @@ variables:
     | section | source | summary | table | tbody | td | tfoot | th
     | thead | title | tr | track | ul
     ){{html_tag_maybe_selfclosing_break_char}}
+
   html_tag_break_char: (?:[ \t>]|$)
   html_tag_maybe_selfclosing_break_char: (?:[ \t]|/?>|$)
 
@@ -385,6 +386,13 @@ variables:
          \* {{no_space_nor_punct}}
     | \B \* {{no_space_but_punct}}
     )
+
+  # Links
+  # =====
+
+  # https://spec.commonmark.org/0.30/#email-autolink
+  email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
+  email_user_commonmark: '[a-zA-Z0-9.!#$%&''*+/=?^_`{|}~-]+'
 
   # Prototypes
   # ==========

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -561,7 +561,7 @@ contexts:
     - include: block-quote-link-definitions
 
   block-quote-footnote-definitions:
-    # Mardown Extras Footnotes
+    # Markdown Extras Footnotes
     - match: '([ \t]*)(\[)({{footnote_name}})(\])(:)'
       captures:
         2: punctuation.definition.reference.begin.markdown
@@ -3036,7 +3036,7 @@ contexts:
     - include: link-definitions
 
   footnote-definitions:
-    # Mardown Extras Footnotes
+    # Markdown Extras Footnotes
     - match: '([ \t]*)(\[)({{footnote_name}})(\])(:)'
       captures:
         2: punctuation.definition.reference.begin.markdown
@@ -4017,7 +4017,7 @@ contexts:
         3: punctuation.separator.path.markdown
         4: punctuation.separator.path.markdown
         5: punctuation.definition.link.end.markdown
-    # Github Flavoured Markdown
+    # GitHub Flavoured Markdown
     - match: '[\w.+-]+(@)[\w-]+(?:\.(?:(?![._-][\W])[\w_-])+)+(?![_-])'
       captures:
         0: meta.link.email.markdown markup.underline.link.markdown
@@ -4031,7 +4031,7 @@ contexts:
       push:
         - autolink-inet-angled-content
         - link-url-scheme-separator
-    # Github Flavoured Markdown
+    # GitHub Flavoured Markdown
     # After a valid domain, zero or more non-space non-< characters may follow
     # https://github.github.com/gfm/#autolinks-extension-
     - match: (?:(?:https|http|ftp)(://)|www\.)[\w-]+
@@ -4369,7 +4369,7 @@ contexts:
       captures:
         1: punctuation.section.div.begin.markdown
       push:
-        - fenced-div-puncuation
+        - fenced-div-punctuation
         - fenced-div-attr
 
   fenced-div-attr:
@@ -4384,7 +4384,7 @@ contexts:
         - tag-attr-name
     - match: else-pop
 
-  fenced-div-puncuation:
+  fenced-div-punctuation:
     - meta_include_prototype: false
     - meta_scope: meta.div.markdown
     - match: ':+'

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -19,17 +19,17 @@ variables:
   atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
 
-  setext_heading_or_paragraph: ^(?:[ ]{,3}=+|(?=[ ]{,3}\S))   # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)         # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
-  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)               # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
+  setext_heading_or_paragraph: ^(?:[ ]{,3}=+[ \t]*$|(?=[ ]{,3}\S))    # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)                 # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
+  setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)                       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
-  list_setext_heading_or_paragraph: (?:[ \t]*=+|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
-  list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$) # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*$(\n?)        # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*$(\n?)        # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading_or_paragraph: (?:[ \t]*=+[ \t]*$|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
+  list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$)        # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*$(\n?)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*$(\n?)               # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
 
   block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -166,24 +166,6 @@ variables:
   tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
   tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
 
-  reference_definition: (?:\[{{reference_name}}\]\:)
-  footnote_name: (?:\^(?:\\\]|[^]])+)
-  reference_name: (?:(?:\\\]|[^]])+)
-
-  blockquote_footnote_end: |-
-    (?x: # pop out of this context if one of the following conditions are met:
-      ^(?= (?:[ \t]*>)* [ \t]*
-        (?: $                           # the line is blank (or only contains whitespace)
-        |   {{reference_definition}}    # a reference definition begins the line
-        |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block}}       # a fenced codeblock begins the line
-        |   {{fenced_div_block}}        # a fenced div block begins the line
-        |   {{thematic_break}}          # line is a thematic beak
-        |   {{list_item}}               # a list item begins the line
-        |   {{html_block}}              # a html block begins the line
-        )
-      )
-    )
 
   blockquote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
@@ -203,22 +185,6 @@ variables:
     (?x: # pop out of this context if one of the following conditions are met:
       ^(?= (?:[ \t]*>)* [ \t]*
         (?: $                           # the line is blank (or only contains whitespace)
-        |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block}}       # a fenced codeblock begins the line
-        |   {{fenced_div_block}}        # a fenced div block begins the line
-        |   {{thematic_break}}          # line is a thematic beak
-        |   {{list_item}}               # a list item begins the line
-        |   {{html_block}}              # a html block begins the line
-        )
-      )
-    )
-
-  footnote_end: |-
-    (?x: # pop out of this context if one of the following conditions are met:
-      ^(?= [ \t]*
-        (?: $                           # the line is blank (or only contains whitespace)
-        |   {{reference_definition}}    # a reference definition begins the line
-        |   {{block_quote}}             # a blockquote begins the line
         |   {{atx_heading}}             # an ATX heading begins the line
         |   {{fenced_code_block}}       # a fenced codeblock begins the line
         |   {{fenced_div_block}}        # a fenced div block begins the line
@@ -258,6 +224,45 @@ variables:
         )
       )
     )
+
+  # References and Footnotes
+  # ========================
+
+  blockquote_footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_name: (?:\^(?:\\\]|[^]])+)
+
+  reference_definition: (?:\[{{reference_name}}\]\:)
+  reference_name: (?:(?:\\\]|[^]])+)
 
   # Tables
   # ======

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -103,31 +103,6 @@ variables:
     | __        {{balance_square_brackets_and_emphasis}}__
     )
 
-  table_cell: |-
-    (?x:
-      # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
-      # emphasis in table cells can't span multiple lines
-      (?:
-        {{balance_square_brackets_pipes_and_emphasis}}
-      | {{balanced_emphasis}}
-      )+  # at least one character
-    )
-  table_first_row: |-
-    (?x:
-      # at least 2 non-escaped pipe chars on the line
-      (?:{{table_cell}}?\|){2}
-
-      # something other than whitespace followed by a pipe char or hyphen,
-      # followed by something other than whitespace and the end of the line
-    | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
-    )
-
-  table_codespan_content: |-
-    (?x:
-      [^`|]             # first or only char must not be a backtick or pipe.
-      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
-    )
-
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -338,6 +313,35 @@ variables:
         |   {{html_block}}              # a html block begins the line
         )
       )
+    )
+
+  # Tables
+  # ======
+
+  table_first_row: |-
+    (?x:
+      # at least 2 non-escaped pipe chars on the line
+      (?:{{table_cell}}?\|){2}
+
+      # something other than whitespace followed by a pipe char or hyphen,
+      # followed by something other than whitespace and the end of the line
+    | (?! \s*\-\s+ | \s+\|){{table_cell}}\|(?!\s+$)
+    )
+
+  table_cell: |-
+    (?x:
+      # Pipes inside other inline spans (such as emphasis, code, etc.) will not break a cell,
+      # emphasis in table cells can't span multiple lines
+      (?:
+        {{balance_square_brackets_pipes_and_emphasis}}
+      | {{balanced_emphasis}}
+      )+  # at least one character
+    )
+
+  table_codespan_content: |-
+    (?x:
+      [^`|]             # first or only char must not be a backtick or pipe.
+      (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
     )
 
   table_end: |-

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -47,6 +47,9 @@ variables:
       [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
     )
 
+  # Fenced code blocks
+  # ==================
+
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -54,11 +57,13 @@ variables:
     |              # or
       (~){3,}      #   3 or more tildas
     )
+
   fenced_code_block_start: |-
     (?x:
       ([ \t]*)
       ({{fenced_code_block}})
     )
+
   fenced_code_block_language: |-
     (?x:             # first word of an infostring is used as language specifier
       \s*            # allow for whitespace between code block start and info string
@@ -67,6 +72,7 @@ variables:
         [^\s:;`]*    # optionally followed by any nonwhitespace character (except backticks)
       )
     )
+
   fenced_code_block_trailing_infostring_characters: |-
     (?x:
       (?:
@@ -75,6 +81,7 @@ variables:
       )?
       (\s*$\n?)              # ... until EOL (fold begin marker)
     )
+
   fenced_code_block_end: |-
     (?x:
       [ \t]*
@@ -167,6 +174,8 @@ variables:
   tag_unquoted_attribute_start: (?=[^{{ascii_space}}=/>}])
   tag_unquoted_attribute_break: (?=[{{ascii_space}}}]|/?>)
 
+  # Pragraphs
+  # =========
 
   blockquote_paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -644,7 +644,7 @@ contexts:
           {{fenced_code_block_language}}?
           .*?(\s*$\n?)   # all characters until EOL
       captures:
-        0: meta.code-fence.definition.begin.text.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: meta.fold.code-fence.begin.markdown
@@ -663,7 +663,7 @@ contexts:
     - include: block-quote-end
     - match: '{{fenced_code_block_end}}'
       captures:
-        0: meta.code-fence.definition.end.text.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
       pop: 1
@@ -1283,18 +1283,19 @@ contexts:
           (?i:\s*(actionscript|as))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.actionscript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.actionscript.2
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.actionscript.markdown-gfm
         source.actionscript.2
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.actionscript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1305,18 +1306,19 @@ contexts:
           (?i:\s*(applescript|osascript|scpt))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.applescript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.applescript
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.applescript.markdown-gfm
         source.applescript
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.applescript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1327,18 +1329,19 @@ contexts:
           (?i:\s*(clojure|clj))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.clojure.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.clojure
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.clojure.markdown-gfm
         source.clojure
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.clojure.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1349,18 +1352,19 @@ contexts:
           (?i:\s*(c|h))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.c.markdown-gfm
         source.c
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1371,18 +1375,19 @@ contexts:
           (?i:\s*(c\+\+|cc|cpp|cxx|h\+\+|hpp|hxx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.c++.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.c++
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.c++.markdown-gfm
         source.c++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.c++.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1393,18 +1398,19 @@ contexts:
           (?i:\s*(csharp|c\#|cs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.csharp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.cs
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.csharp.markdown-gfm
         source.cs
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.csharp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1415,18 +1421,19 @@ contexts:
           (?i:\s*(css))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.css.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.css
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.css.markdown-gfm
         source.css
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.css.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1437,18 +1444,19 @@ contexts:
           (?i:\s*(u?diff|patch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.diff.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.diff
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.diff.markdown-gfm
         source.diff
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.diff.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1459,18 +1467,19 @@ contexts:
           (?i:\s*(bat(?:ch(?:file)?)?|cmd|(?:dos|win)batch))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.dosbatch.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dosbatch
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.dosbatch.markdown-gfm
         source.dosbatch
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.dosbatch.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1481,18 +1490,19 @@ contexts:
           (?i:\s*(erl(?:ang)?|escript))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.erlang.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.erlang
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.erlang.markdown-gfm
         source.erlang
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.erlang.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1503,18 +1513,19 @@ contexts:
           (?i:\s*(dot|graphviz|gv))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.graphviz.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dot
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.graphviz.markdown-gfm
         source.dot
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.graphviz.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1525,18 +1536,19 @@ contexts:
           (?i:\s*(groovy))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.groovy.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.groovy
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.groovy.markdown-gfm
         source.groovy
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.groovy.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1547,18 +1559,19 @@ contexts:
           (?i:\s*(go(?:lang)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.go.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.go
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.go.markdown-gfm
         source.go
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.go.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1569,18 +1582,19 @@ contexts:
           (?i:\s*(haskell|hsc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.haskell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.haskell
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.haskell.markdown-gfm
         source.haskell
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.haskell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1591,18 +1605,19 @@ contexts:
           (?i:\s*(html\+php|phtml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.html-php.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:embedding.php
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.html-php.markdown-gfm
         embedding.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.html-php.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1613,18 +1628,19 @@ contexts:
           (?i:\s*(x?html))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.html.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.basic
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.html.markdown-gfm
         text.html.basic
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.html.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1635,18 +1651,19 @@ contexts:
           (?i:\s*(java))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.java.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.java
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.java.markdown-gfm
         source.java
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.java.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1657,18 +1674,19 @@ contexts:
           (?i:\s*(javascript|js|node))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.javascript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.js
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.javascript.markdown-gfm
         source.js
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.javascript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1679,18 +1697,19 @@ contexts:
           (?i:\s*(jsonc?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.json.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.json
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.json.markdown-gfm
         source.json
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.json.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1701,18 +1720,19 @@ contexts:
           (?i:\s*(jspx?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.jsp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.jsp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.jsp.markdown-gfm
         text.html.jsp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.jsp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1723,18 +1743,19 @@ contexts:
           (?i:\s*(jsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.jsx.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.jsx
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.jsx.markdown-gfm
         source.jsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.jsx.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1745,18 +1766,19 @@ contexts:
           (?i:\s*(latex|tex))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.latex.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.tex.latex
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.latex.markdown-gfm
         text.tex.latex
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.latex.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1767,18 +1789,19 @@ contexts:
           (?i:\s*(lisp))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.lisp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lisp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.lisp.markdown-gfm
         source.lisp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.lisp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1789,18 +1812,19 @@ contexts:
           (?i:\s*(lua))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.lua.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.lua
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.lua.markdown-gfm
         source.lua
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.lua.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1811,18 +1835,19 @@ contexts:
           (?i:\s*(make(?:file)?|mf))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.makefile.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.makefile
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.makefile.markdown-gfm
         source.makefile
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.makefile.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1833,18 +1858,19 @@ contexts:
           (?i:\s*(matlab))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.matlab.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.matlab
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.matlab.markdown-gfm
         source.matlab
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.matlab.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1855,18 +1881,19 @@ contexts:
           (?i:\s*(objc|obj-c|objectivec|objective-c))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.objc.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.objc.markdown-gfm
         source.objc
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.objc.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1877,18 +1904,19 @@ contexts:
           (?i:\s*(objc\+\+|obj-c\+\+|objectivec\+\+|objective-c\+\+))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.objc++.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.objc++
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.objc++.markdown-gfm
         source.objc++
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.objc++.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1899,18 +1927,19 @@ contexts:
           (?i:\s*(ocaml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ocaml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ocaml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ocaml.markdown-gfm
         source.ocaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ocaml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1921,18 +1950,19 @@ contexts:
           (?i:\s*(perl5?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.perl.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.perl
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.perl.markdown-gfm
         source.perl
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.perl.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1943,18 +1973,19 @@ contexts:
           (?i:\s*(php|inc))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.php.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.php
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.php.markdown-gfm
         source.php
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.php.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1965,18 +1996,19 @@ contexts:
           (?i:\s*(python3?|py))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.python.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.python
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.python.markdown-gfm
         source.python
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.python.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -1987,18 +2019,19 @@ contexts:
           (?i:\s*(regexp?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.regexp.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.regexp
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.regexp.markdown-gfm
         source.regexp
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.regexp.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2009,18 +2042,19 @@ contexts:
           (?i:\s*(rscript|r|splus))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.r.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.r
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.r.markdown-gfm
         source.r
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.r.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2031,18 +2065,19 @@ contexts:
           (?i:\s*(ruby|rb|rbx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ruby.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ruby
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ruby.markdown-gfm
         source.ruby
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ruby.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2053,18 +2088,19 @@ contexts:
           (?i:\s*(rust|rs))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.rust.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.rust
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.rust.markdown-gfm
         source.rust
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.rust.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2075,18 +2111,19 @@ contexts:
           (?i:\s*(scala))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.scala.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.scala
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.scala.markdown-gfm
         source.scala
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.scala.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2097,18 +2134,19 @@ contexts:
           (?i:\s*(console|bash|shell(?:-script)?|sh)|zsh)
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.shell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.embedded.markdown
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.shell.markdown-gfm
         source.shell
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.shell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2119,18 +2157,19 @@ contexts:
           (?i:\s*(sql))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.sql.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.sql
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.sql.markdown-gfm
         source.sql
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.sql.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2141,18 +2180,19 @@ contexts:
           (?i:\s*(tsx))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.tsx.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.tsx
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.tsx.markdown-gfm
         source.tsx
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.tsx.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2163,18 +2203,19 @@ contexts:
           (?i:\s*(typescript|ts(?:node)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.typescript.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ts
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.typescript.markdown-gfm
         source.ts
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.typescript.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2185,18 +2226,19 @@ contexts:
           (?i:\s*(atom|plist|svg|xjb|xml|xsd|xsl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.xml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.xml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.xml.markdown-gfm
         text.xml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.xml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2207,18 +2249,19 @@ contexts:
           (?i:\s*(yaml|yml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.yaml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.yaml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.yaml.markdown-gfm
         source.yaml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.yaml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2229,17 +2272,17 @@ contexts:
           {{fenced_code_block_language}}?
           .*?(\s*$\n?)   # all characters until EOL
       captures:
-        0: meta.code-fence.definition.begin.text.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: meta.fold.code-fence.begin.markdown
       push: fenced-raw-content
 
   fenced-raw-content:
-    - meta_content_scope: markup.raw.code-fence.markdown-gfm
+    - meta_content_scope: meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
     - match: '{{fenced_code_block_escape}}'
       captures:
-        0: meta.code-fence.definition.end.text.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
       pop: 1
@@ -2251,18 +2294,19 @@ contexts:
           (?i:\s*(ada))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ada.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ada
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ada.markdown-gfm
         source.ada
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ada.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2273,18 +2317,19 @@ contexts:
           (?i:\s*(ahk))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ahk.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ahk
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ahk.markdown-gfm
         source.ahk
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ahk.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2295,18 +2340,19 @@ contexts:
           (?i:\s*(arduino|ino))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.arduino.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.arduino
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.arduino.markdown-gfm
         source.arduino
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.arduino.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2317,18 +2363,19 @@ contexts:
           (?i:\s*(coffee(?:script)?|cjsx|cson|iced))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.coffee.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.coffee
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.coffee.markdown-gfm
         source.coffee
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.coffee.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2339,18 +2386,19 @@ contexts:
           (?i:\s*(dart))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.dart.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.dart
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.dart.markdown-gfm
         source.dart
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.dart.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2361,18 +2409,19 @@ contexts:
           (?i:\s*(docker(?:file)?))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.docker.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.docker
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.docker.markdown-gfm
         source.shell.docker
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.docker.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2383,18 +2432,19 @@ contexts:
           (?i:\s*(elixir))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.elixir.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.elixir
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.elixir.markdown-gfm
         source.elixir
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.elixir.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2405,18 +2455,19 @@ contexts:
           (?i:\s*(fish))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.fish.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.shell.fish
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.fish.markdown-gfm
         source.shell.fish
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.fish.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2427,18 +2478,19 @@ contexts:
           (?i:\s*(graphql))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.graphql.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.graphql
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.graphql.markdown-gfm
         source.graphql
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.graphql.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2449,18 +2501,19 @@ contexts:
           (?i:\s*(http))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.http.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.http-request-response
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.http.markdown-gfm
         text.http-request-response
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.http.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2471,18 +2524,19 @@ contexts:
           (?i:\s*(ini))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.ini.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.ini
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.ini.markdown-gfm
         source.ini
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.ini.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2493,18 +2547,19 @@ contexts:
           (?i:\s*(jade))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.jade.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.jade
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.jade.markdown-gfm
         source.jade
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.jade.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2515,18 +2570,19 @@ contexts:
           (?i:\s*(julia))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.julia.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.julia
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.julia.markdown-gfm
         source.julia
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.julia.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2537,18 +2593,19 @@ contexts:
           (?i:\s*(kotlin))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.kotlin.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.kotlin
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.kotlin.markdown-gfm
         source.kotlin
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.kotlin.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2559,18 +2616,19 @@ contexts:
           (?i:\s*(less))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.less.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.less
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.less.markdown-gfm
         source.less
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.less.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2581,7 +2639,7 @@ contexts:
           (?i:\s*(mermaid))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.mermaid.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
@@ -2594,7 +2652,7 @@ contexts:
         source.mermaid.embedded.markdown-gfm
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.mermaid.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2605,18 +2663,19 @@ contexts:
           (?i:\s*(nim))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.nim.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.nim
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.nim.markdown-gfm
         source.nim
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.nim.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2627,18 +2686,19 @@ contexts:
           (?i:\s*(pwsh|powershell))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.powershell.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.powershell
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.powershell.markdown-gfm
         source.powershell
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.powershell.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2649,18 +2709,19 @@ contexts:
           (?i:\s*(protobuf))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.protobuf.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.proto
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.protobuf.markdown-gfm
         source.proto
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.protobuf.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2671,18 +2732,19 @@ contexts:
           (?i:\s*(re|reason))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.reason.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.reason
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.reason.markdown-gfm
         source.reason
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.reason.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2693,18 +2755,19 @@ contexts:
           (?i:\s*(sass))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.sass.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.sass
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.sass.markdown-gfm
         source.sass
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.sass.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2715,18 +2778,19 @@ contexts:
           (?i:\s*(scheme))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.scheme.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.scheme
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.scheme.markdown-gfm
         source.scheme
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.scheme.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2737,18 +2801,19 @@ contexts:
           (?i:\s*(scss))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.scss.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.scss
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.scss.markdown-gfm
         source.scss
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.scss.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2759,18 +2824,19 @@ contexts:
           (?i:\s*(s|stata|\{s\}|\{s[\s,].*\}|\{stata\}|\{stata[\s,].*\}))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.stata.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.stata
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.stata.markdown-gfm
         source.stata
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.stata.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2781,18 +2847,19 @@ contexts:
           (?i:\s*(svelte))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.svelte.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.svelte
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.svelte.markdown-gfm
         text.html.svelte
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.svelte.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2803,18 +2870,19 @@ contexts:
           (?i:\s*(swift))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.swift.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.swift
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.swift.markdown-gfm
         source.swift
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.swift.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2825,18 +2893,19 @@ contexts:
           (?i:\s*(terraform|tf|hcl))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.terraform.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.terraform
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.terraform.markdown-gfm
         source.terraform
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.terraform.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2847,18 +2916,19 @@ contexts:
           (?i:\s*(toml))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.toml.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.toml
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.toml.markdown-gfm
         source.toml
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.toml.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2869,18 +2939,19 @@ contexts:
           (?i:\s*(twee))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.twee.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.twee
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.twee.markdown-gfm
         text.twee.embedded.markdown
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.twee.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2891,18 +2962,19 @@ contexts:
           (?i:\s*(twig|craftcms))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.twig.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:text.html.twig
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.twig.markdown-gfm
         text.html.twig
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.twig.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2913,18 +2985,19 @@ contexts:
           (?i:\s*(verilog|v))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.verilog.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.verilog
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.verilog.markdown-gfm
         source.verilog
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.verilog.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2935,18 +3008,19 @@ contexts:
           (?i:\s*(wast))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.wast.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.wast
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.wast.markdown-gfm
         source.wast
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.wast.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2957,18 +3031,19 @@ contexts:
           (?i:\s*(wit))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.wit.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.wit
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.wit.markdown-gfm
         source.wit
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.wit.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 
@@ -2979,18 +3054,19 @@ contexts:
           (?i:\s*(xonsh|xsh))
           {{fenced_code_block_trailing_infostring_characters}}
       captures:
-        0: meta.code-fence.definition.begin.xonsh.markdown-gfm
+        0: meta.code-fence.definition.begin.markdown-gfm
         2: punctuation.definition.raw.code-fence.begin.markdown
         5: constant.other.language-name.markdown
         6: comment.line.infostring.markdown
         7: meta.fold.code-fence.begin.markdown
       embed: scope:source.xonsh
       embed_scope:
+        meta.code-fence.body.markdown-gfm
         markup.raw.code-fence.xonsh.markdown-gfm
         source.xonsh
       escape: '{{fenced_code_block_escape}}'
       escape_captures:
-        0: meta.code-fence.definition.end.xonsh.markdown-gfm
+        0: meta.code-fence.definition.end.markdown-gfm
         1: punctuation.definition.raw.code-fence.end.markdown
         2: meta.fold.code-fence.end.markdown
 

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -15,6 +15,10 @@ version: 2
 hidden: true
 
 variables:
+
+  # Headings
+  # ========
+
   atx_heading: (?:\#{1,6}[ \t\n])                              # 1 to 6 hashes, followed by at least one space or tab or by end of the line
   atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)          # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
   atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)                 # \n is optional so ## is matched as end punctuation in new document (at eof)
@@ -30,6 +34,9 @@ variables:
   list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
   list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*($\n?)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
   list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*($\n?)               # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+
+  # Common Block Indicators
+  # =======================
 
   block_quote: '>'                             # a greater than sign, (followed by any character or the end of the line)
   indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)   # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -319,46 +319,46 @@ contexts:
     - match: (---)\s*(?i:(coffee)\s*)\n
       captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.begin.frontmatter.markdown
+        1: punctuation.section.frontmatter.begin.markdown
         2: constant.other.language-name.markdown
       embed: scope:source.coffee
       embed_scope: meta.frontmatter.markdown source.coffee.embedded.markdown
       escape: ^(---|\.{3})\s*\n  # pandoc requires the remainder of the line to be blank
       escape_captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.end.frontmatter.markdown
+        1: punctuation.section.frontmatter.end.markdown
     - match: (---)\s*(?i:(json)\s*)\n
       captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.begin.frontmatter.markdown
+        1: punctuation.section.frontmatter.begin.markdown
         2: constant.other.language-name.markdown
       embed: scope:source.json
       embed_scope: meta.frontmatter.markdown source.json.embedded.markdown
       escape: ^(---|\.{3})\s*\n # pandoc requires the remainder of the line to be blank
       escape_captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.end.frontmatter.markdown
+        1: punctuation.section.frontmatter.end.markdown
     - match: (---)\s*(?i:(yaml|yml)\s*)?\n
       captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.begin.frontmatter.markdown
+        1: punctuation.section.frontmatter.begin.markdown
         2: constant.other.language-name.markdown
       embed: scope:source.yaml
       embed_scope: meta.frontmatter.markdown source.yaml.embedded.markdown
       escape: ^(---|\.{3})\s*\n  # pandoc requires the remainder of the line to be blank
       escape_captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.end.frontmatter.markdown
+        1: punctuation.section.frontmatter.end.markdown
     - match: (\+{3})\s*\n
       captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.begin.frontmatter.markdown
+        1: punctuation.section.frontmatter.begin.markdown
       embed: scope:source.toml
       embed_scope: meta.frontmatter.markdown source.toml.embedded.markdown
       escape: ^(\+{3})\s*\n
       escape_captures:
         0: meta.frontmatter.markdown
-        1: punctuation.section.block.end.frontmatter.markdown
+        1: punctuation.section.frontmatter.end.markdown
 
   markdown:
     - include: indented-code-blocks

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -15,31 +15,30 @@ version: 2
 hidden: true
 
 variables:
-  atx_heading: (?:[ ]{,3}[#]{1,6}(?:[ \t]|$))         # between 0 and 3 spaces, followed 1 to 6 hashes, followed by at least one space or tab or by end of the line
-  atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$) # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
-  atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)        # \n is optional so ## is matched as end punctuation in new document (at eof)
+  atx_heading: (?:\#{1,6}[ \t\n])                              # 1 to 6 hashes, followed by at least one space or tab or by end of the line
+  atx_heading_space: (?:(?=[ \t]+#+[ \t]*$)|[ \t]+|$)          # consume spaces only if heading is not empty to ensure `atx_heading_end` can fully match closing hashes
+  atx_heading_end: (?:[ \t]+(#+))?[ \t]*($\n?)                 # \n is optional so ## is matched as end punctuation in new document (at eof)
 
   setext_heading_or_paragraph: ^(?:[ ]{,3}=+[ \t]*$|(?=[ ]{,3}\S))    # between 0 and 3 spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
   setext_heading_escape: ^(?=[ ]{,3}(?:=+|-+)[ \t]*$)                 # between 0 and 3 spaces, followed by at least one hyphen or equal sign (setext underline can be of any length)
   setext_heading1_escape: ^(?=[ ]{,3}=+[ \t]*$)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*$(\n?)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
-  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*$(\n?)                       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
+  setext_heading1_end: ^[ ]{,3}(=+)[ \t]*($\n?)                       # between 0 and 3 spaces, followed by at least one equal sign (setext underline can be of any length)
+  setext_heading2_end: ^[ ]{,3}(-+)[ \t]*($\n?)                       # between 0 and 3 spaces, followed by at least one hyphen (setext underline can be of any length)
 
   list_setext_heading_or_paragraph: (?:[ \t]*=+[ \t]*$|(?=[ \t]*\S))  # any number of spaces, followed by non-whitespace (consume equal signs as paragraphs may start with them)
   list_setext_heading_escape: ^(?=[ \t]{2,}(?:==+|--+)[ \t]*$)        # two or more spaces, followed by at least one hyphen or equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
   list_setext_heading1_escape: ^(?=[ \t]{2,}==+[ \t]*$)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*$(\n?)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
-  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*$(\n?)               # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading1_end: ^[ \t]{2,}(==+)[ \t]*($\n?)               # two or more spaces, followed by at least one equal sign (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
+  list_setext_heading2_end: ^[ \t]{2,}(--+)[ \t]*($\n?)               # two or more spaces, followed by at least one hyphen (setext underline can be of any length, but ST needs at least 2 to avoid ambiguity with empty list items)
 
-  block_quote: (?:[ ]{,3}(>)[ ]?)                     # between 0 and 3 spaces, followed by a greater than sign, (followed by any character or the end of the line = "only care about optional space!")
-  indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)          # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
+  block_quote: '>'                             # a greater than sign, (followed by any character or the end of the line)
+  indented_code_block: (?:[ ]{4}|[ ]{0,3}\t)   # a visual tab of width 4 consisting of 4 spaces or 0 to 3 spaces followed by 1 tab
 
-  first_list_item: (?:[ ]{,3}(?:1[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
-  list_item: (?:[ ]{,3}(?:\d{1,9}[.)]|[*+-])\s)       # between 0 and 3 spaces, followed by either: at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
+  first_list_item: (?:(?:1[.)]|[*+-])[ \t\n])  # at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
+  list_item: (?:(?:\d{1,9}[.)]|[*+-])[ \t\n])  # at least one integer and a full stop or a parenthesis, or (a star, plus or dash), followed by whitespace
 
   thematic_break: |-
     (?x:
-      [ ]{,3}                    # between 0 to 3 spaces
       (?:                        # followed by one of the following:
         [-](?:[ \t]*[-]){2,}     # - a dash,        followed by the following at least twice: any number of spaces or tabs followed by a dash
       | [*](?:[ \t]*[*]){2,}     # - a star,        followed by the following at least twice: any number of spaces or tabs followed by a star
@@ -129,15 +128,17 @@ variables:
       (?:[^|]*?[^`|])?  # none must be a pipe, the last additionally must not be a backtick
     )
 
+  fenced_code_block: |-
+    (?x:
+      (`){3,}      #   3 or more backticks
+      (?![^`]*`)   #   not followed by any more backticks on the same line
+    |              # or
+      (~){3,}      #   3 or more tildas
+    )
   fenced_code_block_start: |-
     (?x:
       ([ \t]*)
-      (
-        (`){3,}      #   3 or more backticks
-        (?![^`]*`)   #   not followed by any more backticks on the same line
-      |              # or
-        (~){3,}      #   3 or more tildas
-      )
+      ({{fenced_code_block}})
     )
   fenced_code_block_language: |-
     (?x:             # first word of an infostring is used as language specifier
@@ -167,7 +168,7 @@ variables:
   fenced_code_block_escape: ^{{fenced_code_block_end}}
 
   # https://pandoc.org/MANUAL.html#divs-and-spans
-  fenced_div_block: '[ \t]*(:{3,})'
+  fenced_div_block: ':{3,}'
 
   # https://spec.commonmark.org/0.30/#email-autolink
   email_domain_commonmark: '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?'
@@ -176,17 +177,14 @@ variables:
   # https://spec.commonmark.org/0.30/#html-blocks
   html_block: |-
     (?x:
-      [ ]{,3}
-      (?:
-        {{html_tag_block_end_at_close_tag}}  # html block type 1
-      | {{html_tag_block_end_at_blank_line}} # html block type 6
-      | {{html_block_open_tag}}              # html block type 7
-      | {{html_block_close_tag}}             # html block type 7
-      | {{html_block_comment}}               # html block type 2
-      | {{html_block_decl}}                  # html block type 4
-      | {{html_block_cdata}}                 # html block type 5
-      | {{html_block_preprocessor}}          # html block type 3
-      )
+      {{html_tag_block_end_at_close_tag}}  # html block type 1
+    | {{html_tag_block_end_at_blank_line}} # html block type 6
+    | {{html_block_open_tag}}              # html block type 7
+    | {{html_block_close_tag}}             # html block type 7
+    | {{html_block_comment}}               # html block type 2
+    | {{html_block_decl}}                  # html block type 4
+    | {{html_block_cdata}}                 # html block type 5
+    | {{html_block_preprocessor}}          # html block type 3
     )
   html_block_comment: <!--
   html_block_cdata: <!\[CDATA\[
@@ -253,17 +251,78 @@ variables:
   footnote_name: (?:\^(?:\\\]|[^]])+)
   reference_name: (?:(?:\\\]|[^]])+)
 
+  blockquote_footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  blockquote_paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ ]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  blockquote_nested_paragraph_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= (?:[ \t]*>)* [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  footnote_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ \t]*
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{reference_definition}}    # a reference definition begins the line
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{list_item}}               # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
   paragraph_end: |-
     (?x: # pop out of this context if one of the following conditions are met:
-      ^(?=\s*$                        # the line is blank (or only contains whitespace)
-       |  {{block_quote}}             # a blockquote begins the line
-       |  {{atx_heading}}             # an ATX heading begins the line
-       |  {{fenced_code_block_start}} # a fenced codeblock begins the line
-       |  {{fenced_div_block}}        # a fenced div block begins the line
-       |  {{thematic_break}}          # line is a thematic beak
-       |  {{first_list_item}}         # a list item begins the line
-       |  {{html_block}}              # a html block begins the line
-       )
+      ^(?= [ \t]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
+        |   {{first_list_item}}         # a list item begins the line
+        |   {{html_block}}              # a html block begins the line
+        )
+      )
     )
 
   list_paragraph_end: |-
@@ -272,11 +331,24 @@ variables:
         (?: $                           # the line is blank (or only contains whitespace)
         |   {{block_quote}}             # a blockquote begins the line
         |   {{atx_heading}}             # an ATX heading begins the line
-        |   {{fenced_code_block_start}} # a fenced codeblock begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
         |   {{fenced_div_block}}        # a fenced div block begins the line
         |   {{thematic_break}}          # line is a thematic beak
         |   {{list_item}}               # a list item begins the line
         |   {{html_block}}              # a html block begins the line
+        )
+      )
+    )
+
+  table_end: |-
+    (?x: # pop out of this context if one of the following conditions are met:
+      ^(?= [ ]{,3}
+        (?: $                           # the line is blank (or only contains whitespace)
+        |   {{block_quote}}             # a blockquote begins the line
+        |   {{atx_heading}}             # an ATX heading begins the line
+        |   {{fenced_code_block}}       # a fenced codeblock begins the line
+        |   {{fenced_div_block}}        # a fenced div block begins the line
+        |   {{thematic_break}}          # line is a thematic beak
         )
       )
     )
@@ -592,20 +664,7 @@ contexts:
     - include: footnote-paragraph-common
 
   block-quote-footnote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]*>)* [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{reference_definition}}    # a reference definition begins the line
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_footnote_end}}'
       pop: 1
 
   block-quote-link-definitions:
@@ -705,19 +764,7 @@ contexts:
     - include: inlines
 
   block-quote-nested-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]*>)* [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_nested_paragraph_end}}'
       pop: 1
 
 ###[ CONTAINER BLOCKS: BLOCK QUOTES > PARAGRAPHS ]############################
@@ -733,19 +780,7 @@ contexts:
     - include: inlines
 
   block-quote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= (?:[ \t]{,3}>)*
-           (?: \s* $                       # the line is blank (or only contains whitespace)
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{blockquote_paragraph_end}}'
       pop: 1
 
 ###[ CONTAINER BLOCKS: LISTS ]################################################
@@ -3069,20 +3104,7 @@ contexts:
     - include: links
 
   footnote-paragraph-end:
-    - match: |-
-        (?x)
-        # pop out of this context if one of the following conditions are met:
-        ^(?= [ \t]*
-           (?: $                           # the line is blank (or only contains whitespace)
-           |   {{reference_definition}}    # a reference definition begins the line
-           |   {{atx_heading}}             # an ATX heading begins the line
-           |   {{fenced_code_block_start}} # a fenced codeblock begins the line
-           |   {{fenced_div_block}}        # a fenced div block begins the line
-           |   {{thematic_break}}          # line is a thematic beak
-           |   {{list_item}}               # a list item begins the line
-           |   {{html_block}}              # a html block begins the line
-           )
-        )
+    - match: '{{footnote_end}}'
       pop: 1
 
   link-definitions:
@@ -3187,16 +3209,7 @@ contexts:
 
   table-end:
     # The table is broken at the first empty line, or beginning of another block-level structure
-    - match: |-
-          (?x)^
-          (?= \s*$
-          |   {{atx_heading}}
-          |   {{block_quote}}
-          |   {{fenced_code_block_start}}
-          |   {{fenced_div_block}}
-          |   {{indented_code_block}}
-          |   {{thematic_break}}
-          )
+    - match: '{{table_end}}'
       pop: 1
 
   table-cell-content:
@@ -3258,7 +3271,7 @@ contexts:
 
   thematic-breaks:
     # https://spec.commonmark.org/0.30/#thematic-breaks
-    - match: (?={{thematic_break}})
+    - match: (?=[ \t]*{{thematic_break}})
       push: thematic-break-body
 
   thematic-break-body:
@@ -4361,11 +4374,11 @@ contexts:
 
   fenced-div-blocks:
     # https://pandoc.org/MANUAL.html#divs-and-spans
-    - match: '{{fenced_div_block}}[ \t]*$\n?'
+    - match: '[ \t]*({{fenced_div_block}})[ \t]*$\n?'
       scope: meta.div.markdown
       captures:
         1: punctuation.section.div.end.markdown
-    - match: '{{fenced_div_block}}'
+    - match: '[ \t]*({{fenced_div_block}})'
       captures:
         1: punctuation.section.div.begin.markdown
       push:

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -47,62 +47,6 @@ variables:
       [ \t]*$                    # followed by any number of tabs or spaces, followed by the end of the line
     )
 
-  backticks: |-
-    (?x:
-      (`{4})[^`](?:[^`]|(?!`{4})`+[^`])*(`{4})(?!`)  # 4 backticks, followed by at least one non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
-    | (`{3})[^`](?:[^`]|(?!`{3})`+[^`])*(`{3})(?!`)  # 3 backticks, followed by at least one non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
-    | (`{2})[^`](?:[^`]|(?!`{2})`+[^`])*(`{2})(?!`)  # 2 backticks, followed by at least one non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
-    | (`{1})[^`](?:[^`]|(?!`{1})`+[^`])*(`{1})(?!`)  # 1 backtick,  followed by at least one non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
-    )
-  escapes: \\[-+*/!"#$%&'(),.:;<=>?@\[\\\]^_`{|}~]
-
-  balance_square_brackets: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`]                          # anything that isn't a square bracket or backtick
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`]                        #  anything that isn't a square bracket or backtick
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+
-    )
-  balance_square_brackets_and_emphasis: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`_*]                        # anything that isn't a square bracket, backtick or emphasis
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`_*]                      #  anything that isn't a square bracket, backtick or emphasis
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+                                  # at least one character
-    )
-  balance_square_brackets_pipes_and_emphasis: |-
-    (?x:
-      (?:
-        \\.                               # maybe escaped character (be lazy)
-      | [^\[\]`_*|]                       # anything that isn't a square bracket, backtick or emphasis or table cell separator
-      | {{backticks}}                     # inline code
-      | \[ (?:                            # nested square brackets (one level deep)
-          \\.                             #  maybe escaped character (be lazy)
-        | [^\[\]`_*|]                     #  anything that isn't a square bracket, backtick or emphasis or table cell separator
-        | {{backticks}}                   #  inline code
-        )* \]                             #  closing square bracket
-      )+                                  # at least one character
-    )
-  balanced_emphasis: |-
-    (?x:
-      \*  (?!\*){{balance_square_brackets_and_emphasis}}\*  (?!\*)
-    | \*\*      {{balance_square_brackets_and_emphasis}}\*\*
-    | _   (?!_) {{balance_square_brackets_and_emphasis}}_   (?!_)
-    | __        {{balance_square_brackets_and_emphasis}}__
-    )
-
   fenced_code_block: |-
     (?x:
       (`){3,}      #   3 or more backticks
@@ -357,6 +301,67 @@ variables:
       )
     )
 
+  # Inline
+  # ======
+
+  balanced_emphasis: |-
+    (?x:
+      \*  (?!\*){{balance_square_brackets_and_emphasis}}\*  (?!\*)
+    | \*\*      {{balance_square_brackets_and_emphasis}}\*\*
+    | _   (?!_) {{balance_square_brackets_and_emphasis}}_   (?!_)
+    | __        {{balance_square_brackets_and_emphasis}}__
+    )
+
+  balance_square_brackets: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`]           # anything that isn't a square bracket or backtick
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`]         #  anything that isn't a square bracket or backtick
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+
+    )
+
+  balance_square_brackets_and_emphasis: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`_*]         # anything that isn't a square bracket, backtick or emphasis
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`_*]       #  anything that isn't a square bracket, backtick or emphasis
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+                   # at least one character
+    )
+
+  balance_square_brackets_pipes_and_emphasis: |-
+    (?x:
+      (?:
+        \\.                # maybe escaped character (be lazy)
+      | [^\[\]`_*|]        # anything that isn't a square bracket, backtick or emphasis or table cell separator
+      | {{backticks}}      # inline code
+      | \[ (?:             # nested square brackets (one level deep)
+          \\.              #  maybe escaped character (be lazy)
+        | [^\[\]`_*|]      #  anything that isn't a square bracket, backtick or emphasis or table cell separator
+        | {{backticks}}    #  inline code
+        )* \]              #  closing square bracket
+      )+                   # at least one character
+    )
+
+  backticks: |-
+    (?x:
+      (`{4})[^`](?:[^`]|(?!`{4})`+[^`])*(`{4})(?!`)  # 4 backticks, followed by at least one non backtick character, followed by (less than 4 backticks, or at least one non backtick character) at least once, followed by exactly 4 backticks
+    | (`{3})[^`](?:[^`]|(?!`{3})`+[^`])*(`{3})(?!`)  # 3 backticks, followed by at least one non backtick character, followed by (less than 3 backticks, or at least one non backtick character) at least once, followed by exactly 3 backticks
+    | (`{2})[^`](?:[^`]|(?!`{2})`+[^`])*(`{2})(?!`)  # 2 backticks, followed by at least one non backtick character, followed by (less than 2 backticks, or at least one non backtick character) at least once, followed by exactly 2 backticks
+    | (`{1})[^`](?:[^`]|(?!`{1})`+[^`])*(`{1})(?!`)  # 1 backtick,  followed by at least one non backtick character, followed by (                          at least one non backtick character) at least once, followed by exactly 1 backtick
+    )
+
   # https://spec.commonmark.org/0.30/#left-flanking-delimiter-run
   bold_italic_asterisk_begin: |-
     (?x:
@@ -375,6 +380,11 @@ variables:
          \* {{no_space_nor_punct}}
     | \B \* {{no_space_but_punct}}
     )
+
+  # Prototypes
+  # ==========
+
+  escapes: \\[-+*/!"#$%&'(),.:;<=>?@\[\\\]^_`{|}~]
 
   no_escape_behind: (?<![^\\]\\)(?<![\\]{3})
   # not followed by Unicode whitespace and not followed by a Unicode punctuation character

--- a/syntaxes/MultiMarkdown.sublime-syntax
+++ b/syntaxes/MultiMarkdown.sublime-syntax
@@ -24,13 +24,13 @@ contexts:
     - match: ^(---)\s*\n
       captures:
         0: meta.frontmatter.multimarkdown
-        1: punctuation.section.block.begin.frontmatter.multimarkdown
+        1: punctuation.section.frontmatter.begin.multimarkdown
       embed: frontmatter-content
       embed_scope: meta.frontmatter.multimarkdown
       escape: ^(---|\.{3})\s*\n
       escape_captures:
         0: meta.frontmatter.multimarkdown
-        1: punctuation.section.block.end.frontmatter.multimarkdown
+        1: punctuation.section.frontmatter.end.multimarkdown
       pop: 1
     # Classic key-value frontmatter beginning with first key, terminated by empty line.
     - match: ^(?={{header}})

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -7288,6 +7288,11 @@ __test <span>text__ *formatted</span>*
 
 # TEST: HIGHLIGHT #############################################################
 
+  ==highlight==
+| ^^^^^^^^^^^^^ markup.highlight.markdown
+| ^^ punctuation.definition.highlight.begin.markdown
+|            ^^ punctuation.definition.highlight.end.markdown
+
 __==bold highlight==__
 | <- markup.bold.markdown punctuation.definition.bold.begin.markdown
 |^ markup.bold.markdown - markup.highlight
@@ -7352,9 +7357,9 @@ ___==bold italic highlight==___
 |                           ^ punctuation.definition.italic.end.markdown
 |                            ^^ punctuation.definition.bold.end.markdown
 
-=Hi= Hello, world!
+=Hi= Hello, ===world===!
 | <- - punctuation.definition.highlight
-|^^^^^^^^^^^^^^^^^ meta.paragraph - markup
+|^^^^^^^^^^^^^^^^^^^^^^^ meta.paragraph - markup
 |  ^ - punctuation.definition.highlight
 
 This =text==== is ====curious=.
@@ -7417,6 +7422,69 @@ A ==![image $\ce{H2O}$.](./img/image6.png){#fig:image6 height=12.09cm }==
 |                                                                     ^ punctuation.definition.attributes.end.markdown
 |                                                                      ^^ punctuation.definition.highlight.end.markdown
 
+- ==highlight==
+| ^^^^^^^^^^^^^ markup.highlight.markdown
+| ^^ punctuation.definition.highlight.begin.markdown
+|            ^^ punctuation.definition.highlight.end.markdown
+
+1. ==highlight==
+|  ^^^^^^^^^^^^^ markup.highlight.markdown
+|  ^^ punctuation.definition.highlight.begin.markdown
+|             ^^ punctuation.definition.highlight.end.markdown
+
+Heading
+=======
+==highlight==
+| <- meta.paragraph.markdown markup.highlight.markdown punctuation.definition.highlight.begin.markdown
+|^^^^^^^^^^^^ meta.paragraph.markdown markup.highlight.markdown
+
+Heading
+-------
+==highlight==
+| <- meta.paragraph.markdown markup.highlight.markdown punctuation.definition.highlight.begin.markdown
+|^^^^^^^^^^^^ meta.paragraph.markdown markup.highlight.markdown
+
+==
+==highlight==
+| <- meta.paragraph.markdown markup.highlight.markdown punctuation.definition.highlight.begin.markdown
+|^^^^^^^^^^^^ meta.paragraph.markdown markup.highlight.markdown
+
+===
+==highlight==
+| <- meta.paragraph.markdown markup.highlight.markdown punctuation.definition.highlight.begin.markdown
+|^^^^^^^^^^^^ meta.paragraph.markdown markup.highlight.markdown
+
+---
+==highlight==
+| <- meta.paragraph.markdown markup.highlight.markdown punctuation.definition.highlight.begin.markdown
+|^^^^^^^^^^^^ meta.paragraph.markdown markup.highlight.markdown
+
+Heading
+==
+===not highlighted===
+| <- meta.paragraph.markdown - markup
+|^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup
+
+Heading
+--
+===not highlighted===
+| <- meta.paragraph.markdown - markup
+|^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup
+
+==
+===not highlighted===
+| <- meta.paragraph.markdown - markup
+|^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup
+
+===
+===not highlighted===
+| <- meta.paragraph.markdown - markup
+|^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup
+
+---
+===not highlighted===
+| <- meta.paragraph.markdown - markup
+|^^^^^^^^^^^^^^^^^^^^ meta.paragraph.markdown - markup
 
 # TEST: STRIKETHROUGH #########################################################
 

--- a/tests/syntax_test_markdown.md
+++ b/tests/syntax_test_markdown.md
@@ -1350,32 +1350,32 @@ paragraph
 ## https://spec.commonmark.org/0.30/#example-119
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
  >
 |^^ markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-120
 
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 <
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
  >
 |^^ markup.raw.code-fence.markdown-gfm - punctuation
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-121
 
@@ -1388,30 +1388,30 @@ foo
 ## https://spec.commonmark.org/0.30/#example-122
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ~~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-123
 
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~ 
 | <- punctuation.definition.raw.code-fence.begin
@@ -1421,31 +1421,31 @@ aaa
 ## https://spec.commonmark.org/0.30/#example-124
 
 ````
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
 ```
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ``````
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-125
 
 ~~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 |
 aaa
 ~~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ~~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-128
 
@@ -1461,23 +1461,23 @@ bbb
 ## https://spec.commonmark.org/0.30/#example-129
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 
   
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-130
 
 ```
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-131
 
@@ -1485,9 +1485,9 @@ bbb
  aaa
 aaa
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-132
 
@@ -1496,10 +1496,10 @@ aaa
   aaa
 aaa
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-133
 
@@ -1508,10 +1508,10 @@ aaa
     aaa
   aaa
    ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|  ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.end.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-134
 
@@ -1524,45 +1524,45 @@ aaa
 ## https://spec.commonmark.org/0.30/#example-135
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-136
 
    ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm - punctuation
-|^^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation
-|  ^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|     ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm - punctuation
+|^^ meta.code-fence.definition.begin.markdown-gfm - punctuation
+|  ^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|     ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
   ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-| ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^ meta.code-fence.definition.end.markdown-gfm - punctuation
+| ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-137
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 aaa
-| <- markup.raw.code-fence.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm
     ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|^^^ meta.code-fence.definition.end.text.markdown-gfm - punctuation
-|   ^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|      ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm - punctuation
+|^^^ meta.code-fence.definition.end.markdown-gfm - punctuation
+|   ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|      ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-138
 
@@ -1580,21 +1580,21 @@ aaa
 ~~~~~~
 aaa
 ~~~ ~~
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 |^^^^^^ markup.raw.code-fence.markdown-gfm - punctuation
 
 ~~~~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-140
 
 foo
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 ```
 baz
@@ -1605,69 +1605,69 @@ baz
 
 Paragraph is terminated by fenced code blocks.
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 Code blocks terminate **bold text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold**
 | <- - meta.bold
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
 
 Code blocks terminate __bold text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold__
 | <- - meta.bold
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold
 
 Code blocks terminate *italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be italic*
 | <- - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.italic
 
 Code blocks terminate _italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be italic_
 | <- - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate ***bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic***
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate ___bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic___
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
 
 Code blocks terminate **_bold italic text
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 this must not be bold italic_**
 | <- - meta.bold - meta.italic
 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.bold - meta.italic
@@ -1677,9 +1677,9 @@ this must not be bold italic_**
 foo
 ---
 ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 bar
 |^^^ markup.raw.code-fence.markdown-gfm
 ~~~
@@ -1690,49 +1690,49 @@ bar
 ## https://spec.commonmark.org/0.30/#example-142
 
 ```ruby
-| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|      ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
 end
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
 ```
-| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.ruby.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-143
 
 ~~~~    ruby startline=3 $%@#$
-| <- meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.ruby.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - punctuation - constant
-|       ^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm constant.other.language-name.markdown
-|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.ruby.markdown-gfm - meta.fold - constant
-|                             ^ meta.code-fence.definition.begin.ruby.markdown-gfm meta.fold.code-fence.begin - constant
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^^^ meta.code-fence.definition.begin.markdown-gfm - punctuation - constant
+|       ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|           ^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold - constant
+|                             ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - constant
 def foo(x)
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby meta.function
   return 3
 end
-| <- markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ruby.markdown-gfm source.ruby keyword
 ~~~~~~~
-| <- meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^^^^ meta.code-fence.definition.end.ruby.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ## https://spec.commonmark.org/0.30/#example-144
 
 ````;
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|    ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|    ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 ````
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|   ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-145
 
@@ -1747,46 +1747,46 @@ foo
 ## https://spec.commonmark.org/0.30/#example-146
 
 ~~~ aa ``` ~~~
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|   ^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
-|     ^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold - punctuation
-|             ^ meta.code-fence.definition.begin.text.markdown-gfm - punctuation meta.fold.code-fence.begin.markdown
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|   ^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|     ^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold - punctuation
+|             ^ meta.code-fence.definition.begin.markdown-gfm - punctuation meta.fold.code-fence.begin.markdown
 foo
 ~~~
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ~~~~~foo~
-|^^^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|    ^^^^ meta.code-fence.definition.begin.text.markdown-gfm constant.other.language-name.markdown
-|        ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+|^^^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|        ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 
 ~~~~~
-|^^^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|    ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+|^^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|    ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://spec.commonmark.org/0.30/#example-147
 
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin - punctuation
 ``` aaa
-| <- markup.raw.code-fence.markdown-gfm - punctuation
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - punctuation
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ## https://fenced-code-block-embedded-syntaxes-tests
 
 ```bash
-| <- meta.code-fence.definition.begin.shell.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.shell.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^ meta.code-fence.definition.begin.shell.markdown-gfm constant.other.language-name.markdown
-|      ^ meta.code-fence.definition.begin.shell.markdown-gfm meta.fold.code-fence.begin
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 # test
 | ^^^^^ source.shell comment.line.number-sign
 echo hello, \
@@ -1794,8 +1794,8 @@ echo hello, \
 echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 |                       ^^ constant.character.escape
 ```
-| <- meta.code-fence.definition.end.shell punctuation.definition.raw.code-fence.end
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end punctuation.definition.raw.code-fence.end
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```clojure
 |^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1805,29 +1805,29 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 | <- source.clojure
 |^^^^^^^^^^ source.clojure
 ```
-| <- meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.clojure.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.clojure.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```cmd
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.dosbatch.markdown-gfm source.dosbatch
 ```
-| <- meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.dosbatch.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.dosbatch.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```css
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.css.markdown-gfm source.css
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.css.markdown-gfm source.css
 ```
-| <- meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.css.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.css.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```diff
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1838,9 +1838,9 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 - deleted
 | <- source.diff markup.deleted.diff punctuation.definition.deleted.diff
 ```
-| <- meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.diff.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.diff.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```Graphviz
 |^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1849,40 +1849,40 @@ echo This is a smiley :-\) \(I have to escape the parentheses, though!\)
 graph n {}
 | ^^^ storage.type.dot
 ```
-| <- meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.graphviz.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.graphviz.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```groovy
-| ^^^^^^^ meta.code-fence.definition.begin.groovy.markdown-gfm - meta.fold
-|        ^ meta.code-fence.definition.begin.groovy.markdown-gfm meta.fold.code-fence.begin.markdown
+| ^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|        ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin.markdown
 
-| <- markup.raw.code-fence.groovy.markdown-gfm source.groovy
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.groovy.markdown-gfm source.groovy
 ```
-| <- meta.code-fence.definition.end.groovy.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.groovy.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.groovy.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```haskell
 |^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |         ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.haskell.markdown-gfm source.haskell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.haskell.markdown-gfm source.haskell
 ```
-| <- meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.haskell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.haskell.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
 |      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
   <html>
-| <- markup.raw.code-fence.html.markdown-gfm text.html
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html.markdown-gfm text.html
 | ^^^^^^ text.html meta.tag
 ```
-| <- meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.html.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.html.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```html+php
 |^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1890,12 +1890,12 @@ graph n {}
 <div></div>
 |^^^ entity.name.tag.block
 <?php
-| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded punctuation.section.embedded.begin.php
 var_dump(expression);
-| <- markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded source.php meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.html-php.markdown-gfm embedding.php text.html meta.embedded source.php meta.function-call
 ```
-| <- meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.html-php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```js
 |^^^^ meta.code-fence.definition.begin - meta.fold
@@ -1907,91 +1907,91 @@ for (var i = 0; i < 10; i++) {
     console.log(i);
 }
 ```
-| <- meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.javascript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.javascript.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.jsx.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.jsx.markdown-gfm
 ```
-| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```latex
-| <- meta.code-fence.definition.begin.latex.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^ meta.code-fence.definition.begin.latex.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|  ^^^^^ meta.code-fence.definition.begin.latex.markdown-gfm constant.other.language-name.markdown
-|       ^ meta.code-fence.definition.begin.latex.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^ meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|  ^^^^^ meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
+|       ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
 
-| <- markup.raw.code-fence.latex.markdown-gfm text.tex.latex
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.latex.markdown-gfm text.tex.latex
 ```
-| <- meta.code-fence.definition.end.latex.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.latex.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.latex.markdown-gfm meta.fold.code-fence.end.markdown - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end.markdown - punctuation
 
 ```lisp
 |^^^^^^ meta.code-fence.definition.begin - meta.fold
 |      ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.lisp.markdown-gfm source.lisp
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.lisp.markdown-gfm source.lisp
 ```
-| <- meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.lisp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.lisp.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```lua
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.lua.markdown-gfm source.lua
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.lua.markdown-gfm source.lua
 ```
-| <- meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.lua.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.lua.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```makefile
 |^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |          ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.makefile.markdown-gfm source.makefile
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.makefile.markdown-gfm source.makefile
 ```
-| <- meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.makefile.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.makefile.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```matlab
 |^^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |        ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.matlab.markdown-gfm source.matlab
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.matlab.markdown-gfm source.matlab
 ```
-| <- meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.matlab.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.matlab.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```ocaml
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 
-| <- markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.ocaml.markdown-gfm source.ocaml
 ```
-| <- meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.ocaml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.ocaml.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```php
 |^^^^^ meta.code-fence.definition.begin - meta.fold
 |     ^ meta.code-fence.definition.begin meta.fold.code-fence.begin
 var_dump(expression);
-| <- markup.raw.code-fence.php.markdown-gfm source.php meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.php.markdown-gfm source.php meta.function-call
 ```
-| <- meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.php.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.php.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```python
 |^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2004,83 +2004,83 @@ def function():
 unclosed_paren = (
 |                ^ meta.group.python punctuation.section.group.begin.python
 ```
-| <- meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.python.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.python.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```regex
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 (?x)
 \s+
-| <- markup.raw.code-fence.regexp.markdown-gfm source.regexp
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.regexp.markdown-gfm source.regexp
 ```
-| <- meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.regexp.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.regexp.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```scala
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - merkup
 
-| <- markup.raw.code-fence.scala.markdown-gfm source.scala
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.scala.markdown-gfm source.scala
 ```
-| <- meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.scala.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.scala.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 
 ```sh
 |^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |    ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```shell
 |^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
 |       ^ meta.code-fence.definition.begin meta.fold.code-fence.begin - markup
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```shell-script
 
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 === Generic Interactive Shell ===
 
 ```sh
 $ ls ~
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell comment.other.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell comment.other.shell
 | ^^ meta.function-call.identifier.shell variable.function.shell
 |   ^^ meta.function-call.arguments.shell
 
 output.txt
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call - variable
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call - variable
 |^^^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call - variable
 
 $ ls \
 > /foo/
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell
 |^^^^^^^ markup.raw.code-fence.shell.markdown-gfm source.shell
 
 $ ls \
 > /foo/
 bar
-| <- markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call
 |^^^ markup.raw.code-fence.shell.markdown-gfm source.shell - meta.function-call
 ```
-| <- meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
    ```shell
    $ ls
@@ -2088,8 +2088,8 @@ bar
 |  ^ comment.other.shell
 |    ^^ meta.function-call.identifier.shell variable.function.shell
    ```
-|  ^^^ meta.code-fence.definition.end.shell.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|     ^ meta.code-fence.definition.end.shell.markdown-gfm meta.fold.code-fence.end - punctuation
+|  ^^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|     ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```sql
 |^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2100,23 +2100,23 @@ SELECT TOP 10 *
 |^^^^^^^^^^^^^^^ markup.raw.code-fence.sql source.sql
 FROM TableName
 ```
-| <- meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.sql.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.sql.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```ts
 declare type foo = 'bar'
-| <- markup.raw.code-fence.typescript.markdown-gfm source.ts
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.typescript.markdown-gfm source.ts
 ```
-| <- meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.typescript.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```tsx
 
-| <- markup.raw.code-fence.tsx.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.tsx.markdown-gfm
 ```
-| <- meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.tsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ```xml
 |^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2130,9 +2130,9 @@ declare type foo = 'bar'
     <foobar />
 </example>
 ```
-| <- meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.xml.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jsx:file.jsx
 |^^^^^^^^^^^^^^ meta.code-fence.definition.begin - meta.fold - markup
@@ -2141,54 +2141,54 @@ declare type foo = 'bar'
 |  ^^^ constant.other.language-name.markdown
 |     ^^^^^^^^^ comment.line.infostring.markdown
 
-| <- markup.raw.code-fence.jsx.markdown-gfm
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.jsx.markdown-gfm
 ```
-| <- meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.jsx.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.jsx.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```jldoctest; filter = r"Stacktrace:(\n \[[0-9]+\].*)*"
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|                                                      ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|                                                      ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin.markdown - punctuation
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^ constant.other.language-name.markdown
 |           ^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```R%&?! weired language name
-|^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|                            ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|                            ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^ constant.other.language-name.markdown
 |        ^^^^^^^^^^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ```{key: value}
-|^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|              ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|              ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 ``` {key: value}
-|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm - meta.fold
-|               ^ meta.code-fence.definition.begin.text.markdown-gfm meta.fold.code-fence.begin
+|^^^^^^^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm - meta.fold
+|               ^ meta.code-fence.definition.begin.markdown-gfm meta.fold.code-fence.begin
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |   ^^^^^^^^^^^^ - constant
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|^^ meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-|  ^ meta.code-fence.definition.end.text.markdown-gfm meta.fold.code-fence.end - punctuation
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^ meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|  ^ meta.code-fence.definition.end.markdown-gfm meta.fold.code-fence.end - punctuation
 
 
 # TEST: HTML BLOCKS ###########################################################
@@ -2876,7 +2876,7 @@ This is not a link reference definition, because it occurs inside a code block:
 
 ```
 [foo]: /url
-| <- markup.raw.code-fence.markdown-gfm - meta.link
+| <- meta.code-fence.body.markdown-gfm markup.raw.code-fence.markdown-gfm - meta.link
 |^^^^^^^^^^^ markup.raw.code-fence.markdown-gfm - meta.link
 ```
 
@@ -3335,12 +3335,12 @@ https://foo.bar/baz
 
 | table | followed by
 ```fenced
-| <- meta.code-fence.definition.begin.text.markdown-gfm
-|^^^^^^^^^ meta.code-fence.definition.begin.text.markdown-gfm
+| <- meta.code-fence.definition.begin.markdown-gfm
+|^^^^^^^^^ meta.code-fence.definition.begin.markdown-gfm
 code block
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm
-|^^ meta.code-fence.definition.end.text.markdown-gfm
+| <- meta.code-fence.definition.end.markdown-gfm
+|^^ meta.code-fence.definition.end.markdown-gfm
 
 A line without bolded |
 |                     ^ - punctuation.separator.table-cell
@@ -3730,21 +3730,21 @@ paragraph
 > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 | ^^^ punctuation.definition.raw.code-fence.begin.markdown
 
 > Quoted fenced code block language identifier
 > ```C++
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 |    ^^^ constant.other.language-name.markdown
 
 > Quoted fenced code block language identifier
 > ```C++ info string
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^^^^^^^^^^^^^ markup.quote.markdown meta.code-fence.definition.begin.markdown-gfm
 |    ^^^ constant.other.language-name.markdown
 |       ^^^^^^^^^^^^^ - constant
 
@@ -3760,7 +3760,7 @@ paragraph
 > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown - meta.code-fence
-| ^^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^^ markup.quote.markdown meta.code-fence.definition.end.markdown-gfm
 | ^^^ punctuation.definition.raw.code-fence.end.markdown
 
 > > 2nd level quoted fenced code block
@@ -3774,13 +3774,13 @@ paragraph
 > > ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^^^ markup.quote.markdown - meta.code-fence
-|   ^^^ markup.quote.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|   ^^^ markup.quote.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 > Block quote followed by fenced code block
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
+| <- meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown - meta.quote
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
+| <- meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown - meta.quote
 
 > Quoted fenced code block is terminated by missing > at bol
 > ```
@@ -3798,9 +3798,9 @@ no code block
 > Unterminated quoted fenced code block followed by unquoted fenced code block
 > ```
 ```
-| <- meta.code-fence.definition.begin.text.markdown-gfm - markup.quote
+| <- meta.code-fence.definition.begin.markdown-gfm - markup.quote
 ```
-| <- meta.code-fence.definition.end.text.markdown-gfm - markup.quote
+| <- meta.code-fence.definition.end.markdown-gfm - markup.quote
 
 > > ```
 > This is a paragraph highlight as code,
@@ -4170,7 +4170,7 @@ second line
 >        ```C++
 | <- markup.quote.markdown markup.list.numbered.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
-| ^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm
+| ^^^^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm
 |        ^^^ punctuation.definition.raw.code-fence.begin.markdown
 |           ^^^ constant.other.language-name.markdown
 
@@ -4191,7 +4191,7 @@ second line
 >        ```
 | <- markup.quote.markdown punctuation.definition.blockquote.markdown
 |^ markup.quote.markdown markup.list.numbered.markdown - meta.code-fence
-| ^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm
+| ^^^^^^^^^^^ markup.quote.markdown markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm
 |        ^^^ punctuation.definition.raw.code-fence.end.markdown
 
 ## https://custom-tests/block-quotes/list-blocks/unordered-items-with-reference-definitions
@@ -4550,11 +4550,11 @@ A list item may contain blocks that are separated by more than one blank line.
 1.  foo
 
     ```
-    | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+    | <- markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
     bar
     | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm - punctuation
     ```
-    | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+    | <- markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
     baz
     | <- markup.list.numbered.markdown
@@ -5026,15 +5026,15 @@ So is this, with a empty second item:
 
 - a
 - ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
   b
   | <- markup.list.unnumbered.markdown markup.raw.code-fence.markdown-gfm
 
 
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 - a
 - ```
@@ -5074,12 +5074,12 @@ So is this, with a empty second item:
 - a
   > b
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
   c
   ```
-  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  | <- markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+  |^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 - a
   > b
@@ -5092,13 +5092,13 @@ So is this, with a empty second item:
 ## https://spec.commonmark.org/0.30/#example-324
 
 1. ```
-   | <- markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-   |^^ markup.list.numbered.markdown meta.code-fence.definition.begin.text.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   | <- markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
    foo
    | <- markup.list.numbered.markdown markup.raw.code-fence.markdown-gfm
    ```
-   | <- markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
-   |^^ markup.list.numbered.markdown meta.code-fence.definition.end.text.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+   | <- markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+   |^^ markup.list.numbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
    bar
    | <- markup.list.numbered.markdown
@@ -5412,12 +5412,12 @@ global heading
 
   * foo
 	```xml
-|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
-|    ^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.xml.markdown-gfm constant.other.language-name.markdown
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm punctuation.definition.raw.code-fence.begin.markdown
+|    ^^ markup.list.unnumbered.markdown meta.code-fence.definition.begin.markdown-gfm constant.other.language-name.markdown
 	<tag>
 |^^^^^ markup.list.unnumbered.markdown markup.raw.code-fence.xml.markdown-gfm text.xml meta.tag.xml
 	```
-|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.xml.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
+|^^^ markup.list.unnumbered.markdown meta.code-fence.definition.end.markdown-gfm punctuation.definition.raw.code-fence.end.markdown
 
 ## https://custom-tests/list-blocks/items-with-html-blocks
 
@@ -9289,7 +9289,7 @@ paragraph
 
 ::: code-block
 ```css
-|^^^^^ meta.code-fence.definition.begin.css.markdown-gfm
+|^^^^^ meta.code-fence.definition.begin.markdown-gfm
 |^^ punctuation.definition.raw.code-fence.begin.markdown
 |  ^^^ constant.other.language-name.markdown
 ```


### PR DESCRIPTION
## Bug Fixes

* fix `==highlight==` not being scoped at beginning of paragraphs (fixes #789)

## New Features

* add `Reset Task Items` (resolves #786)
* add `Goto Next Critic` and `Goto Previous Critic` (resolves #787)

## Changes

* drop support for ST3 (latest available version for ST3 is 3.2.0)
* align frontmatter punctuation scopes with ST's default Markdown syntax
* align code fence scopes with ST's default Markdown syntax
* optimize paragraph termination patterns to improve parsing performance
