### PR TITLE
Catch `entity.name.admonition` for highlighting

### DIFF
--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -4309,46 +4309,54 @@ contexts:
 
 ###[ EXTENSIONS: ADMONITIONS ]################################################
 
-  admonitions:
+    admonitions:
     # https://python-markdown.github.io/extensions/admonition/
     - match: '^([ \t]*)(!!!)[ \t]+(caution|danger)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-caution-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(bug|failure)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-error-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(important)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-important-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(abstract|info|note|question|success)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-note-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(quote)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-quote-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(tip)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-tip-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(warning)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-warning-heading
       escape: '{{admonition_escape}}'
     - match: '^([ \t]*)(!!!)[ \t]+(\w+)\b'
       captures:
         2: punctuation.definition.admonition.markdown
+        3: entity.name.admonition.markdown
       embed: admonation-other-heading
       escape: '{{admonition_escape}}'
 

--- a/syntaxes/Markdown.sublime-syntax
+++ b/syntaxes/Markdown.sublime-syntax
@@ -4309,7 +4309,7 @@ contexts:
 
 ###[ EXTENSIONS: ADMONITIONS ]################################################
 
-    admonitions:
+  admonitions:
     # https://python-markdown.github.io/extensions/admonition/
     - match: '^([ \t]*)(!!!)[ \t]+(caution|danger)\b'
       captures:


### PR DESCRIPTION
This change supports highlighting the type names of python-markdown-style admonitions like you can for GFM alerts.

## Before

Recently added support for admonitions but without highlighting:

<img width="604" height="165" alt="before" src="https://github.com/user-attachments/assets/1666e544-ed46-4fc9-8458-dfcdccddd847" />

## During

Highlighting by scoping to e.g. `markup.heading.admonition.caution` or `.tip` which sadly trails off to the edge of the editor:

<img width="606" height="163" alt="during" src="https://github.com/user-attachments/assets/f4ffecd4-7c17-4167-8235-611dc0f19f43" />

## After

Catch and scope highlighting to e.g. `entity.name.admonition.caution` or `.tip` instead:

<img width="607" height="165" alt="after" src="https://github.com/user-attachments/assets/29de59f1-51a6-408c-884e-4d023237070a" />
