### PR TITLE
Plugins: fix linter complaining on bash comments in code blocks

### DIFF
--- a/messages/next.md
+++ b/messages/next.md
@@ -1,0 +1,13 @@
+# MarkdownEditing {version} Changelog
+
+Your _MarkdownEditing_ plugin is updated. Enjoy new version. For any type of
+feedback you can use [GitHub issues][issues].
+
+## Bug Fixes
+
+## New Features
+
+## Changes
+  - embedded linter no longer complains on Bash- and Python-style comments in code blocks (previously it triggered the `MD023` rule)
+
+[issues]: https://github.com/SublimeText-Markdown/MarkdownEditing/issues

--- a/plugins/lint.py
+++ b/plugins/lint.py
@@ -591,7 +591,21 @@ class md023(mddef):
     locator = r"^( +)((?:-+|=+)|(?:#{1,6}(?!#).*))$"
     gid = 1
 
+    # 2025-05-14, studokim: the default implementation complains on bash comments in code blocks
+    def is_inside_code_block(self, text, s, e):
+        def calculate_intendation(text, position):
+            return position - text.rfind("\n", 0, position) - 1
+        keyword = "```"
+        block_s = text.rfind(keyword, 0, s-1)
+        block_e = text.find(keyword, e)
+        block_s_intendation = calculate_intendation(text, block_s)
+        block_e_intendation = calculate_intendation(text, block_e)
+        assert block_s_intendation == block_e_intendation  # if fails, then the algorithm is wrong
+        return e - s >= block_s_intendation
+
     def test(self, text, s, e):
+        if self.is_inside_code_block(text, s, e):
+            return {}
         return {s: "%d spaces found" % (e - s)}
 
 


### PR DESCRIPTION
## Changes

  - embedded linter no longer complains on Bash- and Python-style comments in code blocks (previously it triggered the `MD023` rule)

## Before

```
line 22: MD023 - Headers must start at the beginning of the line, 6 spaces found
```

## After

```
MarkdownLint: no errors found
```